### PR TITLE
Release: dev → main (Apr 7)

### DIFF
--- a/apps/client/src/components/ai-staff/CommonStaffDetailSection.tsx
+++ b/apps/client/src/components/ai-staff/CommonStaffDetailSection.tsx
@@ -110,8 +110,8 @@ export function CommonStaffDetailSection({
 
   // Current model value for the select — fall back to the default model when null
   const effectiveModel = bot.model ?? {
-    provider: "anthropic",
-    id: "claude-sonnet-4-6",
+    provider: "openrouter",
+    id: "anthropic/claude-sonnet-4.6",
   };
   const currentModelValue = `${effectiveModel.provider}::${effectiveModel.id}`;
 

--- a/apps/client/src/lib/common-staff-models.ts
+++ b/apps/client/src/lib/common-staff-models.ts
@@ -7,15 +7,23 @@ export interface StaffModel {
 
 export const COMMON_STAFF_MODELS: StaffModel[] = [
   {
-    provider: "anthropic",
-    id: "claude-sonnet-4-6",
+    provider: "openrouter",
+    id: "anthropic/claude-sonnet-4.6",
     label: "Claude Sonnet 4.6",
     default: true,
   },
-  { provider: "anthropic", id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-  { provider: "openai", id: "gpt-4.1", label: "GPT-4.1" },
-  { provider: "openai", id: "o3", label: "o3" },
-  { provider: "google", id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  {
+    provider: "openrouter",
+    id: "anthropic/claude-opus-4.6",
+    label: "Claude Opus 4.6",
+  },
+  { provider: "openrouter", id: "openai/gpt-4.1", label: "GPT-4.1" },
+  { provider: "openrouter", id: "openai/o3", label: "o3" },
+  {
+    provider: "openrouter",
+    id: "google/gemini-2.5-pro",
+    label: "Gemini 2.5 Pro",
+  },
 ];
 
 export const DEFAULT_STAFF_MODEL = COMMON_STAFF_MODELS.find((m) => m.default)!;

--- a/apps/server/apps/gateway/src/applications/applications.module.ts
+++ b/apps/server/apps/gateway/src/applications/applications.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef, type OnModuleInit, Logger } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { WorkspaceModule } from '../workspace/workspace.module.js';
 import { ChannelsModule } from '../im/channels/channels.module.js';
 import { WebsocketModule } from '../im/websocket/websocket.module.js';
@@ -44,18 +44,4 @@ import {
   ],
   exports: [ApplicationsService, InstalledApplicationsService],
 })
-export class ApplicationsModule implements OnModuleInit {
-  private readonly logger = new Logger(ApplicationsModule.name);
-
-  constructor(
-    private readonly installedApplicationsService: InstalledApplicationsService,
-  ) {}
-
-  async onModuleInit(): Promise<void> {
-    try {
-      await this.installedApplicationsService.backfillAutoInstallApps();
-    } catch (error) {
-      this.logger.warn('Auto-install backfill failed (non-fatal)', error);
-    }
-  }
-}
+export class ApplicationsModule {}

--- a/apps/server/apps/gateway/src/applications/common-staff.controller.spec.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.controller.spec.ts
@@ -50,7 +50,7 @@ const makeCreateDto = (
   overrides: Partial<CreateCommonStaffDto> = {},
 ): CreateCommonStaffDto => ({
   displayName: 'Test Staff',
-  model: { provider: 'anthropic', id: 'claude-3-5-sonnet-20241022' },
+  model: { provider: 'openrouter', id: 'anthropic/claude-sonnet-4.6' },
   roleTitle: 'Software Engineer',
   mentorId: USER_ID,
   persona: 'Helpful assistant',
@@ -252,7 +252,7 @@ describe('CommonStaffController', () => {
         roleTitle: 'Senior Engineer',
         persona: 'Expert',
         jobDescription: 'Leads architecture',
-        model: { provider: 'openai', id: 'gpt-4o' },
+        model: { provider: 'openrouter', id: 'openai/gpt-4o' },
         avatarUrl: 'https://example.com/new-avatar.png',
         mentorId: 'new-mentor-id',
       });
@@ -266,7 +266,7 @@ describe('CommonStaffController', () => {
           roleTitle: 'Senior Engineer',
           persona: 'Expert',
           jobDescription: 'Leads architecture',
-          model: { provider: 'openai', id: 'gpt-4o' },
+          model: { provider: 'openrouter', id: 'openai/gpt-4o' },
           avatarUrl: 'https://example.com/new-avatar.png',
           mentorId: 'new-mentor-id',
         }),

--- a/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
@@ -156,7 +156,7 @@ const makeCreateDto = (
   overrides: Partial<CreateCommonStaffDto> = {},
 ): CreateCommonStaffDto => ({
   displayName: 'Test Staff',
-  model: { provider: 'anthropic', id: 'claude-3-5-sonnet-20241022' },
+  model: { provider: 'openrouter', id: 'anthropic/claude-sonnet-4.6' },
   roleTitle: 'Software Engineer',
   mentorId: OWNER_ID,
   persona: 'Helpful assistant',
@@ -585,7 +585,7 @@ describe('CommonStaffService', () => {
 
         const dto: CreateCommonStaffDto = {
           displayName: '',
-          model: { provider: 'anthropic', id: 'claude-3-5-sonnet-20241022' },
+          model: { provider: 'openrouter', id: 'anthropic/claude-sonnet-4.6' },
           mentorId: MENTOR_ID,
           agenticBootstrap: true,
         };
@@ -602,7 +602,7 @@ describe('CommonStaffService', () => {
 
         const dto: CreateCommonStaffDto = {
           displayName: '',
-          model: { provider: 'anthropic', id: 'claude-3-5-sonnet-20241022' },
+          model: { provider: 'openrouter', id: 'anthropic/claude-sonnet-4.6' },
           mentorId: MENTOR_ID,
           agenticBootstrap: true,
         };
@@ -820,7 +820,7 @@ describe('CommonStaffService', () => {
     it('syncs to claw-hive after update', async () => {
       const dto = makeUpdateDto({
         displayName: 'New Name',
-        model: { provider: 'openai', id: 'gpt-4o' },
+        model: { provider: 'openrouter', id: 'openai/gpt-4o' },
       });
       await service.updateStaff(INSTALLED_APP_ID, TENANT_ID, BOT_ID, dto);
 
@@ -829,7 +829,7 @@ describe('CommonStaffService', () => {
         expect.objectContaining({
           tenantId: TENANT_ID,
           name: 'New Name',
-          model: { provider: 'openai', id: 'gpt-4o' },
+          model: { provider: 'openrouter', id: 'openai/gpt-4o' },
         }),
       );
     });

--- a/apps/server/apps/gateway/src/routines/routines-stream.controller.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routines-stream.controller.spec.ts
@@ -332,7 +332,7 @@ describe('RoutinesStreamController', () => {
       await ended;
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3721/tasks/agent_task_exec_exec-1/events/stream',
+        'http://localhost:3721/tasks/agent_task_exec_exec-1/events',
         expect.objectContaining({
           headers: {
             Accept: 'text/event-stream',

--- a/apps/server/apps/gateway/src/routines/routines-stream.controller.ts
+++ b/apps/server/apps/gateway/src/routines/routines-stream.controller.ts
@@ -114,7 +114,7 @@ export class RoutinesStreamController {
     }
 
     // ── Proxy SSE from TaskCast ──
-    const upstream = `${this.taskcastUrl}/tasks/${taskcastTaskId}/events/stream`;
+    const upstream = `${this.taskcastUrl}/tasks/${taskcastTaskId}/events`;
     const headers: Record<string, string> = {
       Accept: 'text/event-stream',
     };
@@ -136,6 +136,9 @@ export class RoutinesStreamController {
       });
 
       if (!upstreamRes.ok || !upstreamRes.body) {
+        this.logger.warn(
+          `TaskCast upstream returned ${upstreamRes.status} for task ${taskcastTaskId}`,
+        );
         res.status(502).json({ error: 'TaskCast upstream unavailable' });
         return;
       }


### PR DESCRIPTION
## Summary

Major release merging accumulated dev work into main:

- **Task → Routine rename**: Full codebase rename of "task" to "routine" across DB schemas, API, frontend, and i18n (PR #17)
- **Common Staff system**: New managed-bot type with persona generation, agentic bootstrap, 3D badge cards, and inline editing
- **Vercel AI SDK + OpenRouter migration**: Replace direct Anthropic/OpenAI calls with Vercel AI SDK via OpenRouter (PR #14)
- **Notification system**: Web Push, Tauri desktop notifications, and per-channel notification preferences
- **A2UI surface block**: Agent-to-UI rich rendering in message list
- **Desktop app improvements**: Auto-update, custom DMG installer, deep link login, macOS traffic light alignment
- **Channel content refactor**: Extracted `ChannelContent` pure UI component, unified rendering in `TrackingModal`
- **SSE stream fix**: Corrected TaskCast proxy URL path (`/events/stream` → `/events`)
- **Misc fixes**: path-to-regexp v8 middleware, CORS wildcard, X-Tenant-Id header for SSE, runtime deps

## Test plan

- [ ] Verify routine (formerly task) CRUD and execution flow
- [ ] Test common staff creation (form + agentic mode) and persona generation
- [ ] Confirm SSE stream for routine executions works end-to-end
- [ ] Test desktop auto-update dialog on macOS
- [ ] Verify notification preferences and Web Push delivery
- [ ] Check A2UI surface blocks render in agent messages
- [ ] Smoke test all AI model selections via OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)