### PR TITLE
[codex] Seed user avatar fallback colors

### DIFF
--- a/apps/client/src/components/activity/ActivityItem.tsx
+++ b/apps/client/src/components/activity/ActivityItem.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import { Hash, AtSign, MessageSquare, Reply } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { UserAvatar } from "@/components/ui/user-avatar";
@@ -30,7 +31,7 @@ function getNotificationIcon(type: NotificationType) {
 
 function getSourceContext(
   notification: Notification,
-  t: (key: string, options?: Record<string, string>) => string,
+  t: TFunction<"navigation">,
 ): string {
   const { type, title } = notification;
 

--- a/apps/client/src/components/activity/ActivityItem.tsx
+++ b/apps/client/src/components/activity/ActivityItem.tsx
@@ -1,6 +1,6 @@
 import { Hash, AtSign, MessageSquare, Reply } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 import { formatMessageTime } from "@/lib/date-utils";
 import type {
@@ -81,10 +81,6 @@ export function ActivityItem({
 
   const actorName =
     notification.actor?.displayName || notification.actor?.username || "System";
-  const actorInitial =
-    notification.actor?.displayName?.[0] ||
-    notification.actor?.username?.[0]?.toUpperCase() ||
-    "S";
 
   return (
     <div
@@ -107,14 +103,14 @@ export function ActivityItem({
 
       {/* User info and preview */}
       <div className="flex items-start gap-2">
-        <Avatar className="w-8 h-8 shrink-0">
-          {notification.actor?.avatarUrl && (
-            <AvatarImage src={notification.actor.avatarUrl} alt={actorName} />
-          )}
-          <AvatarFallback className="bg-primary text-primary-foreground text-xs">
-            {actorInitial}
-          </AvatarFallback>
-        </Avatar>
+        <UserAvatar
+          userId={notification.actor?.id}
+          name={notification.actor?.displayName ?? actorName}
+          username={notification.actor?.username}
+          avatarUrl={notification.actor?.avatarUrl}
+          className="w-8 h-8 shrink-0"
+          fallbackClassName="text-xs"
+        />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="text-sm font-medium text-nav-foreground truncate">

--- a/apps/client/src/components/channel/AddMemberDialog.tsx
+++ b/apps/client/src/components/channel/AddMemberDialog.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { useWorkspaceMembers } from "@/hooks/useWorkspace";
 import { useChannelMembers, useAddChannelMember } from "@/hooks/useChannels";
 import { useSelectedWorkspaceId } from "@/stores";
@@ -117,12 +117,14 @@ export function AddMemberDialog({
         }`}
       >
         <div className="flex items-center gap-3">
-          <Avatar className="w-9 h-9">
-            {member.avatarUrl && <AvatarImage src={member.avatarUrl} />}
-            <AvatarFallback className="bg-primary/10 text-primary">
-              {displayName[0].toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
+          <UserAvatar
+            userId={member.userId}
+            name={displayName}
+            username={member.username}
+            avatarUrl={member.avatarUrl}
+            isBot={member.userType === "bot"}
+            className="w-9 h-9"
+          />
           <div className="text-left">
             <p className="text-sm font-medium">{displayName}</p>
             <p className="text-xs text-muted-foreground">@{member.username}</p>

--- a/apps/client/src/components/channel/ChannelDetailsModal.tsx
+++ b/apps/client/src/components/channel/ChannelDetailsModal.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   useChannel,
   useChannelMembers,
@@ -284,16 +284,15 @@ export function ChannelDetailsModal({
                           className="flex items-center justify-between p-2 rounded-lg hover:bg-muted"
                         >
                           <div className="flex items-center gap-3">
-                            <Avatar className="w-9 h-9">
-                              {member.user?.avatarUrl && (
-                                <AvatarImage src={member.user.avatarUrl} />
-                              )}
-                              <AvatarFallback className="bg-primary/10 text-primary">
-                                {(member.user?.displayName ||
-                                  member.user?.username ||
-                                  "U")[0].toUpperCase()}
-                              </AvatarFallback>
-                            </Avatar>
+                            <UserAvatar
+                              userId={member.user?.id ?? member.userId}
+                              name={member.user?.displayName}
+                              username={member.user?.username}
+                              avatarUrl={member.user?.avatarUrl}
+                              isBot={member.user?.userType === "bot"}
+                              className="w-9 h-9"
+                              fallbackClassName="text-sm"
+                            />
                             <div>
                               <p className="text-sm font-medium">
                                 {member.user?.displayName ||

--- a/apps/client/src/components/channel/ChannelDetailsModal.tsx
+++ b/apps/client/src/components/channel/ChannelDetailsModal.tsx
@@ -10,7 +10,12 @@ import {
   LogOut,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -116,6 +121,9 @@ export function ChannelDetailsModal({
   if (!channel) return null;
 
   const ChannelIcon = channel.type === "private" ? Lock : Hash;
+  const dialogDescription =
+    channel.description ||
+    `${channel.type === "private" ? t("privateChannel") : t("publicChannel")}, ${t("members", { count: members.length })}`;
 
   return (
     <>
@@ -127,6 +135,9 @@ export function ChannelDetailsModal({
               <ChannelIcon size={20} className="text-muted-foreground" />
               <span>#{channel.name}</span>
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              {dialogDescription}
+            </DialogDescription>
           </div>
 
           {/* Tabs */}

--- a/apps/client/src/components/channel/ChannelHeader.tsx
+++ b/apps/client/src/components/channel/ChannelHeader.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Hash, Lock, Info, Users, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { ChannelDetailsModal } from "./ChannelDetailsModal";
 import { AddMemberDialog } from "./AddMemberDialog";
 import { useChannelMembers } from "@/hooks/useChannels";
@@ -37,10 +37,6 @@ export function ChannelHeader({
     ? otherUser?.displayName || otherUser?.username || "Unknown User"
     : channel.name;
 
-  const getInitials = (name: string) => {
-    return name[0]?.toUpperCase() || "U";
-  };
-
   const isOnline = useIsUserOnline(otherUser?.id);
 
   const openDetails = (tab: "about" | "members" | "settings") => {
@@ -54,17 +50,15 @@ export function ChannelHeader({
         <div className="flex items-center gap-3">
           {isDirect && otherUser ? (
             <div className="relative">
-              <Avatar className="w-8 h-8">
-                {otherUser.avatarUrl && (
-                  <AvatarImage src={otherUser.avatarUrl} alt={displayName} />
-                )}
-                {otherUser.userType === "bot" && !otherUser.avatarUrl && (
-                  <AvatarImage src="/bot.webp" alt={displayName} />
-                )}
-                <AvatarFallback className="bg-accent text-accent-foreground text-sm">
-                  {getInitials(displayName)}
-                </AvatarFallback>
-              </Avatar>
+              <UserAvatar
+                userId={otherUser.id}
+                name={otherUser.displayName ?? displayName}
+                username={otherUser.username}
+                avatarUrl={otherUser.avatarUrl}
+                isBot={otherUser.userType === "bot"}
+                className="w-8 h-8"
+                fallbackClassName="text-sm"
+              />
               {isOnline && (
                 <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-success rounded-full border-2 border-background" />
               )}

--- a/apps/client/src/components/channel/MessageItem.tsx
+++ b/apps/client/src/components/channel/MessageItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2, AlertCircle, RotateCcw, X } from "lucide-react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { MessageContent } from "./MessageContent";
 import { MessageAttachments } from "./MessageAttachments";
 import { MessageContextMenu } from "./MessageContextMenu";
@@ -146,8 +146,6 @@ export function MessageItem({
     );
   }
 
-  const initials =
-    message.sender?.displayName?.[0] || message.sender?.username?.[0] || "?";
   const senderName =
     message.sender?.displayName || message.sender?.username || "Unknown User";
 
@@ -190,22 +188,15 @@ export function MessageItem({
           onReplyInThread={onReplyInThread}
         />
       )}
-      <Avatar className={cn("shrink-0", compact ? "w-8 h-8" : "w-9 h-9")}>
-        {message.sender?.avatarUrl && (
-          <AvatarImage src={message.sender.avatarUrl} alt={senderName} />
-        )}
-        {message.sender?.userType === "bot" && !message.sender?.avatarUrl && (
-          <AvatarImage src="/bot.webp" alt={senderName} />
-        )}
-        <AvatarFallback
-          className={cn(
-            "bg-primary text-primary-foreground",
-            compact ? "text-xs" : "text-sm",
-          )}
-        >
-          {initials.toUpperCase()}
-        </AvatarFallback>
-      </Avatar>
+      <UserAvatar
+        userId={message.sender?.id ?? message.senderId ?? undefined}
+        name={message.sender?.displayName ?? senderName}
+        username={message.sender?.username}
+        avatarUrl={message.sender?.avatarUrl}
+        isBot={message.sender?.userType === "bot"}
+        className={cn("shrink-0", compact ? "w-8 h-8" : "w-9 h-9")}
+        fallbackClassName={compact ? "text-xs" : "text-sm"}
+      />
 
       <div className="flex flex-col items-start flex-1 min-w-0">
         <div className="flex items-baseline gap-2 mb-1">

--- a/apps/client/src/components/channel/ThreadReplyIndicator.tsx
+++ b/apps/client/src/components/channel/ThreadReplyIndicator.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 
 interface Replier {
@@ -45,32 +45,18 @@ export function ThreadReplyIndicator({
         {/* Avatar stack */}
         {lastRepliers.length > 0 && (
           <div className="flex items-center -space-x-1.5">
-            {lastRepliers.slice(0, 5).map((replier) => {
-              const initial =
-                replier.displayName?.[0] || replier.username[0] || "?";
-              return (
-                <Avatar
-                  key={replier.id}
-                  className="w-5 h-5 ring-2 ring-background"
-                >
-                  {replier.avatarUrl && (
-                    <AvatarImage
-                      src={replier.avatarUrl}
-                      alt={replier.displayName || replier.username}
-                    />
-                  )}
-                  {replier.userType === "bot" && !replier.avatarUrl && (
-                    <AvatarImage
-                      src="/bot.webp"
-                      alt={replier.displayName || replier.username}
-                    />
-                  )}
-                  <AvatarFallback className="bg-primary text-primary-foreground text-[8px]">
-                    {initial.toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-              );
-            })}
+            {lastRepliers.slice(0, 5).map((replier) => (
+              <UserAvatar
+                key={replier.id}
+                userId={replier.id}
+                name={replier.displayName}
+                username={replier.username}
+                avatarUrl={replier.avatarUrl}
+                isBot={replier.userType === "bot"}
+                className="w-5 h-5 ring-2 ring-background"
+                fallbackClassName="text-[8px]"
+              />
+            ))}
           </div>
         )}
 

--- a/apps/client/src/components/channel/TrackingCard.tsx
+++ b/apps/client/src/components/channel/TrackingCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { parseLikelyPastDate } from "@/lib/date-utils";
 import { cn } from "@/lib/utils";
 import { useTrackingChannel } from "@/hooks/useTrackingChannel";
@@ -9,6 +9,45 @@ import type { Message, AgentEventMetadata } from "@/types/im";
 
 interface TrackingCardProps {
   message: Message;
+}
+
+const AGENT_EVENT_TYPES = new Set<AgentEventMetadata["agentEventType"]>([
+  "thinking",
+  "writing",
+  "tool_call",
+  "tool_result",
+  "agent_start",
+  "agent_end",
+  "error",
+  "turn_separator",
+]);
+
+const AGENT_EVENT_STATUSES = new Set<AgentEventMetadata["status"]>([
+  "running",
+  "completed",
+  "failed",
+]);
+
+function getAgentEventMetadata(
+  value: unknown,
+  fallback: AgentEventMetadata,
+): AgentEventMetadata {
+  if (!value || typeof value !== "object") {
+    return fallback;
+  }
+
+  const candidate = value as Partial<AgentEventMetadata>;
+
+  if (
+    candidate.agentEventType &&
+    AGENT_EVENT_TYPES.has(candidate.agentEventType) &&
+    candidate.status &&
+    AGENT_EVENT_STATUSES.has(candidate.status)
+  ) {
+    return candidate as AgentEventMetadata;
+  }
+
+  return fallback;
 }
 
 function formatElapsed(startTime: string | number): string {
@@ -65,10 +104,10 @@ export function TrackingCard({ message }: TrackingCardProps) {
   }> = latestMessages.map((msg) => ({
     id: msg.id,
     content: msg.content ?? "",
-    metadata: (msg.metadata as AgentEventMetadata) ?? {
+    metadata: getAgentEventMetadata(msg.metadata, {
       agentEventType: "writing",
       status: "completed",
-    },
+    }),
     isStreaming: false,
   }));
 
@@ -76,10 +115,10 @@ export function TrackingCard({ message }: TrackingCardProps) {
     displayItems.push({
       id: `stream-${activeStream.streamId}`,
       content: activeStream.content,
-      metadata: (activeStream.metadata as AgentEventMetadata) ?? {
+      metadata: getAgentEventMetadata(activeStream.metadata, {
         agentEventType: "writing",
         status: "running",
-      },
+      }),
       isStreaming: true,
     });
   }
@@ -100,14 +139,15 @@ export function TrackingCard({ message }: TrackingCardProps) {
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <Avatar className="w-8 h-8">
-              <AvatarImage src={message.sender?.avatarUrl ?? undefined} />
-              <AvatarFallback className="text-xs">
-                {message.sender?.displayName?.[0] ??
-                  message.sender?.username?.[0] ??
-                  "B"}
-              </AvatarFallback>
-            </Avatar>
+            <UserAvatar
+              userId={message.sender?.id ?? message.senderId ?? undefined}
+              name={message.sender?.displayName}
+              username={message.sender?.username}
+              avatarUrl={message.sender?.avatarUrl}
+              isBot={message.sender?.userType === "bot"}
+              className="w-8 h-8"
+              fallbackClassName="text-xs"
+            />
             <span className="text-sm font-semibold">
               {message.sender?.displayName ?? message.sender?.username ?? "Bot"}
             </span>

--- a/apps/client/src/components/channel/UserProfileCard.tsx
+++ b/apps/client/src/components/channel/UserProfileCard.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from "react-dom";
 import { useRef, useMemo } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { useIMUser, useIsUserOnline } from "@/hooks/useIMUsers";
 
 interface UserProfileCardProps {
@@ -52,7 +52,6 @@ export function UserProfileCard({
   }, [anchorRect]);
 
   const name = user?.displayName || user?.username || displayName;
-  const initials = name[0]?.toUpperCase() || "?";
 
   return createPortal(
     <div
@@ -74,17 +73,15 @@ export function UserProfileCard({
         <div className="p-4">
           <div className="flex items-center gap-3 mb-3">
             <div className="relative shrink-0">
-              <Avatar className="w-12 h-12">
-                {user?.avatarUrl && (
-                  <AvatarImage src={user.avatarUrl} alt={name} />
-                )}
-                {user?.userType === "bot" && !user?.avatarUrl && (
-                  <AvatarImage src="/bot.webp" alt={name} />
-                )}
-                <AvatarFallback className="bg-primary text-primary-foreground text-lg">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
+              <UserAvatar
+                userId={user?.id ?? userId}
+                name={user?.displayName ?? name}
+                username={user?.username}
+                avatarUrl={user?.avatarUrl}
+                isBot={user?.userType === "bot"}
+                className="w-12 h-12"
+                fallbackClassName="text-lg"
+              />
               <span
                 className={`absolute bottom-0 right-0 w-3.5 h-3.5 rounded-full border-2 border-popover ${
                   isOnline ? "bg-success" : "bg-muted-foreground/40"

--- a/apps/client/src/components/channel/__tests__/MessageItem.avatar.test.tsx
+++ b/apps/client/src/components/channel/__tests__/MessageItem.avatar.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { getSeededAvatarGradient } from "@/lib/avatar-colors";
+import type { Message } from "@/types/im";
+
+import { MessageItem } from "../MessageItem";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    channelId: "ch-1",
+    senderId: "user-1",
+    content: "hello",
+    type: "text",
+    isPinned: false,
+    isEdited: false,
+    isDeleted: false,
+    createdAt: "2026-03-27T12:00:00Z",
+    updatedAt: "2026-03-27T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("MessageItem avatar fallback", () => {
+  it("renders seeded initials for a sender without avatarUrl", () => {
+    const message = makeMessage({
+      sender: {
+        id: "user-seeded",
+        email: "alice@example.com",
+        username: "alice",
+        displayName: "Alice Smith",
+        avatarUrl: undefined,
+        status: "online",
+        isActive: true,
+        createdAt: "2026-03-27T12:00:00Z",
+        updatedAt: "2026-03-27T12:00:00Z",
+      },
+    });
+
+    render(<MessageItem message={message} />);
+
+    const fallback = screen.getByText("AS");
+    expect(fallback).toHaveClass(getSeededAvatarGradient("user-seeded"));
+  });
+});

--- a/apps/client/src/components/channel/__tests__/seeded-avatar-surfaces.test.tsx
+++ b/apps/client/src/components/channel/__tests__/seeded-avatar-surfaces.test.tsx
@@ -21,6 +21,7 @@ const mockUseIsUserOnline = vi.fn();
 const mockUseTrackingChannel = vi.fn();
 const mockUseUser = vi.fn();
 const mockTrackingEventItem = vi.fn();
+const mockConsoleError = vi.fn();
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -181,6 +182,7 @@ function makeTrackingMessage(): Message {
 describe("seeded avatar channel surfaces", () => {
   beforeEach(() => {
     vi.stubGlobal("Image", MockImage);
+    vi.spyOn(console, "error").mockImplementation(mockConsoleError);
     mockUseChannelMembers.mockReturnValue({ data: [] });
     mockUseIsUserOnline.mockReturnValue(false);
     mockUseUpdateChannel.mockReturnValue({
@@ -203,6 +205,7 @@ describe("seeded avatar channel surfaces", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -230,6 +233,9 @@ describe("seeded avatar channel surfaces", () => {
     const image = screen.getByRole("img", { name: "Helper Bot" });
 
     expect(image).toHaveAttribute("src", "/bot.webp");
+    expect(mockConsoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Missing `Description`"),
+    );
   });
 
   it("renders seeded stacked avatars in ThreadReplyIndicator", () => {

--- a/apps/client/src/components/channel/__tests__/seeded-avatar-surfaces.test.tsx
+++ b/apps/client/src/components/channel/__tests__/seeded-avatar-surfaces.test.tsx
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { getSeededAvatarGradient } from "@/lib/avatar-colors";
+import { ChannelHeader } from "../ChannelHeader";
+import { ChannelDetailsModal } from "../ChannelDetailsModal";
+import { ThreadReplyIndicator } from "../ThreadReplyIndicator";
+import { TrackingCard } from "../TrackingCard";
+import type {
+  Channel,
+  ChannelMember,
+  ChannelWithUnread,
+  Message,
+} from "@/types/im";
+
+const mockUseChannel = vi.fn();
+const mockUseChannelMembers = vi.fn();
+const mockUseUpdateChannel = vi.fn();
+const mockUseLeaveChannel = vi.fn();
+const mockUseIsUserOnline = vi.fn();
+const mockUseTrackingChannel = vi.fn();
+const mockUseUser = vi.fn();
+const mockTrackingEventItem = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      typeof options?.count === "number" ? `${key}:${options.count}` : key,
+  }),
+}));
+
+vi.mock("@/hooks/useChannels", () => ({
+  useChannel: (...args: unknown[]) => mockUseChannel(...args),
+  useChannelMembers: (...args: unknown[]) => mockUseChannelMembers(...args),
+  useUpdateChannel: (...args: unknown[]) => mockUseUpdateChannel(...args),
+  useLeaveChannel: (...args: unknown[]) => mockUseLeaveChannel(...args),
+}));
+
+vi.mock("@/hooks/useIMUsers", () => ({
+  useIsUserOnline: (...args: unknown[]) => mockUseIsUserOnline(...args),
+}));
+
+vi.mock("@/hooks/useTrackingChannel", () => ({
+  useTrackingChannel: (...args: unknown[]) => mockUseTrackingChannel(...args),
+}));
+
+vi.mock("@/stores", async () => {
+  const actual = await vi.importActual<typeof import("@/stores")>("@/stores");
+  return {
+    ...actual,
+    useUser: (...args: unknown[]) => mockUseUser(...args),
+  };
+});
+
+vi.mock("@/components/channel/AddMemberDialog", () => ({
+  AddMemberDialog: () => null,
+}));
+
+vi.mock("@/components/channel/TrackingEventItem", () => ({
+  TrackingEventItem: (props: unknown) => {
+    mockTrackingEventItem(props);
+    return <div>tracking event</div>;
+  },
+}));
+
+vi.mock("@/components/channel/TrackingModal", () => ({
+  TrackingModal: () => null,
+}));
+
+vi.mock("@/components/dialog/DeleteChannelDialog", () => ({
+  DeleteChannelDialog: () => null,
+}));
+
+class MockImage {
+  complete = true;
+
+  naturalWidth = 1;
+
+  src = "";
+
+  referrerPolicy = "";
+
+  crossOrigin: string | null = null;
+
+  addEventListener() {}
+
+  removeEventListener() {}
+}
+
+function makeDirectChannel(): ChannelWithUnread {
+  return {
+    id: "dm-1",
+    tenantId: "tenant-1",
+    name: "dm",
+    type: "direct",
+    createdBy: "user-1",
+    order: 0,
+    isArchived: false,
+    isActivated: true,
+    unreadCount: 0,
+    createdAt: "2026-03-27T12:00:00Z",
+    updatedAt: "2026-03-27T12:00:00Z",
+    otherUser: {
+      id: "user-seeded",
+      username: "alice",
+      displayName: "Alice Smith",
+      avatarUrl: undefined,
+      status: "online",
+      userType: "human",
+    },
+  };
+}
+
+function makeChannel(): Channel {
+  return {
+    id: "ch-1",
+    tenantId: "tenant-1",
+    name: "general",
+    description: "General",
+    type: "public",
+    createdBy: "user-1",
+    order: 0,
+    isArchived: false,
+    isActivated: true,
+    createdAt: "2026-03-27T12:00:00Z",
+    updatedAt: "2026-03-27T12:00:00Z",
+  };
+}
+
+function makeMember(): ChannelMember {
+  return {
+    id: "member-1",
+    channelId: "ch-1",
+    userId: "bot-1",
+    role: "member",
+    isMuted: false,
+    notificationsEnabled: true,
+    joinedAt: "2026-03-27T12:00:00Z",
+    user: {
+      id: "bot-1",
+      email: "bot@example.com",
+      username: "helper-bot",
+      displayName: "Helper Bot",
+      avatarUrl: undefined,
+      status: "online",
+      isActive: true,
+      userType: "bot",
+      createdAt: "2026-03-27T12:00:00Z",
+      updatedAt: "2026-03-27T12:00:00Z",
+    },
+  };
+}
+
+function makeTrackingMessage(): Message {
+  return {
+    id: "msg-1",
+    channelId: "ch-1",
+    senderId: "bot-1",
+    content: "Tracking summary",
+    type: "tracking",
+    isPinned: false,
+    isEdited: false,
+    isDeleted: false,
+    createdAt: "2026-03-27T12:00:00Z",
+    updatedAt: "2026-03-27T12:00:00Z",
+    sender: {
+      id: "bot-1",
+      email: "bot@example.com",
+      username: "helper-bot",
+      displayName: "Helper Bot",
+      avatarUrl: undefined,
+      status: "online",
+      isActive: true,
+      userType: "bot",
+      createdAt: "2026-03-27T12:00:00Z",
+      updatedAt: "2026-03-27T12:00:00Z",
+    },
+  };
+}
+
+describe("seeded avatar channel surfaces", () => {
+  beforeEach(() => {
+    vi.stubGlobal("Image", MockImage);
+    mockUseChannelMembers.mockReturnValue({ data: [] });
+    mockUseIsUserOnline.mockReturnValue(false);
+    mockUseUpdateChannel.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    mockUseLeaveChannel.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    mockUseTrackingChannel.mockReturnValue({
+      isActivated: false,
+      latestMessages: [],
+      totalMessageCount: 0,
+      isLoading: false,
+      activeStream: null,
+    });
+    mockUseUser.mockReturnValue({ id: "user-1" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a seeded fallback in ChannelHeader for a DM user without an avatar", () => {
+    render(<ChannelHeader channel={makeDirectChannel()} />);
+
+    const fallback = screen.getByText("AS");
+
+    expect(fallback).toHaveClass(getSeededAvatarGradient("user-seeded"));
+  });
+
+  it("renders the bot image in ChannelDetailsModal members when a bot has no avatar", () => {
+    mockUseChannel.mockReturnValue({ data: makeChannel() });
+    mockUseChannelMembers.mockReturnValue({ data: [makeMember()] });
+
+    render(
+      <ChannelDetailsModal
+        isOpen
+        onClose={() => {}}
+        channelId="ch-1"
+        defaultTab="members"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Helper Bot" });
+
+    expect(image).toHaveAttribute("src", "/bot.webp");
+  });
+
+  it("renders seeded stacked avatars in ThreadReplyIndicator", () => {
+    render(
+      <ThreadReplyIndicator
+        replyCount={2}
+        lastRepliers={[
+          {
+            id: "user-thread",
+            username: "alice",
+            displayName: "Alice Smith",
+            avatarUrl: null,
+            userType: "human",
+          },
+        ]}
+      />,
+    );
+
+    const fallback = screen.getByText("AS");
+
+    expect(fallback).toHaveClass(getSeededAvatarGradient("user-thread"));
+  });
+
+  it("renders the bot image in TrackingCard when the sender has no avatar", () => {
+    render(<TrackingCard message={makeTrackingMessage()} />);
+
+    const image = screen.getByRole("img", { name: "Helper Bot" });
+
+    expect(image).toHaveAttribute("src", "/bot.webp");
+  });
+
+  it("falls back to default metadata for an active stream with malformed metadata", () => {
+    mockUseTrackingChannel.mockReturnValue({
+      isActivated: true,
+      latestMessages: [],
+      totalMessageCount: 1,
+      isLoading: false,
+      activeStream: {
+        streamId: "stream-1",
+        content: "working",
+        metadata: { unexpected: true },
+      },
+    });
+
+    render(<TrackingCard message={makeTrackingMessage()} />);
+
+    expect(mockTrackingEventItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          agentEventType: "writing",
+          status: "running",
+        },
+        content: "working",
+        isStreaming: true,
+        compact: true,
+      }),
+    );
+  });
+});

--- a/apps/client/src/components/channel/editor/plugins/MentionsPlugin.tsx
+++ b/apps/client/src/components/channel/editor/plugins/MentionsPlugin.tsx
@@ -17,6 +17,7 @@ import { mergeRegister } from "@lexical/utils";
 import { useTranslation } from "react-i18next";
 import { useSearchUsers } from "@/hooks/useIMUsers";
 import { OnlineStatusDot } from "@/components/ui/online-status-dot";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   useChannel,
   useChannelMembers,
@@ -116,12 +117,15 @@ function MentionSuggestions({
               onClick={() => onSelect(user)}
               onMouseEnter={() => onHover(index)}
             >
-              <Avatar className="w-6 h-6">
-                {user.avatarUrl && <AvatarImage src={user.avatarUrl} />}
-                <AvatarFallback className="bg-primary text-primary-foreground text-xs">
-                  {(user.displayName || user.username)[0].toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
+              <UserAvatar
+                userId={user.id}
+                name={user.displayName || user.username}
+                username={user.username}
+                avatarUrl={user.avatarUrl}
+                isBot={user.userType === "bot"}
+                className="w-6 h-6"
+                fallbackClassName="text-xs"
+              />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium truncate">
                   {user.displayName || user.username}

--- a/apps/client/src/components/dialog/NewMessageDialog.tsx
+++ b/apps/client/src/components/dialog/NewMessageDialog.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from "@tanstack/react-router";
 import { Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { OnlineStatusDot } from "@/components/ui/online-status-dot";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { useSearchUsers } from "@/hooks/useIMUsers";
 import { useCreateDirectChannel } from "@/hooks/useChannels";
 import type { IMUser } from "@/types/im";
@@ -100,11 +100,14 @@ export function NewMessageDialog({ isOpen, onClose }: NewMessageDialogProps) {
                     disabled={createDirectChannel.isPending}
                     className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted transition-colors text-left disabled:opacity-50"
                   >
-                    <Avatar className="w-10 h-10">
-                      <AvatarFallback className="bg-primary text-primary-foreground">
-                        {(user.displayName || user.username)[0].toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
+                    <UserAvatar
+                      userId={user.id}
+                      name={user.displayName || user.username}
+                      username={user.username}
+                      avatarUrl={user.avatarUrl}
+                      isBot={user.userType === "bot"}
+                      className="w-10 h-10"
+                    />
                     <div className="flex-1 min-w-0">
                       <p className="font-medium text-sm text-foreground truncate">
                         {user.displayName || user.username}

--- a/apps/client/src/components/layout/MainSidebar.tsx
+++ b/apps/client/src/components/layout/MainSidebar.tsx
@@ -23,6 +23,7 @@ import { supportedLanguages } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -515,13 +516,14 @@ export function MainSidebar() {
             <Popover open={userMenuOpen} onOpenChange={setUserMenuOpen}>
               <PopoverTrigger asChild>
                 <div className="relative cursor-pointer">
-                  <Avatar className="w-10 h-10">
-                    <AvatarFallback className="bg-primary hover:bg-primary/90 transition-colors text-primary-foreground text-sm font-medium">
-                      {currentUser?.displayName?.[0] ||
-                        currentUser?.username?.[0]?.toUpperCase() ||
-                        "U"}
-                    </AvatarFallback>
-                  </Avatar>
+                  <UserAvatar
+                    userId={currentUser?.id}
+                    name={currentUser?.displayName}
+                    username={currentUser?.username}
+                    avatarUrl={currentUser?.avatarUrl}
+                    className="w-10 h-10"
+                    fallbackClassName="transition-opacity hover:opacity-90 text-sm font-medium"
+                  />
                   <div
                     className={cn(
                       "absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-nav-bg",
@@ -540,16 +542,15 @@ export function MainSidebar() {
                 <div className="p-4">
                   <div className="flex items-center gap-3">
                     <div className="relative">
-                      <Avatar
+                      <UserAvatar
+                        userId={currentUser?.id}
+                        name={currentUser?.displayName}
+                        username={currentUser?.username}
+                        avatarUrl={currentUser?.avatarUrl}
                         className="w-12 h-12 cursor-pointer"
+                        fallbackClassName="text-lg font-medium"
                         onClick={devtoolsTap}
-                      >
-                        <AvatarFallback className="bg-primary text-primary-foreground text-lg font-medium">
-                          {currentUser?.displayName?.[0] ||
-                            currentUser?.username?.[0]?.toUpperCase() ||
-                            "U"}
-                        </AvatarFallback>
-                      </Avatar>
+                      />
                       {devtoolsMessage && (
                         <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1 whitespace-nowrap rounded bg-foreground px-2 py-1 text-xs text-background shadow-md animate-in fade-in zoom-in-95 duration-150">
                           {devtoolsMessage}

--- a/apps/client/src/components/layout/MainSidebar.tsx
+++ b/apps/client/src/components/layout/MainSidebar.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { supportedLanguages } from "@/i18n";
+import { getInitials, getSeededAvatarGradient } from "@/lib/avatar-colors";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -71,20 +72,6 @@ const navigationItems = [
   { id: "library", labelKey: "library" as const, icon: Library },
   { id: "application", labelKey: "application" as const, icon: LayoutGrid },
   { id: "more", labelKey: "more" as const, icon: MoreHorizontal },
-];
-
-// Workspace avatar gradient colors - softer, modern palette
-const WORKSPACE_GRADIENTS = [
-  "from-indigo-500 to-blue-400",
-  "from-violet-500 to-purple-400",
-  "from-rose-400 to-pink-400",
-  "from-emerald-500 to-teal-400",
-  "from-amber-400 to-orange-400",
-  "from-cyan-500 to-sky-400",
-  "from-fuchsia-500 to-pink-400",
-  "from-lime-500 to-green-400",
-  "from-blue-500 to-indigo-400",
-  "from-orange-500 to-red-400",
 ];
 
 export function MainSidebar() {
@@ -266,18 +253,6 @@ export function MainSidebar() {
     prevWorkspaceIdRef.current = selectedWorkspaceId;
   }, [selectedWorkspaceId, queryClient, navigate]);
 
-  const getInitials = (name: string) => {
-    const words = name.trim().split(/\s+/);
-    if (words.length === 1) {
-      return words[0][0].toUpperCase();
-    }
-    return (words[0][0] + words[1][0]).toUpperCase();
-  };
-
-  const getWorkspaceGradient = (index: number) => {
-    return WORKSPACE_GRADIENTS[index % WORKSPACE_GRADIENTS.length];
-  };
-
   const sidebarCollapsed = useSidebarCollapsed();
 
   const renderNavigationItems = () =>
@@ -353,9 +328,6 @@ export function MainSidebar() {
             ) : sidebarCollapsed && workspaces && workspaces.length > 1 ? (
               /* Stacked workspace avatars when collapsed - current on top */
               (() => {
-                const currentIdx = workspaces.findIndex(
-                  (w) => w.id === currentWorkspace?.id,
-                );
                 const others = workspaces.filter(
                   (w) => w.id !== currentWorkspace?.id,
                 );
@@ -372,13 +344,12 @@ export function MainSidebar() {
                       >
                         {/* Background avatars (behind, offset) */}
                         {others.slice(0, 2).map((workspace, i) => {
-                          const origIdx = workspaces.indexOf(workspace);
                           return (
                             <div
                               key={workspace.id}
                               className={cn(
                                 "absolute flex items-center justify-center bg-linear-to-br text-white text-xs font-semibold rounded-lg border-2 border-nav-bg opacity-60",
-                                getWorkspaceGradient(origIdx),
+                                getSeededAvatarGradient(workspace.id),
                               )}
                               style={{
                                 width: "32px",
@@ -397,9 +368,7 @@ export function MainSidebar() {
                           <div
                             className={cn(
                               "w-10 h-10 absolute top-0 left-0 flex items-center justify-center bg-linear-to-br text-white text-sm font-semibold rounded-xl shadow-md",
-                              getWorkspaceGradient(
-                                currentIdx >= 0 ? currentIdx : 0,
-                              ),
+                              getSeededAvatarGradient(currentWorkspace.id),
                             )}
                             style={{ zIndex: 10 }}
                           >
@@ -413,7 +382,7 @@ export function MainSidebar() {
                         <p className="font-semibold text-xs mb-2 text-muted-foreground px-2">
                           {tNav("moreWorkspaces")}
                         </p>
-                        {workspaces.map((workspace, index) => {
+                        {workspaces.map((workspace) => {
                           const isActive =
                             currentWorkspace?.id === workspace.id;
                           return (
@@ -432,7 +401,7 @@ export function MainSidebar() {
                               <div
                                 className={cn(
                                   "w-6 h-6 rounded-md flex items-center justify-center bg-linear-to-br text-white text-xs font-semibold shrink-0",
-                                  getWorkspaceGradient(index),
+                                  getSeededAvatarGradient(workspace.id),
                                   !isActive && "opacity-60",
                                 )}
                               >
@@ -460,7 +429,7 @@ export function MainSidebar() {
                 );
               })()
             ) : (
-              visibleWorkspaces.map((workspace, index) => {
+              visibleWorkspaces.map((workspace) => {
                 const isSelected = currentWorkspace?.id === workspace.id;
                 return (
                   <Tooltip key={workspace.id}>
@@ -468,7 +437,7 @@ export function MainSidebar() {
                       <div
                         className={cn(
                           "cursor-pointer transition-all duration-200 flex items-center justify-center bg-linear-to-br text-white font-semibold",
-                          getWorkspaceGradient(index),
+                          getSeededAvatarGradient(workspace.id),
                           isSelected
                             ? "w-11 h-11 rounded-lg text-base shadow-[0_2px_12px_rgba(0,0,0,0.3)]"
                             : "w-9 h-9 rounded-full text-sm opacity-50 hover:opacity-90 hover:rounded-2xl hover:w-10 hover:h-10",

--- a/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
@@ -329,15 +329,12 @@ export function HomeSubSidebar() {
     const otherUser = channel.otherUser;
     const displayName =
       otherUser?.displayName || otherUser?.username || "Direct Message";
-    const avatarText =
-      otherUser?.displayName?.[0] || otherUser?.username?.[0] || "D";
 
     return {
       id: channel.id,
       channelId: channel.id,
       userId: otherUser?.id,
       name: displayName,
-      avatar: avatarText,
       avatarUrl: otherUser?.avatarUrl,
       status: otherUser?.status || ("offline" as const),
       unreadCount: channel.unreadCount || 0,
@@ -631,7 +628,6 @@ export function HomeSubSidebar() {
                     <UserListItem
                       key={dm.id}
                       name={dm.name}
-                      avatar={dm.avatar}
                       avatarUrl={dm.avatarUrl}
                       userId={dm.userId}
                       isSelected={selectedChannelId === dm.channelId}

--- a/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
@@ -40,15 +40,12 @@ export function MessagesSubSidebar() {
       const otherUser = channel.otherUser;
       const displayName =
         otherUser?.displayName || otherUser?.username || "Direct Message";
-      const avatarText =
-        otherUser?.displayName?.[0] || otherUser?.username?.[0] || "D";
 
       return {
         id: channel.id,
         channelId: channel.id,
         userId: otherUser?.id,
         name: displayName,
-        avatar: avatarText,
         avatarUrl: otherUser?.avatarUrl,
         unreadCount: channel.unreadCount || 0,
         isBot: otherUser?.userType === "bot",
@@ -77,10 +74,6 @@ export function MessagesSubSidebar() {
     } catch (error) {
       console.error("Failed to create/open direct channel:", error);
     }
-  };
-
-  const getInitials = (name: string) => {
-    return name[0]?.toUpperCase() || "U";
   };
 
   const isLoading = isLoadingChannels || isLoadingMembers;
@@ -115,7 +108,6 @@ export function MessagesSubSidebar() {
                   <UserListItem
                     key={dm.id}
                     name={dm.name}
-                    avatar={dm.avatar}
                     avatarUrl={dm.avatarUrl}
                     userId={dm.userId}
                     isSelected={selectedChannelId === dm.channelId}
@@ -140,7 +132,6 @@ export function MessagesSubSidebar() {
                       <UserListItem
                         key={member.id}
                         name={displayName}
-                        avatar={getInitials(displayName)}
                         userId={member.userId}
                         subtitle={
                           member.displayName ? `@${member.username}` : undefined

--- a/apps/client/src/components/search/SearchFilterFrom.tsx
+++ b/apps/client/src/components/search/SearchFilterFrom.tsx
@@ -8,8 +8,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Checkbox } from "@/components/ui/checkbox";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 import { useWorkspaceMembers } from "@/hooks/useWorkspace";
 import { useSelectedWorkspaceId, useUser } from "@/stores";
@@ -153,13 +153,15 @@ export function SearchFilterFrom({
                           "border-primary-foreground data-[state=checked]:bg-primary-foreground data-[state=checked]:text-primary",
                       )}
                     />
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage src={member.avatarUrl || undefined} />
-                      <AvatarFallback className="text-xs">
-                        {(member.displayName ||
-                          member.username)?.[0]?.toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
+                    <UserAvatar
+                      userId={member.userId}
+                      name={member.displayName || member.username}
+                      username={member.username}
+                      avatarUrl={member.avatarUrl}
+                      isBot={member.userType === "bot"}
+                      className="h-6 w-6"
+                      fallbackClassName="text-xs"
+                    />
                     <span className="flex-1 truncate text-sm">
                       {member.displayName || member.username}
                       {isCurrentUser && (

--- a/apps/client/src/components/sidebar/UserListItem.tsx
+++ b/apps/client/src/components/sidebar/UserListItem.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { Link } from "@tanstack/react-router";
 import { useIsUserOnline } from "@/hooks/useIMUsers";
 
@@ -57,6 +57,7 @@ export function UserListItem({
   const avatarSizeClass = avatarSize === "sm" ? "w-6 h-6" : "w-8 h-8";
   const avatarTextClass = avatarSize === "sm" ? "text-xs" : "text-sm";
   const onlineIndicatorSize = avatarSize === "sm" ? "w-2.5 h-2.5" : "w-3 h-3";
+  const username = subtitle?.startsWith("@") ? subtitle.slice(1) : undefined;
 
   const content = (
     <Button
@@ -70,15 +71,15 @@ export function UserListItem({
       )}
     >
       <div className="relative">
-        <Avatar className={avatarSizeClass}>
-          {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
-          {isBot && !avatarUrl && <AvatarImage src="/bot.webp" alt={name} />}
-          <AvatarFallback
-            className={cn("bg-accent text-accent-foreground", avatarTextClass)}
-          >
-            {avatar}
-          </AvatarFallback>
-        </Avatar>
+        <UserAvatar
+          userId={userId}
+          name={name || avatar}
+          username={username}
+          avatarUrl={avatarUrl}
+          isBot={isBot}
+          className={avatarSizeClass}
+          fallbackClassName={avatarTextClass}
+        />
         {isOnline && (
           <div
             className={cn(

--- a/apps/client/src/components/sidebar/UserListItem.tsx
+++ b/apps/client/src/components/sidebar/UserListItem.tsx
@@ -8,8 +8,6 @@ import { useIsUserOnline } from "@/hooks/useIMUsers";
 export interface UserListItemProps {
   /** Display name */
   name: string;
-  /** Avatar text (initials) */
-  avatar: string;
   /** Avatar image URL */
   avatarUrl?: string;
   /** User ID for real-time online status detection */
@@ -40,7 +38,6 @@ export interface UserListItemProps {
  */
 export function UserListItem({
   name,
-  avatar,
   avatarUrl,
   userId,
   isSelected = false,
@@ -73,7 +70,7 @@ export function UserListItem({
       <div className="relative">
         <UserAvatar
           userId={userId}
-          name={name || avatar}
+          name={name}
           username={username}
           avatarUrl={avatarUrl}
           isBot={isBot}

--- a/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
+++ b/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { getSeededAvatarGradient } from "@/lib/avatar-colors";
+
+import { UserListItem } from "../UserListItem";
+
+vi.mock("@/hooks/useIMUsers", () => ({
+  useIsUserOnline: vi.fn(() => false),
+}));
+
+describe("UserListItem avatar fallback", () => {
+  it("uses userId as the seeded fallback key", () => {
+    render(
+      <UserListItem
+        name="Alice Smith"
+        avatar="A"
+        userId="user-seeded"
+        subtitle="@alice"
+      />,
+    );
+
+    expect(screen.getByText("AS")).toHaveClass(
+      getSeededAvatarGradient("user-seeded"),
+    );
+  });
+});

--- a/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
+++ b/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
@@ -14,7 +14,6 @@ describe("UserListItem avatar fallback", () => {
     render(
       <UserListItem
         name="Alice Smith"
-        avatar="A"
         userId="user-seeded"
         subtitle="@alice"
       />,

--- a/apps/client/src/components/ui/__tests__/UserAvatar.test.tsx
+++ b/apps/client/src/components/ui/__tests__/UserAvatar.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { getInitials, getSeededAvatarGradient } from "@/lib/avatar-colors";
+import { UserAvatar } from "../user-avatar";
+
+class MockImage {
+  complete = true;
+
+  naturalWidth = 1;
+
+  src = "";
+
+  referrerPolicy = "";
+
+  crossOrigin: string | null = null;
+
+  addEventListener() {}
+
+  removeEventListener() {}
+}
+
+describe("UserAvatar", () => {
+  beforeEach(() => {
+    vi.stubGlobal("Image", MockImage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a seeded fallback for a human user without an avatar URL", () => {
+    render(
+      <UserAvatar
+        userId="user-123"
+        name="Alice Doe"
+        username="alice"
+        fallbackClassName="ring-2"
+      />,
+    );
+
+    const fallback = screen.getByText(getInitials("Alice Doe"));
+
+    expect(fallback).toHaveClass(
+      "bg-linear-to-br",
+      "text-white",
+      getSeededAvatarGradient("user-123"),
+      "ring-2",
+    );
+  });
+
+  it("renders the uploaded avatar when an avatar URL exists", () => {
+    render(
+      <UserAvatar
+        userId="user-456"
+        name="Alice Doe"
+        username="alice"
+        avatarUrl="https://example.com/avatar.png"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Alice Doe" });
+
+    expect(image).toHaveAttribute("src", "https://example.com/avatar.png");
+  });
+
+  it("uses the username when the name is whitespace only", () => {
+    render(<UserAvatar username="helper" name="   " />);
+
+    expect(screen.getByText("H")).toBeInTheDocument();
+    expect(
+      screen.getByText("H").closest("[data-slot='avatar-fallback']"),
+    ).toHaveClass(getSeededAvatarGradient("helper"));
+  });
+
+  it("renders the bot image and does not show fallback initials when isBot is true", () => {
+    render(<UserAvatar userId="bot-1" username="helper-bot" isBot />);
+
+    const image = screen.getByRole("img", { name: "helper-bot" });
+
+    expect(image).toHaveAttribute("src", "/bot.webp");
+    expect(screen.queryByText("H")).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/components/ui/user-avatar.tsx
+++ b/apps/client/src/components/ui/user-avatar.tsx
@@ -1,0 +1,50 @@
+import type { ComponentProps } from "react";
+
+import { getInitials, getSeededAvatarGradient } from "@/lib/avatar-colors";
+import { cn } from "@/lib/utils";
+
+import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
+
+export interface UserAvatarProps extends ComponentProps<typeof Avatar> {
+  userId?: string;
+  name?: string | null;
+  username?: string | null;
+  avatarUrl?: string | null;
+  isBot?: boolean;
+  fallbackClassName?: string;
+}
+
+export function UserAvatar({
+  userId,
+  name,
+  username,
+  avatarUrl,
+  isBot,
+  fallbackClassName,
+  ...props
+}: UserAvatarProps) {
+  const normalizedName = name?.trim() || null;
+  const normalizedUsername = username?.trim() || null;
+  const displayName = normalizedName || normalizedUsername || "Unknown User";
+  const seed = userId?.trim() || normalizedUsername || normalizedName || "?";
+  const initials = getInitials(normalizedName || normalizedUsername);
+
+  return (
+    <Avatar {...props}>
+      {avatarUrl ? (
+        <AvatarImage src={avatarUrl} alt={displayName} />
+      ) : isBot ? (
+        <AvatarImage src="/bot.webp" alt={displayName} />
+      ) : null}
+      <AvatarFallback
+        className={cn(
+          "bg-linear-to-br text-white",
+          getSeededAvatarGradient(seed),
+          fallbackClassName,
+        )}
+      >
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/client/src/lib/__tests__/avatar-colors.test.ts
+++ b/apps/client/src/lib/__tests__/avatar-colors.test.ts
@@ -51,6 +51,30 @@ describe("getInitials", () => {
     expect(getInitials("e\u0301clair")).toBe("\u00c9");
   });
 
+  it("reuses a cached Intl.Segmenter instance for repeated calls", () => {
+    const segment = vi.fn((input: string) =>
+      [
+        {
+          segment: Array.from(input.normalize("NFC"))[0] ?? "",
+        },
+      ][Symbol.iterator](),
+    );
+    const Segmenter = vi.fn(
+      class MockSegmenter {
+        segment = segment;
+      },
+    );
+
+    vi.stubGlobal("Intl", {
+      ...Intl,
+      Segmenter,
+    });
+
+    expect(getInitials("Alice")).toBe("A");
+    expect(getInitials("Bob")).toBe("B");
+    expect(Segmenter).toHaveBeenCalledTimes(1);
+  });
+
   it('returns "?" for an empty name', () => {
     expect(getInitials("")).toBe("?");
   });

--- a/apps/client/src/lib/__tests__/avatar-colors.test.ts
+++ b/apps/client/src/lib/__tests__/avatar-colors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  AVATAR_GRADIENTS,
+  getInitials,
+  getSeededAvatarGradient,
+} from "../avatar-colors";
+
+describe("getSeededAvatarGradient", () => {
+  it("returns the same gradient for the same seed", () => {
+    const seed = "workspace-123";
+    const expectedGradient = "from-lime-500 to-green-400";
+
+    expect(getSeededAvatarGradient(seed)).toBe(expectedGradient);
+    expect(getSeededAvatarGradient(`  ${seed}  `)).toBe(expectedGradient);
+  });
+
+  it("returns a gradient from the shared palette", () => {
+    expect(AVATAR_GRADIENTS).toContain(
+      getSeededAvatarGradient("workspace-123"),
+    );
+  });
+});
+
+describe("getInitials", () => {
+  it('returns "A" for a single-word name', () => {
+    expect(getInitials("Alice")).toBe("A");
+  });
+
+  it('returns "AS" for a multi-word name', () => {
+    expect(getInitials("Alice Smith")).toBe("AS");
+  });
+
+  it("trims extra spacing before extracting initials", () => {
+    expect(getInitials("  Alice   Smith  ")).toBe("AS");
+  });
+
+  it("keeps a one-word Unicode initial to a single displayed character", () => {
+    expect(getInitials("ß")).toBe("S");
+  });
+
+  it('returns "?" for an empty name', () => {
+    expect(getInitials("")).toBe("?");
+  });
+
+  it('returns "?" for an undefined name', () => {
+    expect(getInitials(undefined)).toBe("?");
+  });
+});

--- a/apps/client/src/lib/__tests__/avatar-colors.test.ts
+++ b/apps/client/src/lib/__tests__/avatar-colors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AVATAR_GRADIENTS,
   getInitials,
@@ -22,6 +22,10 @@ describe("getSeededAvatarGradient", () => {
 });
 
 describe("getInitials", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('returns "A" for a single-word name', () => {
     expect(getInitials("Alice")).toBe("A");
   });
@@ -36,6 +40,15 @@ describe("getInitials", () => {
 
   it("keeps a one-word Unicode initial to a single displayed character", () => {
     expect(getInitials("ß")).toBe("S");
+  });
+
+  it("keeps a combined Unicode grapheme when Intl.Segmenter is unavailable", () => {
+    vi.stubGlobal("Intl", {
+      ...Intl,
+      Segmenter: undefined,
+    });
+
+    expect(getInitials("e\u0301clair")).toBe("\u00c9");
   });
 
   it('returns "?" for an empty name', () => {

--- a/apps/client/src/lib/avatar-colors.ts
+++ b/apps/client/src/lib/avatar-colors.ts
@@ -1,0 +1,67 @@
+export const AVATAR_GRADIENTS = [
+  "from-indigo-500 to-blue-400",
+  "from-violet-500 to-purple-400",
+  "from-rose-400 to-pink-400",
+  "from-emerald-500 to-teal-400",
+  "from-amber-400 to-orange-400",
+  "from-cyan-500 to-sky-400",
+  "from-fuchsia-500 to-pink-400",
+  "from-lime-500 to-green-400",
+  "from-blue-500 to-indigo-400",
+  "from-orange-500 to-red-400",
+] as const;
+
+function hashSeed(seed: string): number {
+  let hash = 5381;
+
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash << 5) + hash + seed.charCodeAt(i);
+    hash |= 0;
+  }
+
+  return Math.abs(hash);
+}
+
+function getFirstDisplayedGrapheme(value: string): string {
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
+    const firstSegment = segmenter.segment(value)[Symbol.iterator]().next()
+      .value?.segment;
+
+    return firstSegment ?? "";
+  }
+
+  return Array.from(value)[0] ?? "";
+}
+
+function getInitialFromPart(part: string): string {
+  return getFirstDisplayedGrapheme(part.toUpperCase());
+}
+
+export function getSeededAvatarGradient(seed?: string | null): string {
+  const normalizedSeed = seed?.trim() || "?";
+  const index = hashSeed(normalizedSeed) % AVATAR_GRADIENTS.length;
+
+  return AVATAR_GRADIENTS[index];
+}
+
+export function getInitials(name?: string | null): string {
+  const normalizedName = name?.trim();
+
+  if (!normalizedName) {
+    return "?";
+  }
+
+  const parts = normalizedName.split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  const first = getInitialFromPart(parts[0] ?? "");
+  const second = getInitialFromPart(parts[1] ?? "");
+
+  return first + second || "?";
+}

--- a/apps/client/src/lib/avatar-colors.ts
+++ b/apps/client/src/lib/avatar-colors.ts
@@ -26,6 +26,9 @@ type IntlWithOptionalSegmenter = typeof Intl & {
   ) => GraphemeSegmenter;
 };
 
+let cachedIntlRef: typeof Intl | undefined;
+let cachedGraphemeSegmenter: GraphemeSegmenter | null | undefined;
+
 function hashSeed(seed: string): number {
   let hash = 5381;
 
@@ -39,18 +42,28 @@ function hashSeed(seed: string): number {
 
 function getGraphemeSegmenter(): GraphemeSegmenter | null {
   if (typeof Intl === "undefined") {
+    cachedIntlRef = undefined;
+    cachedGraphemeSegmenter = null;
     return null;
+  }
+
+  if (cachedIntlRef === Intl && cachedGraphemeSegmenter !== undefined) {
+    return cachedGraphemeSegmenter;
   }
 
   const intlWithSegmenter = Intl as IntlWithOptionalSegmenter;
+  cachedIntlRef = Intl;
 
   if (typeof intlWithSegmenter.Segmenter !== "function") {
+    cachedGraphemeSegmenter = null;
     return null;
   }
 
-  return new intlWithSegmenter.Segmenter(undefined, {
+  cachedGraphemeSegmenter = new intlWithSegmenter.Segmenter(undefined, {
     granularity: "grapheme",
   });
+
+  return cachedGraphemeSegmenter;
 }
 
 function getFirstDisplayedGrapheme(value: string): string {

--- a/apps/client/src/lib/avatar-colors.ts
+++ b/apps/client/src/lib/avatar-colors.ts
@@ -11,6 +11,21 @@ export const AVATAR_GRADIENTS = [
   "from-orange-500 to-red-400",
 ] as const;
 
+type GraphemeSegment = {
+  segment: string;
+};
+
+type GraphemeSegmenter = {
+  segment(input: string): Iterable<GraphemeSegment>;
+};
+
+type IntlWithOptionalSegmenter = typeof Intl & {
+  Segmenter?: new (
+    locales?: string | string[],
+    options?: { granularity?: "grapheme" | "word" | "sentence" },
+  ) => GraphemeSegmenter;
+};
+
 function hashSeed(seed: string): number {
   let hash = 5381;
 
@@ -22,18 +37,33 @@ function hashSeed(seed: string): number {
   return Math.abs(hash);
 }
 
+function getGraphemeSegmenter(): GraphemeSegmenter | null {
+  if (typeof Intl === "undefined") {
+    return null;
+  }
+
+  const intlWithSegmenter = Intl as IntlWithOptionalSegmenter;
+
+  if (typeof intlWithSegmenter.Segmenter !== "function") {
+    return null;
+  }
+
+  return new intlWithSegmenter.Segmenter(undefined, {
+    granularity: "grapheme",
+  });
+}
+
 function getFirstDisplayedGrapheme(value: string): string {
-  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
-    const segmenter = new Intl.Segmenter(undefined, {
-      granularity: "grapheme",
-    });
+  const segmenter = getGraphemeSegmenter();
+
+  if (segmenter) {
     const firstSegment = segmenter.segment(value)[Symbol.iterator]().next()
       .value?.segment;
 
     return firstSegment ?? "";
   }
 
-  return Array.from(value)[0] ?? "";
+  return Array.from(value.normalize("NFC"))[0] ?? "";
 }
 
 function getInitialFromPart(part: string): string {

--- a/apps/client/src/routes/_authenticated/more/members.tsx
+++ b/apps/client/src/routes/_authenticated/more/members.tsx
@@ -13,13 +13,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   useWorkspaceMembers,
   useCurrentWorkspaceRole,
@@ -199,16 +199,14 @@ function MembersPage() {
                   className="flex items-center justify-between p-4 rounded-lg hover:bg-accent/50 transition-colors border"
                 >
                   <div className="flex items-center gap-3 flex-1 min-w-0">
-                    <Avatar className="w-10 h-10">
-                      {member.avatarUrl && (
-                        <AvatarImage src={member.avatarUrl} />
-                      )}
-                      <AvatarFallback className="bg-primary/10 text-primary">
-                        {(member.displayName || member.username)
-                          .charAt(0)
-                          .toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
+                    <UserAvatar
+                      userId={member.userId}
+                      name={member.displayName || member.username}
+                      username={member.username}
+                      avatarUrl={member.avatarUrl}
+                      isBot={member.userType === "bot"}
+                      className="w-10 h-10"
+                    />
                     <div className="flex-1 min-w-0">
                       <div className="font-medium truncate">
                         {member.displayName || member.username}

--- a/docs/superpowers/specs/2026-04-01-user-avatar-seeded-colors-design.md
+++ b/docs/superpowers/specs/2026-04-01-user-avatar-seeded-colors-design.md
@@ -1,0 +1,189 @@
+# User Avatar Seeded Colors Design
+
+## Overview
+
+Fix the current default-avatar issue where users without `avatarUrl` all render with nearly the same fallback color, making them hard to distinguish in dense message and member lists.
+
+The frontend will introduce a dedicated `UserAvatar` component for user identity rendering and a shared seeded avatar color utility reused by both user avatars and workspace avatars. Fallback colors remain restricted to a predefined safe palette already established by workspace avatars.
+
+## Goals
+
+- Make default user avatar colors deterministic from `userId`
+- Keep avatar colors stable across pages and sessions
+- Reuse the existing workspace avatar palette instead of inventing a new color system
+- Centralize user-avatar fallback logic so new screens do not regress to hardcoded single-color fallbacks
+
+## Non-Goals
+
+- No backend or database changes
+- No changes to uploaded avatar behavior
+- No changes to bot image fallback behavior
+- No visual redesign of workspace avatar layout or interaction
+- No attempt to guarantee unique colors per user inside a workspace
+
+## Current Problem
+
+Today, user avatar fallbacks are rendered in many call sites with hardcoded classes such as `bg-primary`, `bg-primary/10`, or `bg-accent`. This creates two problems:
+
+- users without uploaded avatars look too similar
+- fallback behavior is duplicated across multiple components, so fixes do not propagate automatically
+
+Workspace avatars already use a predefined gradient palette, but that logic is local to `MainSidebar.tsx` and indexed by workspace list position rather than a stable seed.
+
+## Chosen Approach
+
+Use a component-based approach:
+
+1. Extract the workspace gradient palette into a shared avatar-color utility
+2. Add a stable seed-to-palette mapping function based on a string hash
+3. Introduce a `UserAvatar` component that owns fallback rendering for user identities
+4. Migrate existing user-avatar call sites to `UserAvatar`
+5. Update workspace avatars to reuse the shared palette utility without changing their product behavior
+
+This is preferred over piecemeal call-site fixes because it removes the duplication that caused the inconsistency in the first place.
+
+## Alternatives Considered
+
+### 1. Patch Existing User Avatar Call Sites Only
+
+Replace hardcoded fallback classes in a few key screens with seeded classes.
+
+Pros:
+
+- smaller immediate diff
+- fastest path for visible improvement
+
+Cons:
+
+- leaves duplicate avatar behavior in place
+- new screens can still reintroduce the bug
+- does not create a single source of truth for user fallback rendering
+
+### 2. Chosen: Shared Utility Plus `UserAvatar`
+
+Pros:
+
+- stable and reusable
+- aligns user and workspace avatars with the same palette source
+- reduces future UI drift
+
+Cons:
+
+- touches more files this round
+- requires minor migration work at existing call sites
+
+## Design
+
+### Shared Avatar Color Utility
+
+Add a small utility under `apps/client/src/lib/` to own seeded avatar colors and initials.
+
+Responsibilities:
+
+- export the shared predefined gradient palette currently used by workspace avatars
+- expose `getSeededAvatarGradient(seed: string): string`
+- expose `getInitials(name: string): string`
+
+Hashing requirements:
+
+- deterministic for the same input
+- simple and local, with no crypto dependency
+- output mapped by modulo into the predefined palette
+
+Seed rules:
+
+- user avatar fallback uses `userId`
+- workspace avatar fallback uses `workspaceId` when available
+- if an ID is temporarily unavailable, fall back to a stable textual seed such as display name or username rather than random behavior
+
+### `UserAvatar` Component
+
+Add a reusable component under `apps/client/src/components/ui/` or another existing avatar-oriented location in the client.
+
+Inputs should cover current user-avatar usage:
+
+- `userId?: string`
+- `name?: string`
+- `username?: string`
+- `avatarUrl?: string | null`
+- `isBot?: boolean`
+- `className?: string`
+- `fallbackClassName?: string`
+
+Behavior:
+
+- if `avatarUrl` exists, render `AvatarImage`
+- else if `isBot` is true, render `/bot.webp`
+- else render initials in a gradient fallback chosen from the seeded palette
+- if `name` is unavailable, use `username`
+- if both are unavailable, render `?`
+
+The component should build on the existing Radix `Avatar`, `AvatarImage`, and `AvatarFallback` primitives rather than replace them.
+
+### Workspace Avatar Reuse
+
+`MainSidebar.tsx` currently owns:
+
+- the workspace gradient palette constant
+- initials logic
+- workspace gradient selection logic
+
+This logic should move to the shared avatar-color utility. The sidebar should keep its existing layout and stacked rendering, but compute gradients via the shared utility so user and workspace avatars share one palette source.
+
+This is a refactor for reuse, not a UI redesign.
+
+### Migration Scope
+
+Migrate the main user-facing user-avatar call sites that currently duplicate fallback logic, prioritizing:
+
+- message list items
+- streaming or agent-adjacent user message items where applicable
+- sidebar current-user avatar
+- reusable user list items
+- member pickers and member lists
+- user profile cards and other direct user identity surfaces encountered in the current client
+
+Out-of-scope avatar surfaces can remain temporarily on raw `AvatarFallback` only if they are not user identities or if they intentionally use a different visual treatment.
+
+## Testing
+
+Add unit tests for the shared avatar-color utility:
+
+- same seed returns the same gradient class
+- different seeds map into the predefined palette
+- empty or missing display names still produce safe initials output
+
+Add or update component tests only where a current test already covers avatar fallback behavior. This change does not require broad snapshot coverage if the utility behavior is directly tested and the main migrated components render correctly.
+
+## Rollout and Risk
+
+Primary risk:
+
+- some user-avatar call sites may still bypass `UserAvatar`, leaving inconsistent fallback styling
+
+Mitigation:
+
+- migrate the highest-traffic user avatar surfaces in this change
+- keep the new component easy to adopt so later cleanup is mechanical
+
+Secondary risk:
+
+- gradient text contrast may become inconsistent on some surfaces that previously used solid semantic colors
+
+Mitigation:
+
+- reuse the existing workspace palette, which is already accepted in the product
+- keep fallback text white and preserve existing size/layout classes
+
+## Implementation Notes
+
+- No API contract changes are needed
+- No OpenClaw, IM, or websocket compatibility concerns apply because this is a client-only rendering change
+- The work should be implemented with test-first changes around the new utility
+
+## Success Criteria
+
+- users without uploaded avatars no longer all appear with the same fallback color
+- the same user renders with the same fallback color everywhere in the client
+- workspace avatars still look and behave the same as before
+- avatar fallback logic for users is centralized in one component instead of duplicated across many files


### PR DESCRIPTION
## Summary
- add a shared seeded avatar palette utility and `UserAvatar` component for stable user fallback colors
- migrate user-facing fallback avatar surfaces to the seeded component and reuse the same palette for workspace avatars
- add avatar regression coverage, including a follow-up accessibility fix for `ChannelDetailsModal` dialog descriptions

## Why
Default user avatars were all rendered with the same fallback color, which made them hard to distinguish. This change makes fallback colors stable per user id while keeping colors inside the existing safe predefined palette.

## Test Plan
- `pnpm --dir apps/client test -- src/components/channel/__tests__/seeded-avatar-surfaces.test.tsx src/components/ui/__tests__/UserAvatar.test.tsx src/lib/__tests__/avatar-colors.test.ts src/components/channel/__tests__/MessageItem.avatar.test.tsx src/components/sidebar/__tests__/UserListItem.avatar.test.tsx`
- `pnpm --dir apps/client build`
