### PR TITLE
feat(client): add A2UI choice surface rendering in chat

### DIFF
--- a/apps/client/src/components/channel/A2UIResponseItem.tsx
+++ b/apps/client/src/components/channel/A2UIResponseItem.tsx
@@ -15,7 +15,9 @@ export function A2UIResponseItem({ message, metadata }: A2UIResponseItemProps) {
   if (!summary && metadata.selections) {
     summary = Object.entries(metadata.selections)
       .map(([title, sel]) => {
-        const vals = (sel as { selected: string[] }).selected ?? [];
+        const raw = sel as { selected: string[]; otherText?: string | null };
+        const vals = (raw.selected ?? []).filter((v) => v !== "__other__");
+        if (raw.otherText) vals.push(`Other — "${raw.otherText}"`);
         return `${title}: ${vals.join(", ")}`;
       })
       .join("; ");

--- a/apps/client/src/components/channel/A2UIResponseItem.tsx
+++ b/apps/client/src/components/channel/A2UIResponseItem.tsx
@@ -1,0 +1,30 @@
+import type { AgentEventMetadata, Message } from "@/types/im";
+
+export interface A2UIResponseItemProps {
+  message: Message;
+  metadata: AgentEventMetadata;
+}
+
+/**
+ * Compact single-line display for an A2UI response message.
+ * Styled like TrackingEventItem — left border, compact, muted colors.
+ */
+export function A2UIResponseItem({
+  message,
+  metadata: _metadata,
+}: A2UIResponseItemProps) {
+  return (
+    <div className="flex items-center min-h-6">
+      {/* Status dot */}
+      <div className="w-2 h-2 rounded-full shrink-0 mr-[26px] bg-emerald-500" />
+      {/* Label */}
+      <span className="text-xs font-semibold shrink-0 w-[72px] text-emerald-500">
+        Selected
+      </span>
+      {/* Content summary */}
+      <span className="text-xs truncate flex-1 min-w-0 ml-2 text-muted-foreground">
+        {message.content}
+      </span>
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/A2UIResponseItem.tsx
+++ b/apps/client/src/components/channel/A2UIResponseItem.tsx
@@ -9,21 +9,29 @@ export interface A2UIResponseItemProps {
  * Compact single-line display for an A2UI response message.
  * Styled like TrackingEventItem — left border, compact, muted colors.
  */
-export function A2UIResponseItem({
-  message,
-  metadata: _metadata,
-}: A2UIResponseItemProps) {
+export function A2UIResponseItem({ message, metadata }: A2UIResponseItemProps) {
+  // Use message content if available, fall back to metadata selections
+  let summary = message.content;
+  if (!summary && metadata.selections) {
+    summary = Object.entries(metadata.selections)
+      .map(([title, sel]) => {
+        const vals = (sel as { selected: string[] }).selected ?? [];
+        return `${title}: ${vals.join(", ")}`;
+      })
+      .join("; ");
+  }
+
   return (
     <div className="flex items-center min-h-6">
-      {/* Status dot */}
-      <div className="w-2 h-2 rounded-full shrink-0 mr-[26px] bg-emerald-500" />
+      {/* Checkmark */}
+      <span className="shrink-0 mr-2 text-emerald-500 text-xs">✓</span>
       {/* Label */}
-      <span className="text-xs font-semibold shrink-0 w-[72px] text-emerald-500">
-        Selected
+      <span className="text-xs font-semibold shrink-0 text-emerald-500">
+        Selected:
       </span>
       {/* Content summary */}
-      <span className="text-xs truncate flex-1 min-w-0 ml-2 text-muted-foreground">
-        {message.content}
+      <span className="text-xs truncate flex-1 min-w-0 ml-1 text-muted-foreground">
+        {summary || "—"}
       </span>
     </div>
   );

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSendMessage } from "@/hooks/useMessages";
+import { useCurrentUser } from "@/hooks/useAuth";
 import type { AgentEventMetadata, Message } from "@/types/im";
 import {
   parseChoicesPayload,
@@ -61,6 +62,7 @@ function TabBar({
     <div className="flex gap-1 mb-2">
       {tabs.map((tab, i) => (
         <button
+          type="button"
           key={tab.title}
           onClick={() => onSelect(i)}
           className={cn(
@@ -111,7 +113,6 @@ function ReadOnlyChoicesForm({
               type={tab.type === "single-select" ? "radio" : "checkbox"}
               checked={selected.includes(opt.value)}
               disabled
-              readOnly
               className="mt-0.5"
             />
             <div>
@@ -131,7 +132,6 @@ function ReadOnlyChoicesForm({
                 type={tab.type === "single-select" ? "radio" : "checkbox"}
                 checked={selected.includes("__other__")}
                 disabled
-                readOnly
                 className="mt-0.5"
               />
               <span className="text-sm font-semibold">Other</span>
@@ -141,7 +141,6 @@ function ReadOnlyChoicesForm({
                 type="text"
                 value={otherText}
                 disabled
-                readOnly
                 className="mt-1 ml-5 w-full bg-card border border-border rounded px-2 py-1 text-xs opacity-60"
               />
             )}
@@ -210,7 +209,9 @@ function CollapsedHeader({
   return (
     <div className="bg-card border border-border rounded-lg overflow-hidden">
       <button
+        type="button"
         onClick={onToggle}
+        aria-expanded={expanded}
         className="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-accent/50 transition-colors group cursor-pointer"
       >
         <span className={cn("text-sm shrink-0", colorClass)}>{icon}</span>
@@ -260,6 +261,7 @@ function ActiveSurface({
 }) {
   const sendMessage = useSendMessage(channelId);
   const queryClient = useQueryClient();
+  const currentUser = useCurrentUser();
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [selectedValues, setSelectedValues] = useState<
     Record<string, string[]>
@@ -304,8 +306,21 @@ function ActiveSurface({
     setOtherTexts((prev) => ({ ...prev, [tabKey]: text }));
   };
 
+  const [validationError, setValidationError] = useState<string | null>(null);
+
   const handleSubmit = () => {
     if (sendMessage.isPending) return;
+
+    // Validate: single-select tabs must have a selection
+    for (const t of parsed.tabs) {
+      const sel = selectedValues[t.title] ?? [];
+      if (t.type === "single-select" && sel.length === 0) {
+        setValidationError(`Please select an option for "${t.title}"`);
+        return;
+      }
+    }
+    setValidationError(null);
+
     const selections: Record<
       string,
       { selected: string[]; otherText: string | null }
@@ -372,6 +387,10 @@ function ActiveSurface({
                               ...(m.metadata as Record<string, unknown>),
                               status: "resolved",
                               selections,
+                              responderId: currentUser.data?.id,
+                              responderName:
+                                currentUser.data?.displayName ??
+                                currentUser.data?.username,
                             },
                           }
                         : m,
@@ -394,7 +413,7 @@ function ActiveSurface({
       ref={containerRef}
       tabIndex={-1}
       onKeyDown={handleKeyDown}
-      className="bg-card border border-border rounded-lg overflow-hidden px-3 py-3 outline-none"
+      className="bg-card border border-border rounded-lg overflow-hidden px-3 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
     >
       {parsed.tabs.length > 1 && (
         <TabBar
@@ -404,64 +423,75 @@ function ActiveSurface({
         />
       )}
 
-      <p className="text-sm font-medium mb-2">{tab.prompt}</p>
+      <fieldset className="border-none p-0 m-0">
+        <legend className="text-sm font-medium mb-2">{tab.prompt}</legend>
 
-      <div className="space-y-1.5">
-        {tab.options.map((opt) => (
-          <label
-            key={opt.value}
-            className="flex items-start gap-2 cursor-pointer"
-          >
-            <input
-              type={tab.type === "single-select" ? "radio" : "checkbox"}
-              name={`a2ui-${surfaceId}-${tabKey}`}
-              checked={selected.includes(opt.value)}
-              onChange={() => handleOptionChange(opt.value)}
-              className="mt-0.5"
-            />
-            <div>
-              <span className="text-sm font-semibold">{opt.label}</span>
-              {opt.description && (
-                <p className="text-xs text-muted-foreground">
-                  {opt.description}
-                </p>
-              )}
-            </div>
-          </label>
-        ))}
-
-        {tab.hasOther && (
-          <div>
-            <label className="flex items-start gap-2 cursor-pointer">
+        <div
+          className="space-y-1.5"
+          role={tab.type === "single-select" ? "radiogroup" : undefined}
+        >
+          {tab.options.map((opt) => (
+            <label
+              key={opt.value}
+              className="flex items-start gap-2 cursor-pointer"
+            >
               <input
                 type={tab.type === "single-select" ? "radio" : "checkbox"}
                 name={`a2ui-${surfaceId}-${tabKey}`}
-                checked={selected.includes("__other__")}
-                onChange={() => handleOptionChange("__other__")}
+                checked={selected.includes(opt.value)}
+                onChange={() => handleOptionChange(opt.value)}
                 className="mt-0.5"
               />
-              <span className="text-sm font-semibold">Other</span>
+              <div>
+                <span className="text-sm font-semibold">{opt.label}</span>
+                {opt.description && (
+                  <p className="text-xs text-muted-foreground">
+                    {opt.description}
+                  </p>
+                )}
+              </div>
             </label>
-            {selected.includes("__other__") && (
-              <input
-                type="text"
-                value={otherText}
-                onChange={(e) => handleOtherTextChange(e.target.value)}
-                placeholder="Enter your answer..."
-                className="mt-1 ml-5 w-full bg-card border border-border rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            )}
-          </div>
-        )}
-      </div>
+          ))}
+
+          {tab.hasOther && (
+            <div>
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type={tab.type === "single-select" ? "radio" : "checkbox"}
+                  name={`a2ui-${surfaceId}-${tabKey}`}
+                  checked={selected.includes("__other__")}
+                  onChange={() => handleOptionChange("__other__")}
+                  className="mt-0.5"
+                />
+                <span className="text-sm font-semibold">Other</span>
+              </label>
+              {selected.includes("__other__") && (
+                <input
+                  type="text"
+                  value={otherText}
+                  onChange={(e) => handleOtherTextChange(e.target.value)}
+                  placeholder="Enter your answer..."
+                  className="mt-1 ml-5 w-full bg-card border border-border rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </fieldset>
 
       <button
+        type="button"
         onClick={handleSubmit}
         disabled={sendMessage.isPending}
         className="w-full mt-3 bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {sendMessage.isPending ? "Submitting..." : "Submit answers"}
       </button>
+      {validationError && (
+        <p className="text-center text-xs text-red-500 mt-1">
+          {validationError}
+        </p>
+      )}
       {onCancel && (
         <p className="text-center text-xs text-muted-foreground mt-1">
           Press Esc to cancel

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -23,6 +23,7 @@ export interface A2UISurfaceBlockProps {
     >,
   ) => void;
   onCancel?: (surfaceId: string) => void;
+  readOnly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +109,7 @@ function ReadOnlyChoicesForm({
       <p className="text-sm font-medium mb-2">{tab.prompt}</p>
       <div className="space-y-1.5">
         {tab.options.map((opt) => (
-          <div key={opt.value} className="flex items-start gap-2 opacity-60">
+          <label key={opt.value} className="flex items-start gap-2 opacity-60">
             <input
               type={tab.type === "single-select" ? "radio" : "checkbox"}
               checked={selected.includes(opt.value)}
@@ -123,11 +124,11 @@ function ReadOnlyChoicesForm({
                 </p>
               )}
             </div>
-          </div>
+          </label>
         ))}
         {tab.hasOther && (
           <div className="opacity-60">
-            <div className="flex items-start gap-2">
+            <label className="flex items-start gap-2">
               <input
                 type={tab.type === "single-select" ? "radio" : "checkbox"}
                 checked={selected.includes("__other__")}
@@ -135,7 +136,7 @@ function ReadOnlyChoicesForm({
                 className="mt-0.5"
               />
               <span className="text-sm font-semibold">Other</span>
-            </div>
+            </label>
             {selected.includes("__other__") && (
               <input
                 type="text"
@@ -289,6 +290,7 @@ function ActiveSurface({
   const otherText = otherTexts[tabKey] ?? "";
 
   const handleOptionChange = (value: string) => {
+    if (validationError) setValidationError(null);
     setSelectedValues((prev) => {
       const current = prev[tabKey] ?? [];
       if (tab.type === "single-select") {
@@ -511,14 +513,15 @@ export function A2UISurfaceBlock({
   channelId,
   onSubmit,
   onCancel,
+  readOnly = false,
 }: A2UISurfaceBlockProps) {
   const [expanded, setExpanded] = useState(false);
 
   const payload = metadata.payload;
   const parsed = payload ? parseChoicesPayload(payload) : null;
 
-  // Active / running → interactive form
-  if (metadata.status === "running") {
+  // Active / running → interactive form (unless readOnly)
+  if (metadata.status === "running" && !readOnly) {
     if (!parsed) {
       return (
         <div className="bg-card border border-border rounded-lg px-3 py-2 text-sm">

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useSendMessage } from "@/hooks/useMessages";
 import type { AgentEventMetadata, Message } from "@/types/im";
 import {
   parseChoicesPayload,
@@ -242,16 +244,22 @@ function CollapsedHeader({
 // ---------------------------------------------------------------------------
 
 function ActiveSurface({
+  message,
   metadata,
   parsed,
+  channelId,
   onSubmit,
   onCancel,
 }: {
+  message: Message;
   metadata: AgentEventMetadata;
   parsed: ParsedChoicesSurface;
+  channelId: string;
   onSubmit?: A2UISurfaceBlockProps["onSubmit"];
   onCancel?: A2UISurfaceBlockProps["onCancel"];
 }) {
+  const sendMessage = useSendMessage(channelId);
+  const queryClient = useQueryClient();
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [selectedValues, setSelectedValues] = useState<
     Record<string, string[]>
@@ -316,10 +324,42 @@ function ActiveSurface({
     }
     if (onSubmit) {
       onSubmit(surfaceId, selections);
-    } else {
-      // Fallback: log to console when onSubmit is not wired
-      console.log("[A2UISurfaceBlock] submit", surfaceId, selections);
     }
+
+    // Send visible message to channel with a2ui_response metadata
+    const summary = Object.entries(selections)
+      .map(([title, sel]) => {
+        const parts = sel.selected.filter((v) => v !== "__other__");
+        if (sel.otherText) parts.push(`Other — "${sel.otherText}"`);
+        return `${title}: ${parts.join(", ")}`;
+      })
+      .join("; ");
+
+    sendMessage.mutate({
+      content: `Selected: ${summary}`,
+      metadata: {
+        agentEventType: "a2ui_response",
+        status: "completed",
+        surfaceId,
+        selections,
+      },
+    });
+
+    // Optimistic: mark this surface as resolved in local cache
+    queryClient.setQueryData<Message[]>(["messages", channelId], (old) =>
+      old?.map((m) =>
+        m.id === message.id
+          ? {
+              ...m,
+              metadata: {
+                ...(m.metadata as Record<string, unknown>),
+                status: "resolved",
+                selections,
+              },
+            }
+          : m,
+      ),
+    );
   };
 
   return (
@@ -406,9 +446,9 @@ function ActiveSurface({
 // ---------------------------------------------------------------------------
 
 export function A2UISurfaceBlock({
-  message: _message,
+  message,
   metadata,
-  channelId: _channelId,
+  channelId,
   onSubmit,
   onCancel,
 }: A2UISurfaceBlockProps) {
@@ -430,8 +470,10 @@ export function A2UISurfaceBlock({
     }
     return (
       <ActiveSurface
+        message={message}
         metadata={metadata}
         parsed={parsed}
+        channelId={channelId}
         onSubmit={onSubmit}
         onCancel={onCancel}
       />

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -305,6 +305,7 @@ function ActiveSurface({
   };
 
   const handleSubmit = () => {
+    if (sendMessage.isPending) return;
     const selections: Record<
       string,
       { selected: string[]; otherText: string | null }
@@ -331,7 +332,7 @@ function ActiveSurface({
       .join("; ");
 
     sendMessage.mutate({
-      content: `Selected: ${summary}`,
+      content: summary,
       metadata: {
         agentEventType: "a2ui_response",
         status: "completed",
@@ -350,8 +351,11 @@ function ActiveSurface({
         return {
           ...old,
           pages: old.pages.map((page: unknown) => {
-            if (!Array.isArray(page)) return page;
-            return page.map((m: Message) =>
+            // Handle both Message[] and PaginatedMessagesResponse formats
+            const msgs: Message[] = Array.isArray(page)
+              ? page
+              : ((page as { messages: Message[] }).messages ?? []);
+            const updated = msgs.map((m: Message) =>
               m.id === message.id
                 ? {
                     ...m,
@@ -363,6 +367,9 @@ function ActiveSurface({
                   }
                 : m,
             );
+            return Array.isArray(page)
+              ? updated
+              : { ...(page as object), messages: updated };
           }),
         };
       },

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -331,47 +331,51 @@ function ActiveSurface({
       })
       .join("; ");
 
-    sendMessage.mutate({
-      content: summary,
-      metadata: {
-        agentEventType: "a2ui_response",
-        status: "completed",
-        surfaceId,
-        selections,
+    sendMessage.mutate(
+      {
+        content: summary,
+        metadata: {
+          agentEventType: "a2ui_response",
+          status: "completed",
+          surfaceId,
+          selections,
+        },
       },
-    });
-
-    // Optimistic: mark this surface as resolved in local cache.
-    // The messages query is an InfiniteQuery with pages, not a flat array.
-    queryClient.setQueriesData(
-      { queryKey: ["messages", channelId] },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (old: any) => {
-        if (!old?.pages) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page: unknown) => {
-            // Handle both Message[] and PaginatedMessagesResponse formats
-            const msgs: Message[] = Array.isArray(page)
-              ? page
-              : ((page as { messages: Message[] }).messages ?? []);
-            const updated = msgs.map((m: Message) =>
-              m.id === message.id
-                ? {
-                    ...m,
-                    metadata: {
-                      ...(m.metadata as Record<string, unknown>),
-                      status: "resolved",
-                      selections,
-                    },
-                  }
-                : m,
-            );
-            return Array.isArray(page)
-              ? updated
-              : { ...(page as object), messages: updated };
-          }),
-        };
+      {
+        onSuccess: () => {
+          // Mark surface as resolved only after message is sent successfully.
+          // If send fails, the surface stays interactive so the user can retry.
+          queryClient.setQueriesData(
+            { queryKey: ["messages", channelId] },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (old: any) => {
+              if (!old?.pages) return old;
+              return {
+                ...old,
+                pages: old.pages.map((page: unknown) => {
+                  const msgs: Message[] = Array.isArray(page)
+                    ? page
+                    : ((page as { messages: Message[] }).messages ?? []);
+                  const updated = msgs.map((m: Message) =>
+                    m.id === message.id
+                      ? {
+                          ...m,
+                          metadata: {
+                            ...(m.metadata as Record<string, unknown>),
+                            status: "resolved",
+                            selections,
+                          },
+                        }
+                      : m,
+                  );
+                  return Array.isArray(page)
+                    ? updated
+                    : { ...(page as object), messages: updated };
+                }),
+              };
+            },
+          );
+        },
       },
     );
   };
@@ -449,9 +453,11 @@ function ActiveSurface({
       >
         {sendMessage.isPending ? "Submitting..." : "Submit answers"}
       </button>
-      <p className="text-center text-xs text-muted-foreground mt-1">
-        Press Esc to cancel
-      </p>
+      {onCancel && (
+        <p className="text-center text-xs text-muted-foreground mt-1">
+          Press Esc to cancel
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -168,12 +168,9 @@ function CollapsedHeader({
   onToggle: () => void;
 }) {
   const status = metadata.status as string;
-  const surfaceStatus = metadata.surfaceMetadata?.status as string | undefined;
-  const effectiveStatus = surfaceStatus ?? status;
 
-  const isResolved =
-    effectiveStatus === "resolved" || effectiveStatus === "completed";
-  const isTimeout = effectiveStatus === "timeout";
+  const isResolved = status === "resolved" || status === "completed";
+  const isTimeout = status === "timeout";
   // cancelled is whatever remains
 
   const icon = isResolved ? "\u2713" : isTimeout ? "\u23F1" : "\u2717";
@@ -281,11 +278,6 @@ function ActiveSurface({
     }
   };
 
-  // Auto-focus so Esc handler works immediately
-  useEffect(() => {
-    containerRef.current?.focus();
-  }, []);
-
   const tab = parsed.tabs[activeTabIndex];
   const tabKey = tab.title;
   const selected = selectedValues[tabKey] ?? [];
@@ -345,20 +337,32 @@ function ActiveSurface({
       },
     });
 
-    // Optimistic: mark this surface as resolved in local cache
-    queryClient.setQueryData<Message[]>(["messages", channelId], (old) =>
-      old?.map((m) =>
-        m.id === message.id
-          ? {
-              ...m,
-              metadata: {
-                ...(m.metadata as Record<string, unknown>),
-                status: "resolved",
-                selections,
-              },
-            }
-          : m,
-      ),
+    // Optimistic: mark this surface as resolved in local cache.
+    // The messages query is an InfiniteQuery with pages, not a flat array.
+    queryClient.setQueriesData(
+      { queryKey: ["messages", channelId] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (old: any) => {
+        if (!old?.pages) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page: unknown) => {
+            if (!Array.isArray(page)) return page;
+            return page.map((m: Message) =>
+              m.id === message.id
+                ? {
+                    ...m,
+                    metadata: {
+                      ...(m.metadata as Record<string, unknown>),
+                      status: "resolved",
+                      selections,
+                    },
+                  }
+                : m,
+            );
+          }),
+        };
+      },
     );
   };
 
@@ -430,9 +434,10 @@ function ActiveSurface({
 
       <button
         onClick={handleSubmit}
-        className="w-full mt-3 bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity"
+        disabled={sendMessage.isPending}
+        className="w-full mt-3 bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        Submit answers
+        {sendMessage.isPending ? "Submitting..." : "Submit answers"}
       </button>
       <p className="text-center text-xs text-muted-foreground mt-1">
         Press Esc to cancel

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -318,16 +318,17 @@ function ActiveSurface({
         otherText: hasOtherSelected ? (otherTexts[t.title] ?? "") : null,
       };
     }
-    if (onSubmit) {
-      onSubmit(surfaceId, selections);
-    }
-
-    // Send visible message to channel with a2ui_response metadata
+    // Build summary with human-readable labels (not raw values)
     const summary = Object.entries(selections)
       .map(([title, sel]) => {
-        const parts = sel.selected.filter((v) => v !== "__other__");
-        if (sel.otherText) parts.push(`Other — "${sel.otherText}"`);
-        return `${title}: ${parts.join(", ")}`;
+        const parsedTab = parsed.tabs.find((t) => t.title === title);
+        const labels = sel.selected
+          .filter((v) => v !== "__other__")
+          .map(
+            (v) => parsedTab?.options.find((o) => o.value === v)?.label ?? v,
+          );
+        if (sel.otherText) labels.push(`Other — "${sel.otherText}"`);
+        return `${title}: ${labels.join(", ")}`;
       })
       .join("; ");
 
@@ -343,38 +344,46 @@ function ActiveSurface({
       },
       {
         onSuccess: () => {
-          // Mark surface as resolved only after message is sent successfully.
-          // If send fails, the surface stays interactive so the user can retry.
-          queryClient.setQueriesData(
-            { queryKey: ["messages", channelId] },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (old: any) => {
-              if (!old?.pages) return old;
-              return {
-                ...old,
-                pages: old.pages.map((page: unknown) => {
-                  const msgs: Message[] = Array.isArray(page)
-                    ? page
-                    : ((page as { messages: Message[] }).messages ?? []);
-                  const updated = msgs.map((m: Message) =>
-                    m.id === message.id
-                      ? {
-                          ...m,
-                          metadata: {
-                            ...(m.metadata as Record<string, unknown>),
-                            status: "resolved",
-                            selections,
-                          },
-                        }
-                      : m,
-                  );
-                  return Array.isArray(page)
-                    ? updated
-                    : { ...(page as object), messages: updated };
-                }),
-              };
-            },
-          );
+          // Notify parent (if handler provided)
+          if (onSubmit) onSubmit(surfaceId, selections);
+
+          // Mark surface as resolved in ALL matching message caches
+          // (covers both ["messages", channelId] and ["messages", channelId, anchor])
+          const matchingQueries = queryClient
+            .getQueryCache()
+            .findAll({ queryKey: ["messages", channelId] });
+          for (const query of matchingQueries) {
+            queryClient.setQueryData(
+              query.queryKey,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (old: any) => {
+                if (!old?.pages) return old;
+                return {
+                  ...old,
+                  pages: old.pages.map((page: unknown) => {
+                    const msgs: Message[] = Array.isArray(page)
+                      ? page
+                      : ((page as { messages: Message[] }).messages ?? []);
+                    const updated = msgs.map((m: Message) =>
+                      m.id === message.id
+                        ? {
+                            ...m,
+                            metadata: {
+                              ...(m.metadata as Record<string, unknown>),
+                              status: "resolved",
+                              selections,
+                            },
+                          }
+                        : m,
+                    );
+                    return Array.isArray(page)
+                      ? updated
+                      : { ...(page as object), messages: updated };
+                  }),
+                };
+              },
+            );
+          }
         },
       },
     );

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -198,6 +198,9 @@ function CollapsedHeader({
     }
     const responder = metadata.responderName ?? "User";
     summary = `${responder} selected: ${parts.join("; ")}`;
+  } else if (isResolved) {
+    // Resolved but no parsed data (e.g., payload parse failed)
+    summary = "Choices submitted";
   } else if (isTimeout) {
     summary = "Selection timed out";
   } else {

--- a/apps/client/src/components/channel/A2UISurfaceBlock.tsx
+++ b/apps/client/src/components/channel/A2UISurfaceBlock.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AgentEventMetadata, Message } from "@/types/im";
+import {
+  parseChoicesPayload,
+  type ParsedChoicesSurface,
+  type ParsedTab,
+} from "@/lib/a2ui-parser";
+
+export interface A2UISurfaceBlockProps {
+  message: Message;
+  metadata: AgentEventMetadata;
+  channelId: string;
+  onSubmit?: (
+    surfaceId: string,
+    selections: Record<
+      string,
+      { selected: string[]; otherText: string | null }
+    >,
+  ) => void;
+  onCancel?: (surfaceId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildInitialSelections(tabs: ParsedTab[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const tab of tabs) {
+    result[tab.title] = [...tab.defaultSelected];
+  }
+  return result;
+}
+
+function buildInitialOtherTexts(tabs: ParsedTab[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const tab of tabs) {
+    result[tab.title] = "";
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tab Bar (shared by active & read-only views)
+// ---------------------------------------------------------------------------
+
+function TabBar({
+  tabs,
+  activeIndex,
+  onSelect,
+}: {
+  tabs: ParsedTab[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  return (
+    <div className="flex gap-1 mb-2">
+      {tabs.map((tab, i) => (
+        <button
+          key={tab.title}
+          onClick={() => onSelect(i)}
+          className={cn(
+            "px-3 py-1 rounded-md text-xs font-medium transition-colors",
+            i === activeIndex
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-foreground hover:bg-accent",
+          )}
+        >
+          {tab.title}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Read-Only Choices Form (for resolved / timeout / cancelled expanded view)
+// ---------------------------------------------------------------------------
+
+function ReadOnlyChoicesForm({
+  parsed,
+  selections,
+}: {
+  parsed: ParsedChoicesSurface;
+  selections?: Record<string, { selected: string[]; otherText: string | null }>;
+}) {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const tab = parsed.tabs[activeTabIndex];
+  const tabSel = selections?.[tab.title];
+  const selected = tabSel?.selected ?? [];
+  const otherText = tabSel?.otherText ?? "";
+
+  return (
+    <div className="pt-2">
+      {parsed.tabs.length > 1 && (
+        <TabBar
+          tabs={parsed.tabs}
+          activeIndex={activeTabIndex}
+          onSelect={setActiveTabIndex}
+        />
+      )}
+      <p className="text-sm font-medium mb-2">{tab.prompt}</p>
+      <div className="space-y-1.5">
+        {tab.options.map((opt) => (
+          <div key={opt.value} className="flex items-start gap-2 opacity-60">
+            <input
+              type={tab.type === "single-select" ? "radio" : "checkbox"}
+              checked={selected.includes(opt.value)}
+              disabled
+              readOnly
+              className="mt-0.5"
+            />
+            <div>
+              <span className="text-sm font-semibold">{opt.label}</span>
+              {opt.description && (
+                <p className="text-xs text-muted-foreground">
+                  {opt.description}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+        {tab.hasOther && (
+          <div className="opacity-60">
+            <div className="flex items-start gap-2">
+              <input
+                type={tab.type === "single-select" ? "radio" : "checkbox"}
+                checked={selected.includes("__other__")}
+                disabled
+                readOnly
+                className="mt-0.5"
+              />
+              <span className="text-sm font-semibold">Other</span>
+            </div>
+            {selected.includes("__other__") && (
+              <input
+                type="text"
+                value={otherText}
+                disabled
+                readOnly
+                className="mt-1 ml-5 w-full bg-card border border-border rounded px-2 py-1 text-xs opacity-60"
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Collapsed Header (resolved / timeout / cancelled)
+// ---------------------------------------------------------------------------
+
+function CollapsedHeader({
+  metadata,
+  parsed,
+  expanded,
+  onToggle,
+}: {
+  metadata: AgentEventMetadata;
+  parsed: ParsedChoicesSurface | null;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const status = metadata.status as string;
+  const surfaceStatus = metadata.surfaceMetadata?.status as string | undefined;
+  const effectiveStatus = surfaceStatus ?? status;
+
+  const isResolved =
+    effectiveStatus === "resolved" || effectiveStatus === "completed";
+  const isTimeout = effectiveStatus === "timeout";
+  // cancelled is whatever remains
+
+  const icon = isResolved ? "\u2713" : isTimeout ? "\u23F1" : "\u2717";
+  const colorClass = isResolved
+    ? "text-emerald-500"
+    : isTimeout
+      ? "text-amber-500"
+      : "text-red-500";
+
+  // Build summary text
+  let summary: string;
+  if (isResolved && metadata.selections && parsed) {
+    const parts: string[] = [];
+    for (const [tabTitle, sel] of Object.entries(metadata.selections)) {
+      const parsedTab = parsed.tabs.find((t) => t.title === tabTitle);
+      const labels = sel.selected
+        .filter((v) => v !== "__other__")
+        .map((v) => parsedTab?.options.find((o) => o.value === v)?.label ?? v);
+      if (sel.selected.includes("__other__")) {
+        labels.push(
+          sel.otherText ? `Other \u2014 "${sel.otherText}"` : "Other",
+        );
+      }
+      parts.push(labels.join(", "));
+    }
+    const responder = metadata.responderName ?? "User";
+    summary = `${responder} selected: ${parts.join("; ")}`;
+  } else if (isTimeout) {
+    summary = "Selection timed out";
+  } else {
+    summary = "Selection cancelled";
+  }
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-accent/50 transition-colors group cursor-pointer"
+      >
+        <span className={cn("text-sm shrink-0", colorClass)}>{icon}</span>
+        <span className="text-sm text-foreground truncate flex-1 min-w-0">
+          {summary}
+        </span>
+        <ChevronRight
+          size={14}
+          className={cn(
+            "shrink-0 text-muted-foreground transition-transform duration-200",
+            "group-hover:text-foreground",
+            expanded && "rotate-90",
+          )}
+        />
+      </button>
+
+      {expanded && parsed && (
+        <div className="px-3 pb-3 border-t border-border">
+          <ReadOnlyChoicesForm
+            parsed={parsed}
+            selections={metadata.selections}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Active Surface (running / interactive)
+// ---------------------------------------------------------------------------
+
+function ActiveSurface({
+  metadata,
+  parsed,
+  onSubmit,
+  onCancel,
+}: {
+  metadata: AgentEventMetadata;
+  parsed: ParsedChoicesSurface;
+  onSubmit?: A2UISurfaceBlockProps["onSubmit"];
+  onCancel?: A2UISurfaceBlockProps["onCancel"];
+}) {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const [selectedValues, setSelectedValues] = useState<
+    Record<string, string[]>
+  >(() => buildInitialSelections(parsed.tabs));
+  const [otherTexts, setOtherTexts] = useState<Record<string, string>>(() =>
+    buildInitialOtherTexts(parsed.tabs),
+  );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const surfaceId = metadata.surfaceId ?? parsed.surfaceId;
+
+  // Scope Esc to this surface via container focus
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      if (onCancel) {
+        onCancel(surfaceId);
+      }
+    }
+  };
+
+  // Auto-focus so Esc handler works immediately
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  const tab = parsed.tabs[activeTabIndex];
+  const tabKey = tab.title;
+  const selected = selectedValues[tabKey] ?? [];
+  const otherText = otherTexts[tabKey] ?? "";
+
+  const handleOptionChange = (value: string) => {
+    setSelectedValues((prev) => {
+      const current = prev[tabKey] ?? [];
+      if (tab.type === "single-select") {
+        return { ...prev, [tabKey]: [value] };
+      }
+      // multi-select: toggle
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      return { ...prev, [tabKey]: next };
+    });
+  };
+
+  const handleOtherTextChange = (text: string) => {
+    setOtherTexts((prev) => ({ ...prev, [tabKey]: text }));
+  };
+
+  const handleSubmit = () => {
+    const selections: Record<
+      string,
+      { selected: string[]; otherText: string | null }
+    > = {};
+    for (const t of parsed.tabs) {
+      const sel = selectedValues[t.title] ?? [];
+      const hasOtherSelected = sel.includes("__other__");
+      selections[t.title] = {
+        selected: sel,
+        otherText: hasOtherSelected ? (otherTexts[t.title] ?? "") : null,
+      };
+    }
+    if (onSubmit) {
+      onSubmit(surfaceId, selections);
+    } else {
+      // Fallback: log to console when onSubmit is not wired
+      console.log("[A2UISurfaceBlock] submit", surfaceId, selections);
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className="bg-card border border-border rounded-lg overflow-hidden px-3 py-3 outline-none"
+    >
+      {parsed.tabs.length > 1 && (
+        <TabBar
+          tabs={parsed.tabs}
+          activeIndex={activeTabIndex}
+          onSelect={setActiveTabIndex}
+        />
+      )}
+
+      <p className="text-sm font-medium mb-2">{tab.prompt}</p>
+
+      <div className="space-y-1.5">
+        {tab.options.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex items-start gap-2 cursor-pointer"
+          >
+            <input
+              type={tab.type === "single-select" ? "radio" : "checkbox"}
+              name={`a2ui-${surfaceId}-${tabKey}`}
+              checked={selected.includes(opt.value)}
+              onChange={() => handleOptionChange(opt.value)}
+              className="mt-0.5"
+            />
+            <div>
+              <span className="text-sm font-semibold">{opt.label}</span>
+              {opt.description && (
+                <p className="text-xs text-muted-foreground">
+                  {opt.description}
+                </p>
+              )}
+            </div>
+          </label>
+        ))}
+
+        {tab.hasOther && (
+          <div>
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type={tab.type === "single-select" ? "radio" : "checkbox"}
+                name={`a2ui-${surfaceId}-${tabKey}`}
+                checked={selected.includes("__other__")}
+                onChange={() => handleOptionChange("__other__")}
+                className="mt-0.5"
+              />
+              <span className="text-sm font-semibold">Other</span>
+            </label>
+            {selected.includes("__other__") && (
+              <input
+                type="text"
+                value={otherText}
+                onChange={(e) => handleOtherTextChange(e.target.value)}
+                placeholder="Enter your answer..."
+                className="mt-1 ml-5 w-full bg-card border border-border rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        className="w-full mt-3 bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity"
+      >
+        Submit answers
+      </button>
+      <p className="text-center text-xs text-muted-foreground mt-1">
+        Press Esc to cancel
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Export
+// ---------------------------------------------------------------------------
+
+export function A2UISurfaceBlock({
+  message: _message,
+  metadata,
+  channelId: _channelId,
+  onSubmit,
+  onCancel,
+}: A2UISurfaceBlockProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const payload = metadata.payload;
+  const parsed = payload ? parseChoicesPayload(payload) : null;
+
+  // Active / running → interactive form
+  if (metadata.status === "running") {
+    if (!parsed) {
+      return (
+        <div className="bg-card border border-border rounded-lg px-3 py-2 text-sm">
+          <span className="text-red-500">
+            Failed to parse A2UI surface payload
+          </span>
+        </div>
+      );
+    }
+    return (
+      <ActiveSurface
+        metadata={metadata}
+        parsed={parsed}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  // Completed / failed → collapsed header with optional expand
+  return (
+    <CollapsedHeader
+      metadata={metadata}
+      parsed={parsed}
+      expanded={expanded}
+      onToggle={() => setExpanded(!expanded)}
+    />
+  );
+}

--- a/apps/client/src/components/channel/MessageList.tsx
+++ b/apps/client/src/components/channel/MessageList.tsx
@@ -391,8 +391,8 @@ export function MessageList({
         }
       }
 
-      // A2UI surface block — interactive choices
-      if (agentMeta?.agentEventType === "a2ui_surface_update") {
+      // A2UI surface block — interactive choices (skip in readOnly mode)
+      if (agentMeta?.agentEventType === "a2ui_surface_update" && !readOnly) {
         return (
           <div id={`message-${message.id}`} className="px-4 py-1">
             <A2UISurfaceBlock

--- a/apps/client/src/components/channel/MessageList.tsx
+++ b/apps/client/src/components/channel/MessageList.tsx
@@ -391,13 +391,14 @@ export function MessageList({
         }
       }
 
-      // A2UI surface block — interactive choices (skip in readOnly mode)
-      if (agentMeta?.agentEventType === "a2ui_surface_update" && !readOnly) {
+      // A2UI surface block — render always, pass readOnly to suppress interactivity
+      if (agentMeta?.agentEventType === "a2ui_surface_update") {
         return (
           <div id={`message-${message.id}`} className="px-4 py-1">
             <A2UISurfaceBlock
               message={message}
               metadata={agentMeta}
+              readOnly={readOnly}
               channelId={channelId}
             />
           </div>

--- a/apps/client/src/components/channel/MessageList.tsx
+++ b/apps/client/src/components/channel/MessageList.tsx
@@ -407,7 +407,11 @@ export function MessageList({
       // A2UI response — compact "User selected X" display
       if (agentMeta?.agentEventType === "a2ui_response") {
         return (
-          <div id={`message-${message.id}`} className="px-4 py-0.5">
+          <div
+            id={`message-${message.id}`}
+            className="ml-4 border-l-2 border-emerald-500/15 bg-emerald-500/[0.03] rounded-r-md pr-4 py-0.5"
+            style={{ paddingLeft: "13px" }}
+          >
             <A2UIResponseItem message={message} metadata={agentMeta} />
           </div>
         );

--- a/apps/client/src/components/channel/MessageList.tsx
+++ b/apps/client/src/components/channel/MessageList.tsx
@@ -26,6 +26,8 @@ import { cn } from "@/lib/utils";
 import { MessageItem } from "./MessageItem";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { StreamingMessageItem } from "./StreamingMessageItem";
+import { A2UISurfaceBlock } from "./A2UISurfaceBlock";
+import { A2UIResponseItem } from "./A2UIResponseItem";
 import { BotThinkingIndicator } from "./BotThinkingIndicator";
 import { NewMessagesIndicator } from "./NewMessagesIndicator";
 import { UnreadDivider } from "./UnreadDivider";
@@ -387,6 +389,28 @@ export function MessageList({
             <div className="min-h-px overflow-hidden" aria-hidden="true" />
           );
         }
+      }
+
+      // A2UI surface block — interactive choices
+      if (agentMeta?.agentEventType === "a2ui_surface_update") {
+        return (
+          <div id={`message-${message.id}`} className="px-4 py-1">
+            <A2UISurfaceBlock
+              message={message}
+              metadata={agentMeta}
+              channelId={channelId}
+            />
+          </div>
+        );
+      }
+
+      // A2UI response — compact "User selected X" display
+      if (agentMeta?.agentEventType === "a2ui_response") {
+        return (
+          <div id={`message-${message.id}`} className="px-4 py-0.5">
+            <A2UIResponseItem message={message} metadata={agentMeta} />
+          </div>
+        );
       }
 
       const hasReplies =

--- a/apps/client/src/components/channel/TrackingEventItem.tsx
+++ b/apps/client/src/components/channel/TrackingEventItem.tsx
@@ -18,12 +18,18 @@ const STATUS_DOT_CLASSES: Record<AgentEventMetadata["status"], string> = {
   running: "bg-emerald-500 animate-pulse",
   completed: "bg-emerald-500",
   failed: "bg-red-500",
+  resolved: "bg-emerald-500",
+  timeout: "bg-amber-500",
+  cancelled: "bg-red-500",
 };
 
 const LABEL_CLASSES: Record<AgentEventMetadata["status"], string> = {
   running: "text-yellow-400",
   completed: "text-emerald-500",
   failed: "text-red-500",
+  resolved: "text-emerald-500",
+  timeout: "text-amber-500",
+  cancelled: "text-red-500",
 };
 
 const EVENT_LABELS: Record<AgentEventMetadata["agentEventType"], string> = {
@@ -35,6 +41,8 @@ const EVENT_LABELS: Record<AgentEventMetadata["agentEventType"], string> = {
   agent_end: "Completed",
   error: "Error",
   turn_separator: "Turn",
+  a2ui_surface_update: "Choices",
+  a2ui_response: "Selected",
 };
 
 function truncateLine(str: string, maxLen: number): string {

--- a/apps/client/src/lib/__tests__/a2ui-parser.test.ts
+++ b/apps/client/src/lib/__tests__/a2ui-parser.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Unit tests for the A2UI v0.9 payload parser.
+ *
+ * Each test builds a minimal but realistic three-message payload and asserts
+ * that `parseChoicesPayload` produces the expected `ParsedChoicesSurface`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseChoicesPayload } from "../a2ui-parser";
+import type { ParsedChoicesSurface } from "../a2ui-parser";
+
+// ---------------------------------------------------------------------------
+// Builder helpers
+// ---------------------------------------------------------------------------
+
+function makeCreateSurface(surfaceId = "choices-tc1") {
+  return {
+    version: "v0.9",
+    createSurface: { surfaceId, catalogId: "cat-1", sendDataModel: true },
+  };
+}
+
+interface OptionDef {
+  label: string;
+  value: string;
+}
+
+interface TabDef {
+  title?: string;
+  prompt: string;
+  variant: "mutuallyExclusive" | "multipleSelection";
+  options: OptionDef[];
+  /** Descriptions aligned with options array (after stripping __other__). */
+  descriptions?: (string | undefined)[];
+  selected?: string[];
+  otherText?: string;
+}
+
+/**
+ * Build `updateComponents` for a single-tab surface (no Tabs component).
+ */
+function makeSingleTabComponents(tab: TabDef) {
+  const components: unknown[] = [
+    { id: "root", type: "Column", children: ["tab-0", "submit"] },
+    { id: "tab-0", type: "Column", children: ["tab-0-prompt", "tab-0-picker"] },
+    { id: "tab-0-prompt", type: "Text", text: tab.prompt, variant: "h3" },
+    {
+      id: "tab-0-picker",
+      type: "ChoicePicker",
+      variant: tab.variant,
+      options: tab.options,
+    },
+    { id: "submit-label", type: "Text", text: "Submit" },
+    { id: "submit", type: "Button", label: "Submit" },
+  ];
+
+  // Inject description components where specified.
+  if (tab.descriptions) {
+    tab.descriptions.forEach((desc, j) => {
+      if (desc !== undefined) {
+        components.push({
+          id: `tab-0-opt-${j}-desc`,
+          type: "Text",
+          text: desc,
+        });
+      }
+    });
+  }
+
+  // Inject other TextField if last option is __other__.
+  const lastOpt = tab.options[tab.options.length - 1];
+  if (lastOpt?.value === "__other__") {
+    components.push({ id: "tab-0-other", type: "TextField" });
+  }
+
+  return { version: "v0.9", updateComponents: { components } };
+}
+
+/**
+ * Build `updateComponents` for a multi-tab surface (includes Tabs component).
+ */
+function makeMultiTabComponents(tabs: TabDef[]) {
+  const tabsComponent = {
+    id: "tabs",
+    type: "Tabs",
+    tabs: tabs.map((t, i) => ({
+      title: t.title ?? `Tab ${i + 1}`,
+      child: `tab-${i}`,
+    })),
+  };
+
+  const root = {
+    id: "root",
+    type: "Column",
+    children: ["tabs", "submit"],
+  };
+
+  const components: unknown[] = [root, tabsComponent];
+
+  tabs.forEach((tab, i) => {
+    components.push(
+      {
+        id: `tab-${i}`,
+        type: "Column",
+        children: [`tab-${i}-prompt`, `tab-${i}-picker`],
+      },
+      { id: `tab-${i}-prompt`, type: "Text", text: tab.prompt, variant: "h3" },
+      {
+        id: `tab-${i}-picker`,
+        type: "ChoicePicker",
+        variant: tab.variant,
+        options: tab.options,
+      },
+    );
+
+    if (tab.descriptions) {
+      tab.descriptions.forEach((desc, j) => {
+        if (desc !== undefined) {
+          components.push({
+            id: `tab-${i}-opt-${j}-desc`,
+            type: "Text",
+            text: desc,
+          });
+        }
+      });
+    }
+
+    const lastOpt = tab.options[tab.options.length - 1];
+    if (lastOpt?.value === "__other__") {
+      components.push({ id: `tab-${i}-other`, type: "TextField" });
+    }
+  });
+
+  components.push(
+    { id: "submit-label", type: "Text", text: "Submit" },
+    { id: "submit", type: "Button", label: "Submit" },
+  );
+
+  return { version: "v0.9", updateComponents: { components } };
+}
+
+function makeDataModel(
+  tabs: Array<{ selected: string[]; otherText?: string }>,
+) {
+  return {
+    version: "v0.9",
+    updateDataModel: {
+      surfaceId: "choices-tc1",
+      value: {
+        tabs: tabs.map((t) => ({
+          selected: t.selected,
+          otherText: t.otherText ?? "",
+        })),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseChoicesPayload", () => {
+  // 1. Single tab, single-select, with __other__
+  it("single tab single-select with Other strips __other__ and sets hasOther:true", () => {
+    const payload = [
+      makeCreateSurface("choices-s1"),
+      makeSingleTabComponents({
+        prompt: "Pick a color",
+        variant: "mutuallyExclusive",
+        options: [
+          { label: "Red", value: "red" },
+          { label: "Blue", value: "blue" },
+          { label: "Other", value: "__other__" },
+        ],
+      }),
+      makeDataModel([{ selected: ["red"] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    expect(result.surfaceId).toBe("choices-s1");
+    expect(result.tabs).toHaveLength(1);
+
+    const tab = result.tabs[0];
+    expect(tab.type).toBe("single-select");
+    expect(tab.hasOther).toBe(true);
+    expect(tab.options).toHaveLength(2);
+    expect(tab.options.map((o) => o.value)).toEqual(["red", "blue"]);
+    expect(tab.defaultSelected).toEqual(["red"]);
+  });
+
+  // 2. Single tab, multi-select, without Other
+  it("single tab multi-select without Other", () => {
+    const payload = [
+      makeCreateSurface("choices-m1"),
+      makeSingleTabComponents({
+        prompt: "Choose fruits",
+        variant: "multipleSelection",
+        options: [
+          { label: "Apple", value: "apple" },
+          { label: "Banana", value: "banana" },
+          { label: "Cherry", value: "cherry" },
+        ],
+      }),
+      makeDataModel([{ selected: ["apple", "cherry"] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    const tab = result.tabs[0];
+    expect(tab.type).toBe("multi-select");
+    expect(tab.hasOther).toBe(false);
+    expect(tab.options).toHaveLength(3);
+    expect(tab.defaultSelected).toEqual(["apple", "cherry"]);
+  });
+
+  // 3. Multi-tab mixed types (2 tabs via Tabs component)
+  it("multi-tab layout uses Tabs component and produces one ParsedTab per tab", () => {
+    const payload = [
+      makeCreateSurface("choices-multi"),
+      makeMultiTabComponents([
+        {
+          title: "Step 1",
+          prompt: "Choose size",
+          variant: "mutuallyExclusive",
+          options: [
+            { label: "Small", value: "s" },
+            { label: "Large", value: "l" },
+          ],
+        },
+        {
+          title: "Step 2",
+          prompt: "Choose extras",
+          variant: "multipleSelection",
+          options: [
+            { label: "Cheese", value: "cheese" },
+            { label: "Bacon", value: "bacon" },
+          ],
+        },
+      ]),
+      makeDataModel([{ selected: ["s"] }, { selected: ["cheese"] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    expect(result.tabs).toHaveLength(2);
+    expect(result.tabs[0].title).toBe("Step 1");
+    expect(result.tabs[0].type).toBe("single-select");
+    expect(result.tabs[1].title).toBe("Step 2");
+    expect(result.tabs[1].type).toBe("multi-select");
+  });
+
+  // 4. Option descriptions are extracted
+  it("extracts option descriptions from tab-{i}-opt-{j}-desc components", () => {
+    const payload = [
+      makeCreateSurface("choices-desc"),
+      makeSingleTabComponents({
+        prompt: "Choose a plan",
+        variant: "mutuallyExclusive",
+        options: [
+          { label: "Free", value: "free" },
+          { label: "Pro", value: "pro" },
+          { label: "Enterprise", value: "enterprise" },
+        ],
+        descriptions: [
+          "No cost, limited features",
+          undefined,
+          "Unlimited everything",
+        ],
+      }),
+      makeDataModel([{ selected: [] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    const opts = result.tabs[0].options;
+    expect(opts[0].description).toBe("No cost, limited features");
+    expect(opts[1].description).toBeUndefined();
+    expect(opts[2].description).toBe("Unlimited everything");
+  });
+
+  // 5. defaultSelected is extracted from data model
+  it("extracts defaultSelected from the updateDataModel message", () => {
+    const payload = [
+      makeCreateSurface("choices-dm"),
+      makeSingleTabComponents({
+        prompt: "Pick one",
+        variant: "mutuallyExclusive",
+        options: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+        ],
+      }),
+      makeDataModel([{ selected: ["b"] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result!.tabs[0].defaultSelected).toEqual(["b"]);
+  });
+
+  // 6. Single tab without Tabs component still works
+  it("single tab (no Tabs component) still parses correctly", () => {
+    const payload = [
+      makeCreateSurface("choices-notabs"),
+      makeSingleTabComponents({
+        prompt: "What is your goal?",
+        variant: "mutuallyExclusive",
+        options: [{ label: "Lose weight", value: "lose" }],
+      }),
+    ];
+
+    const result = parseChoicesPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.tabs).toHaveLength(1);
+    expect(result!.tabs[0].prompt).toBe("What is your goal?");
+  });
+
+  // 7. Zero regular options + hasOther → empty options array with hasOther true
+  it("handles picker with only __other__ option: empty options, hasOther true", () => {
+    const payload = [
+      makeCreateSurface("choices-onlyother"),
+      makeSingleTabComponents({
+        prompt: "Anything else?",
+        variant: "mutuallyExclusive",
+        options: [{ label: "Other", value: "__other__" }],
+      }),
+      makeDataModel([{ selected: [] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    const tab = result.tabs[0];
+    expect(tab.hasOther).toBe(true);
+    expect(tab.options).toHaveLength(0);
+  });
+
+  // 8. Option without description → description key absent (undefined)
+  it("option without matching desc component has undefined description", () => {
+    const payload = [
+      makeCreateSurface("choices-nodesc"),
+      makeSingleTabComponents({
+        prompt: "Naked options",
+        variant: "mutuallyExclusive",
+        options: [
+          { label: "Alpha", value: "alpha" },
+          { label: "Beta", value: "beta" },
+        ],
+        // no descriptions provided
+      }),
+      makeDataModel([{ selected: [] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result!.tabs[0].options[0].description).toBeUndefined();
+    expect(result!.tabs[0].options[1].description).toBeUndefined();
+  });
+
+  // 9. Empty defaultSelected (no data model message)
+  it("returns empty defaultSelected when updateDataModel is absent", () => {
+    const payload = [
+      makeCreateSurface("choices-nodata"),
+      makeSingleTabComponents({
+        prompt: "Choose",
+        variant: "mutuallyExclusive",
+        options: [{ label: "X", value: "x" }],
+      }),
+      // no data model message
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+    expect(result.tabs[0].defaultSelected).toEqual([]);
+  });
+
+  // 10. Unparseable / empty payload → null
+  it("returns null for empty payload", () => {
+    expect(parseChoicesPayload([])).toBeNull();
+  });
+
+  it("returns null for non-array input", () => {
+    expect(parseChoicesPayload(null as any)).toBeNull();
+  });
+
+  it("returns null when createSurface message is missing", () => {
+    const payload = [
+      makeSingleTabComponents({
+        prompt: "X",
+        variant: "mutuallyExclusive",
+        options: [{ label: "A", value: "a" }],
+      }),
+    ];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  it("returns null when updateComponents message is missing", () => {
+    const payload = [makeCreateSurface()];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  // 11. Missing picker component → null
+  it("returns null when a picker component is absent for a tab", () => {
+    // Build updateComponents without the picker
+    const badComponents = {
+      version: "v0.9",
+      updateComponents: {
+        components: [
+          { id: "root", type: "Column", children: ["tab-0", "submit"] },
+          { id: "tab-0", type: "Column", children: ["tab-0-prompt"] },
+          {
+            id: "tab-0-prompt",
+            type: "Text",
+            text: "No picker here",
+            variant: "h3",
+          },
+          // deliberately no tab-0-picker
+        ],
+      },
+    };
+
+    const payload = [makeCreateSurface(), badComponents];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  it("returns null when a prompt component is absent for a tab", () => {
+    const badComponents = {
+      version: "v0.9",
+      updateComponents: {
+        components: [
+          { id: "root", type: "Column", children: ["tab-0", "submit"] },
+          { id: "tab-0", type: "Column", children: ["tab-0-picker"] },
+          // deliberately no tab-0-prompt
+          {
+            id: "tab-0-picker",
+            type: "ChoicePicker",
+            variant: "mutuallyExclusive",
+            options: [{ label: "A", value: "a" }],
+          },
+        ],
+      },
+    };
+
+    const payload = [makeCreateSurface(), badComponents];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  // Multi-tab with empty tabs array → null
+  it("returns null when Tabs component has empty tabs array", () => {
+    const badComponents = {
+      version: "v0.9",
+      updateComponents: {
+        components: [
+          { id: "root", type: "Column", children: ["tabs", "submit"] },
+          { id: "tabs", type: "Tabs", tabs: [] },
+        ],
+      },
+    };
+
+    const payload = [makeCreateSurface(), badComponents];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  // Graceful handling of corrupt/non-object messages
+  it("returns null for payload containing non-object items", () => {
+    expect(
+      parseChoicesPayload([null, undefined, 42, "string"] as unknown[]),
+    ).toBeNull();
+  });
+
+  // updateComponents.components not an array → null
+  it("returns null when updateComponents.components is not an array", () => {
+    const badMsg = {
+      version: "v0.9",
+      updateComponents: { components: "not-an-array" },
+    };
+    const payload = [makeCreateSurface(), badMsg];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  // surfaceId missing from createSurface → null
+  it("returns null when surfaceId is absent from createSurface", () => {
+    const badCreate = {
+      version: "v0.9",
+      createSurface: { catalogId: "cat-1" },
+    };
+    const payload = [
+      badCreate,
+      makeSingleTabComponents({
+        prompt: "X",
+        variant: "mutuallyExclusive",
+        options: [{ label: "A", value: "a" }],
+      }),
+    ];
+    expect(parseChoicesPayload(payload)).toBeNull();
+  });
+
+  // Multi-tab: per-tab descriptions and defaults
+  it("multi-tab: each tab gets correct options, descriptions, and defaultSelected", () => {
+    const payload = [
+      makeCreateSurface("choices-multi-full"),
+      makeMultiTabComponents([
+        {
+          title: "Colors",
+          prompt: "Pick a color",
+          variant: "mutuallyExclusive",
+          options: [
+            { label: "Red", value: "red" },
+            { label: "Green", value: "green" },
+          ],
+          descriptions: ["Warm hue", "Cool hue"],
+        },
+        {
+          title: "Sizes",
+          prompt: "Pick sizes",
+          variant: "multipleSelection",
+          options: [
+            { label: "S", value: "s" },
+            { label: "M", value: "m" },
+            { label: "Other", value: "__other__" },
+          ],
+          descriptions: [undefined, undefined],
+        },
+      ]),
+      makeDataModel([{ selected: ["green"] }, { selected: ["s", "m"] }]),
+    ];
+
+    const result = parseChoicesPayload(payload) as ParsedChoicesSurface;
+    expect(result).not.toBeNull();
+
+    const tab0 = result.tabs[0];
+    expect(tab0.title).toBe("Colors");
+    expect(tab0.options[0].description).toBe("Warm hue");
+    expect(tab0.options[1].description).toBe("Cool hue");
+    expect(tab0.defaultSelected).toEqual(["green"]);
+
+    const tab1 = result.tabs[1];
+    expect(tab1.title).toBe("Sizes");
+    expect(tab1.hasOther).toBe(true);
+    expect(tab1.options).toHaveLength(2);
+    expect(tab1.defaultSelected).toEqual(["s", "m"]);
+  });
+});

--- a/apps/client/src/lib/a2ui-parser.ts
+++ b/apps/client/src/lib/a2ui-parser.ts
@@ -1,0 +1,176 @@
+/**
+ * A2UI v0.9 payload parser for the PresentChoices surface.
+ *
+ * The PresentChoices agent tool emits 3 messages:
+ *   1. createSurface  – surface identity
+ *   2. updateComponents – flat component list describing the UI layout
+ *   3. updateDataModel  – initial/default selected values
+ *
+ * This module parses those 3 messages into a structured `ParsedChoicesSurface`
+ * suitable for rendering choice UI in the dashboard.
+ */
+
+export interface ParsedOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface ParsedTab {
+  title: string;
+  prompt: string;
+  type: "single-select" | "multi-select";
+  options: ParsedOption[];
+  hasOther: boolean;
+  defaultSelected: string[];
+}
+
+export interface ParsedChoicesSurface {
+  surfaceId: string;
+  tabs: ParsedTab[];
+}
+
+/** The sentinel option value used by PresentChoices for the free-text "other" slot. */
+const OTHER_VALUE = "__other__";
+
+/**
+ * Parse a three-message A2UI v0.9 payload produced by the `PresentChoices` tool.
+ *
+ * @param payload - Array of raw message objects (order does not matter).
+ * @returns Parsed surface, or `null` if the payload cannot be interpreted.
+ */
+export function parseChoicesPayload(
+  payload: unknown[],
+): ParsedChoicesSurface | null {
+  try {
+    if (!Array.isArray(payload) || payload.length === 0) return null;
+
+    // Locate the three expected messages by their discriminant key.
+    const createMsg = payload.find(
+      (m): m is Record<string, unknown> =>
+        m !== null && typeof m === "object" && "createSurface" in (m as object),
+    ) as Record<string, unknown> | undefined;
+
+    const componentsMsg = payload.find(
+      (m): m is Record<string, unknown> =>
+        m !== null &&
+        typeof m === "object" &&
+        "updateComponents" in (m as object),
+    ) as Record<string, unknown> | undefined;
+
+    const dataModelMsg = payload.find(
+      (m): m is Record<string, unknown> =>
+        m !== null &&
+        typeof m === "object" &&
+        "updateDataModel" in (m as object),
+    ) as Record<string, unknown> | undefined;
+
+    if (!createMsg || !componentsMsg) return null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const createSurface = createMsg.createSurface as any;
+    const surfaceId = createSurface?.surfaceId as string | undefined;
+    if (!surfaceId) return null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateComponents = componentsMsg.updateComponents as any;
+    const components: unknown[] = updateComponents?.components;
+    if (!Array.isArray(components)) return null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const findComp = (id: string): any =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      components.find((c: any) => c?.id === id);
+
+    // Determine tab count and titles.
+    // Multi-tab: a Tabs component exists with a `tabs` array.
+    // Single-tab: no Tabs component; fall back to the prompt text.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tabsComp: any = findComp("tabs");
+    let tabCount: number;
+    let tabTitles: string[];
+
+    if (tabsComp) {
+      if (!Array.isArray(tabsComp.tabs) || tabsComp.tabs.length === 0)
+        return null;
+      tabCount = tabsComp.tabs.length;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tabTitles = tabsComp.tabs.map((t: any) => (t?.title as string) ?? "");
+    } else {
+      // Single-tab mode: there is no explicit tab title in the A2UI payload.
+      // Use the prompt text as the title, or fall back to "Selection".
+      tabCount = 1;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const promptComp: any = findComp("tab-0-prompt");
+      tabTitles = [(promptComp?.text as string) ?? "Selection"];
+    }
+
+    // Extract data-model defaults if present.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateDataModel = (dataModelMsg?.updateDataModel as any)?.value as
+      | { tabs: Array<{ selected: string[]; otherText: string }> }
+      | undefined;
+
+    const tabs: ParsedTab[] = [];
+
+    for (let i = 0; i < tabCount; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const promptComp: any = findComp(`tab-${i}-prompt`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pickerComp: any = findComp(`tab-${i}-picker`);
+
+      if (!promptComp || !pickerComp) return null;
+
+      const prompt = promptComp.text as string;
+      const pickerVariant = pickerComp.variant as string;
+      const type: "single-select" | "multi-select" =
+        pickerVariant === "multipleSelection"
+          ? "multi-select"
+          : "single-select";
+
+      // Separate __other__ from regular options.
+      const rawOptions: Array<{ label: string; value: string }> = Array.isArray(
+        pickerComp.options,
+      )
+        ? pickerComp.options
+        : [];
+
+      const hasOther =
+        rawOptions.length > 0 &&
+        rawOptions[rawOptions.length - 1].value === OTHER_VALUE;
+
+      const regularOptions = hasOther
+        ? rawOptions.slice(0, -1)
+        : [...rawOptions];
+
+      // Attach per-option descriptions from `tab-{i}-opt-{j}-desc` Text components.
+      const options: ParsedOption[] = regularOptions.map((opt, j) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const descComp: any = findComp(`tab-${i}-opt-${j}-desc`);
+        const description = descComp?.text as string | undefined;
+        return {
+          value: opt.value,
+          label: opt.label,
+          ...(description !== undefined ? { description } : {}),
+        };
+      });
+
+      // Default selections from data model (tab index aligned).
+      const defaultSelected: string[] =
+        updateDataModel?.tabs?.[i]?.selected ?? [];
+
+      tabs.push({
+        title: tabTitles[i] ?? `Tab ${i + 1}`,
+        prompt,
+        type,
+        options,
+        hasOther,
+        defaultSelected,
+      });
+    }
+
+    return { surfaceId, tabs };
+  } catch {
+    return null;
+  }
+}

--- a/apps/client/src/lib/agent-event-metadata.ts
+++ b/apps/client/src/lib/agent-event-metadata.ts
@@ -17,6 +17,9 @@ const AGENT_EVENT_STATUSES = new Set<AgentEventMetadata["status"]>([
   "running",
   "completed",
   "failed",
+  "resolved",
+  "timeout",
+  "cancelled",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -73,7 +76,9 @@ export function getAgentEventMetadata(
       ? { surfaceMetadata: value.surfaceMetadata }
       : {}),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(isRecord(value.selections) ? { selections: value.selections as any } : {}),
+    ...(isRecord(value.selections)
+      ? { selections: value.selections as any }
+      : {}),
     ...(typeof value.responderId === "string"
       ? { responderId: value.responderId }
       : {}),

--- a/apps/client/src/lib/agent-event-metadata.ts
+++ b/apps/client/src/lib/agent-event-metadata.ts
@@ -75,9 +75,13 @@ export function getAgentEventMetadata(
     ...(isRecord(value.surfaceMetadata)
       ? { surfaceMetadata: value.surfaceMetadata }
       : {}),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(isRecord(value.selections)
-      ? { selections: value.selections as any }
+      ? {
+          selections: value.selections as Record<
+            string,
+            { selected: string[]; otherText: string | null }
+          >,
+        }
       : {}),
     ...(typeof value.responderId === "string"
       ? { responderId: value.responderId }

--- a/apps/client/src/lib/agent-event-metadata.ts
+++ b/apps/client/src/lib/agent-event-metadata.ts
@@ -22,6 +22,28 @@ const AGENT_EVENT_STATUSES = new Set<AgentEventMetadata["status"]>([
   "cancelled",
 ]);
 
+/** Validate and normalize selections — ensure each entry has selected: string[] */
+function normalizeSelections(
+  raw: Record<string, unknown>,
+): Record<string, { selected: string[]; otherText: string | null }> {
+  const result: Record<
+    string,
+    { selected: string[]; otherText: string | null }
+  > = {};
+  for (const [key, val] of Object.entries(raw)) {
+    if (typeof val === "object" && val !== null) {
+      const entry = val as Record<string, unknown>;
+      result[key] = {
+        selected: Array.isArray(entry.selected)
+          ? entry.selected.filter((v): v is string => typeof v === "string")
+          : [],
+        otherText: typeof entry.otherText === "string" ? entry.otherText : null,
+      };
+    }
+  }
+  return result;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -77,10 +99,9 @@ export function getAgentEventMetadata(
       : {}),
     ...(isRecord(value.selections)
       ? {
-          selections: value.selections as Record<
-            string,
-            { selected: string[]; otherText: string | null }
-          >,
+          selections: normalizeSelections(
+            value.selections as Record<string, unknown>,
+          ),
         }
       : {}),
     ...(typeof value.responderId === "string"

--- a/apps/client/src/lib/agent-event-metadata.ts
+++ b/apps/client/src/lib/agent-event-metadata.ts
@@ -9,6 +9,8 @@ const AGENT_EVENT_TYPES = new Set<AgentEventMetadata["agentEventType"]>([
   "agent_end",
   "error",
   "turn_separator",
+  "a2ui_surface_update",
+  "a2ui_response",
 ]);
 
 const AGENT_EVENT_STATUSES = new Set<AgentEventMetadata["status"]>([
@@ -63,6 +65,21 @@ export function getAgentEventMetadata(
       : {}),
     ...(isRecord(value.toolArgs) ? { toolArgs: value.toolArgs } : {}),
     ...(typeof value.success === "boolean" ? { success: value.success } : {}),
+    ...(typeof value.surfaceId === "string"
+      ? { surfaceId: value.surfaceId }
+      : {}),
+    ...(Array.isArray(value.payload) ? { payload: value.payload } : {}),
+    ...(isRecord(value.surfaceMetadata)
+      ? { surfaceMetadata: value.surfaceMetadata }
+      : {}),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(isRecord(value.selections) ? { selections: value.selections as any } : {}),
+    ...(typeof value.responderId === "string"
+      ? { responderId: value.responderId }
+      : {}),
+    ...(typeof value.responderName === "string"
+      ? { responderName: value.responderName }
+      : {}),
   };
 }
 

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -19,7 +19,13 @@ export interface AgentEventMetadata {
     | "turn_separator"
     | "a2ui_surface_update"
     | "a2ui_response";
-  status: "running" | "completed" | "failed";
+  status:
+    | "running"
+    | "completed"
+    | "failed"
+    | "resolved"
+    | "timeout"
+    | "cancelled";
   toolName?: string;
   toolCallId?: string;
   toolArgs?: Record<string, unknown>;
@@ -225,6 +231,7 @@ export interface CreateMessageDto {
   clientMsgId?: string;
   parentId?: string;
   attachments?: AttachmentDto[];
+  metadata?: Record<string, unknown>;
 }
 
 export interface UpdateMessageDto {

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -16,12 +16,20 @@ export interface AgentEventMetadata {
     | "agent_start"
     | "agent_end"
     | "error"
-    | "turn_separator";
+    | "turn_separator"
+    | "a2ui_surface_update"
+    | "a2ui_response";
   status: "running" | "completed" | "failed";
   toolName?: string;
   toolCallId?: string;
   toolArgs?: Record<string, unknown>;
   success?: boolean;
+  surfaceId?: string;
+  payload?: unknown[];
+  surfaceMetadata?: Record<string, unknown>;
+  selections?: Record<string, { selected: string[]; otherText: string | null }>;
+  responderId?: string;
+  responderName?: string;
 }
 
 export interface ChannelSnapshot {

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
   },
   "lint-staged": {
     "apps/client/**/*.{ts,tsx,js,jsx}": [
-      "eslint --fix --config apps/client/eslint.config.mjs",
+      "pnpm --filter @team9/client exec eslint --fix",
       "prettier --write"
     ],
     "apps/server/**/*.ts": [
-      "eslint --fix --config apps/server/eslint.config.mjs",
+      "pnpm --filter @team9/server exec eslint --fix",
       "prettier --write"
     ],
     "*.{json,md,yaml,yml}": [


### PR DESCRIPTION
## Summary

- Add `A2UISurfaceBlock` component for interactive choice presentation in the chat flow
- Add `A2UIResponseItem` for compact "User selected X" display after submission
- Port A2UI v0.9 payload parser from dashboard
- Extend `AgentEventMetadata` with A2UI types + status union (resolved/timeout/cancelled)
- Wire `useSendMessage` for actual submission + optimistic cache update
- Fix lint-staged to use workspace-local ESLint v9

## Quality Checklist
- [x] Spec/Quality check — 4 issues fixed (status types, submit wiring, cache update, response fallback)
- [x] Review loop (Claude) — 4 issues fixed (cache shape, double-submit, dead status indirection, auto-focus)
- [x] Test completeness — N/A (client has no testing-library)
- [x] Copilot review — 8 comments: 2 fixed, 4 already fixed, 2 skipped (minor)
- [x] Codex review — N/A (bash permission issue)
- [x] Documentation consistency — spec present
- [x] No merge conflicts
- [x] CI passing (lint + test)

## Test Plan
- [x] TypeScript compiles with no new errors
- [x] lint-staged hook passes (eslint v9 + prettier)
- [x] CI: lint pass, test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)