### PR TITLE
feat(billing): add plus plan tier with i18n and themed plan cards

### DIFF
--- a/apps/client/src/analytics/posthog/sync.tsx
+++ b/apps/client/src/analytics/posthog/sync.tsx
@@ -27,7 +27,7 @@ export function Team9PostHogIdentitySync() {
 
     if (!hasAuthToken || !user) {
       if (lastIdentifiedUserId !== null || lastGroupedWorkspaceId !== null) {
-        client.reset(true);
+        client.reset();
         clearIdentitySyncState();
       }
       return;

--- a/apps/client/src/components/billing/plan-card.tsx
+++ b/apps/client/src/components/billing/plan-card.tsx
@@ -93,6 +93,10 @@ function getPlanTierRank(productOrTitle: BillingProduct | string) {
     return 10;
   }
 
+  if (normalized.includes("plus")) {
+    return 15;
+  }
+
   if (normalized.includes("pro")) {
     return 20;
   }
@@ -255,6 +259,10 @@ export function getPlanCardTheme(index: number, title: string): PlanCardTheme {
 
   if (normalizedTitle.includes("starter")) {
     return "accent";
+  }
+
+  if (normalizedTitle.includes("plus")) {
+    return "dark";
   }
 
   if (normalizedTitle.includes("pro")) {

--- a/apps/client/src/components/billing/plan-card.tsx
+++ b/apps/client/src/components/billing/plan-card.tsx
@@ -7,21 +7,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import i18n from "@/i18n";
 import { cn } from "@/lib/utils";
 import type { BillingProduct } from "@/types/workspace";
 
-export const FREE_PLAN_FEATURES = [
-  "100 refresh credits every day",
-  "4,000 credits per month",
-  "In-depth research for everyday tasks",
-  "Professional websites for standard output",
-  "Insightful slides for regular content",
-  "Task scaling with Wide Research",
-  "Early access to beta features",
-  "20 concurrent tasks",
-  "20 scheduled tasks",
-  "Shared team workspace billing",
-];
+type WorkspaceT = (key: string, options?: Record<string, unknown>) => string;
 
 export type PlanGroup = {
   key: string;
@@ -31,12 +21,24 @@ export type PlanGroup = {
   sortOrder: number;
 };
 
-export type PlanCardTheme = "free" | "accent" | "dark";
+export type PlanCardTheme = "free" | "plus" | "pro";
+
+function getLocale() {
+  return i18n.language ?? i18n.resolvedLanguage ?? "en";
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat(getLocale()).format(value);
+}
+
+function getWorkspaceT(): WorkspaceT {
+  return i18n.getFixedT(getLocale(), "workspace") as WorkspaceT;
+}
 
 export function formatMoney(amountCents: number) {
   const hasFraction = amountCents % 100 !== 0;
 
-  return new Intl.NumberFormat("en-US", {
+  return new Intl.NumberFormat(getLocale(), {
     style: "currency",
     currency: "USD",
     minimumFractionDigits: hasFraction ? 2 : 0,
@@ -45,7 +47,10 @@ export function formatMoney(amountCents: number) {
 }
 
 export function formatCredits(amount: number) {
-  return `${new Intl.NumberFormat("en-US").format(amount)} credits`;
+  const t = getWorkspaceT();
+  return t("billing.plans.creditsLabel", {
+    credits: formatNumber(amount),
+  });
 }
 
 export function formatInterval(
@@ -56,21 +61,29 @@ export function formatInterval(
     return null;
   }
 
-  if (!intervalCount || intervalCount === 1) {
-    return interval;
-  }
+  const t = getWorkspaceT();
+  const count = intervalCount ?? 1;
+  const fallback = count === 1 ? interval : `${count} ${interval}s`;
 
-  return `${intervalCount} ${interval}s`;
+  return t(`billing.interval.${interval}`, {
+    count,
+    defaultValue: fallback,
+  });
 }
 
 export function formatPlanCredits(product: BillingProduct) {
+  const t = getWorkspaceT();
+
   if (!product.credits) {
-    return "Credits configured in Billing Hub";
+    return t("billing.plans.creditsConfiguredInBillingHub");
   }
 
   const cycle = formatInterval(product.interval, product.intervalCount);
   return cycle
-    ? `${formatCredits(product.credits)} / ${cycle}`
+    ? t("billing.plans.planCreditsWithCycle", {
+        credits: formatNumber(product.credits),
+        cycle,
+      })
     : formatCredits(product.credits);
 }
 
@@ -177,25 +190,15 @@ export function formatPlanOptionLabel(product: BillingProduct) {
   return formatPlanCredits(product);
 }
 
-export function buildPlanFeatures(product: BillingProduct) {
-  const normalizedTitle = product.name.trim().toLowerCase();
-  const monthlyCredits = product.credits
-    ? `${new Intl.NumberFormat("en-US").format(product.credits)} credits per month`
-    : "Monthly credits configured in Billing Hub";
+function resolvePlanCopyKey(title: string) {
+  const normalizedTitle = title.trim().toLowerCase();
 
-  if (normalizedTitle.includes("starter")) {
-    return [
-      "300 refresh credits every day",
-      monthlyCredits,
-      "In-depth research with self-set usage",
-      "Professional websites for changing needs",
-      "Insightful slides for steady creation",
-      "Wide Research scaled to your chosen plan",
-      "Early access to beta features",
-      "20 concurrent tasks",
-      "20 scheduled tasks",
-      "Priority support for workspace admins",
-    ];
+  if (normalizedTitle.includes("free")) {
+    return "free" as const;
+  }
+
+  if (normalizedTitle.includes("plus") || normalizedTitle.includes("starter")) {
+    return "plus" as const;
   }
 
   if (
@@ -203,17 +206,58 @@ export function buildPlanFeatures(product: BillingProduct) {
     normalizedTitle.includes("business") ||
     normalizedTitle.includes("enterprise")
   ) {
+    return "pro" as const;
+  }
+
+  return "generic" as const;
+}
+
+export function getFreePlanFeatures() {
+  const t = getWorkspaceT();
+
+  return [
+    t("billing.plans.free.features.oneTimeCredits"),
+    t("billing.plans.free.features.coreModels"),
+    t("billing.plans.free.features.basicResearch"),
+    t("billing.plans.free.features.fileMemory"),
+    t("billing.plans.free.features.agentTools"),
+    t("billing.plans.free.features.multiAgent"),
+    t("billing.plans.free.features.beta"),
+  ];
+}
+
+export function buildPlanFeatures(product: BillingProduct) {
+  const t = getWorkspaceT();
+  const planCopyKey = resolvePlanCopyKey(product.name);
+  const monthlyCredits = product.credits
+    ? t("billing.plans.monthlyCredits", {
+        credits: formatNumber(product.credits),
+      })
+    : t("billing.plans.creditsConfiguredInBillingHub");
+
+  if (planCopyKey === "plus") {
     return [
-      "300 refresh credits every day",
       monthlyCredits,
-      "In-depth research for large-scale tasks",
-      "Professional websites with data analytics",
-      "Insightful slides for batch production",
-      "Wide Research for sustained heavy use",
-      "Early access to beta features",
-      "20 concurrent tasks",
-      "20 scheduled tasks",
-      "Advanced billing controls and reporting",
+      t("billing.plans.plus.features.modelAccess"),
+      t("billing.plans.plus.features.nanoBanana"),
+      t("billing.plans.plus.features.fileMemory"),
+      t("billing.plans.plus.features.premiumTools"),
+      t("billing.plans.plus.features.multiAgent"),
+      t("billing.plans.plus.features.beta"),
+      t("billing.plans.plus.features.support"),
+    ];
+  }
+
+  if (planCopyKey === "pro") {
+    return [
+      monthlyCredits,
+      t("billing.plans.pro.features.modelAccess"),
+      t("billing.plans.pro.features.nanoBanana"),
+      t("billing.plans.pro.features.fileMemory"),
+      t("billing.plans.pro.features.premiumTools"),
+      t("billing.plans.pro.features.multiAgent"),
+      t("billing.plans.pro.features.beta"),
+      t("billing.plans.pro.features.support"),
     ];
   }
 
@@ -223,8 +267,8 @@ export function buildPlanFeatures(product: BillingProduct) {
   for (const feature of [
     ...baseFeatures,
     monthlyCredits,
-    "Shared workspace billing controls for owners and admins",
-    "Managed through Billing Hub checkout and portal",
+    t("billing.plans.generic.features.sharedBilling"),
+    t("billing.plans.generic.features.managedThroughBillingHub"),
   ]) {
     if (!feature || features.includes(feature)) {
       continue;
@@ -237,50 +281,47 @@ export function buildPlanFeatures(product: BillingProduct) {
 }
 
 export function getPlanDescription(title: string) {
-  const normalizedTitle = title.trim().toLowerCase();
+  const t = getWorkspaceT();
 
-  if (normalizedTitle.includes("starter")) {
-    return "适合稳定使用场景，能覆盖大部分日常需求。";
+  switch (resolvePlanCopyKey(title)) {
+    case "free":
+      return t("billing.plans.free.description");
+    case "plus":
+      return t("billing.plans.plus.description");
+    case "pro":
+      return t("billing.plans.pro.description");
+    default:
+      return t("billing.plans.generic.description");
   }
-
-  if (
-    normalizedTitle.includes("pro") ||
-    normalizedTitle.includes("business") ||
-    normalizedTitle.includes("enterprise")
-  ) {
-    return "适合重度使用团队，强调更高额度和更高优先级。";
-  }
-
-  return "适合先体验产品，保留最基本的额度与能力。";
 }
 
 export function getPlanCardTheme(index: number, title: string): PlanCardTheme {
   const normalizedTitle = title.toLowerCase();
 
   if (normalizedTitle.includes("starter")) {
-    return "accent";
+    return "plus";
   }
 
   if (normalizedTitle.includes("plus")) {
-    return "dark";
+    return "plus";
   }
 
   if (normalizedTitle.includes("pro")) {
-    return "dark";
+    return "pro";
   }
 
   if (
     normalizedTitle.includes("business") ||
     normalizedTitle.includes("enterprise")
   ) {
-    return "dark";
+    return "pro";
   }
 
   if (index === 0) {
-    return "accent";
+    return "plus";
   }
 
-  return index % 2 === 1 ? "dark" : "accent";
+  return index % 2 === 1 ? "pro" : "plus";
 }
 
 export function PlanCard({
@@ -312,18 +353,16 @@ export function PlanCard({
   optionValue?: string;
   onOptionChange?: (value: string) => void;
 }) {
-  const isDark = theme === "dark";
-
   return (
     <section
       className={cn(
         "relative flex h-full flex-col overflow-hidden rounded-[1.4rem] border px-5 py-5 shadow-[0_28px_90px_-50px_rgba(15,23,42,0.3)]",
         theme === "free" &&
           "border-slate-200/80 bg-[linear-gradient(180deg,#ffffff_0%,#f4f8ff_100%)] text-slate-950",
-        theme === "accent" &&
-          "border-[#78a9ff] bg-[linear-gradient(180deg,#f8fbff_0%,#dfeafc_100%)] text-slate-950",
-        theme === "dark" &&
-          "border-slate-700 bg-[linear-gradient(180deg,#313f61_0%,#27395f_100%)] text-white",
+        theme === "plus" &&
+          "border-[#d4e2fb] bg-[linear-gradient(180deg,#fbfdff_0%,#eef4ff_58%,#e6efff_100%)] text-slate-950 shadow-[0_34px_95px_-58px_rgba(72,104,164,0.2)]",
+        theme === "pro" &&
+          "border-[#eadcc0] bg-[linear-gradient(180deg,#fffdf9_0%,#f9f2e7_56%,#f4ebdc_100%)] text-slate-950 shadow-[0_34px_95px_-58px_rgba(151,116,60,0.16)]",
       )}
     >
       <div
@@ -331,20 +370,20 @@ export function PlanCard({
           "pointer-events-none absolute inset-0",
           theme === "free" &&
             "bg-[radial-gradient(circle_at_top_left,rgba(225,235,255,0.95),transparent_40%),radial-gradient(circle_at_bottom_right,rgba(214,226,245,0.45),transparent_36%)]",
-          theme === "accent" &&
-            "bg-[radial-gradient(circle_at_top_center,rgba(255,255,255,0.95),transparent_34%),radial-gradient(circle_at_bottom_left,rgba(116,169,255,0.18),transparent_38%)]",
-          theme === "dark" &&
-            "bg-[radial-gradient(circle_at_top_left,rgba(130,152,196,0.2),transparent_36%),radial-gradient(circle_at_bottom_right,rgba(14,23,43,0.15),transparent_32%)]",
+          theme === "plus" &&
+            "bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.98),transparent_36%),radial-gradient(circle_at_top_right,rgba(183,205,246,0.34),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(126,171,255,0.12),transparent_42%)]",
+          theme === "pro" &&
+            "bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.98),transparent_36%),radial-gradient(circle_at_top_right,rgba(244,229,200,0.5),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(219,177,108,0.12),transparent_42%)]",
         )}
       />
 
       <div className="relative flex h-full flex-col">
         <div
           className={cn(
-            "w-fit rounded-full px-4 py-2 text-base font-semibold tracking-tight",
+            "w-fit rounded-full border px-4 py-2 text-base font-semibold tracking-tight backdrop-blur",
             theme === "free" && "bg-slate-100 text-slate-600",
-            theme === "accent" && "bg-[#d6e4ff] text-[#315d9f]",
-            theme === "dark" && "bg-white/12 text-white/90",
+            theme === "plus" && "border-white/70 bg-white/74 text-[#44638f]",
+            theme === "pro" && "border-[#efe2c7] bg-white/76 text-[#8b6738]",
           )}
         >
           {badge}
@@ -354,7 +393,7 @@ export function PlanCard({
           <div
             className={cn(
               "text-[2.8rem] leading-none font-semibold tracking-[-0.06em] sm:text-[3.15rem]",
-              isDark ? "text-white" : "text-[#18325d]",
+              theme === "pro" ? "text-[#3f3120]" : "text-[#18325d]",
             )}
           >
             {priceAmount}
@@ -362,7 +401,7 @@ export function PlanCard({
               <span
                 className={cn(
                   "ml-2 text-lg font-medium tracking-normal",
-                  isDark ? "text-white/85" : "text-[#54698d]",
+                  theme === "pro" ? "text-[#8a7355]" : "text-[#607290]",
                 )}
               >
                 / {priceCycle}
@@ -372,7 +411,7 @@ export function PlanCard({
           <p
             className={cn(
               "mt-3.5 min-h-[4rem] text-[0.95rem] leading-6 font-medium",
-              isDark ? "text-white/86" : "text-[#5d7295]",
+              theme === "pro" ? "text-[#7a6750]" : "text-[#667a98]",
             )}
           >
             {description}
@@ -381,13 +420,19 @@ export function PlanCard({
 
         <Button
           className={cn(
-            "mt-3.5 h-11 w-full rounded-full border border-black/10 bg-[#151515] text-base font-semibold text-white shadow-none hover:bg-black/90",
+            "mt-3.5 h-11 w-full rounded-full text-base font-semibold transition-all duration-200 transform-gpu hover:-translate-y-1 active:translate-y-0",
+            theme === "plus" &&
+              "border border-[#25324a]/8 bg-[linear-gradient(180deg,#25324a_0%,#161f31_100%)] text-white shadow-[0_18px_34px_-18px_rgba(72,104,164,0.24)] hover:brightness-[1.04] hover:shadow-[0_28px_44px_-18px_rgba(72,104,164,0.32)]",
+            theme === "pro" &&
+              "border border-[#2a2114]/8 bg-[linear-gradient(180deg,#2b241c_0%,#19130d_100%)] text-white shadow-[0_18px_34px_-18px_rgba(151,116,60,0.22)] hover:brightness-[1.04] hover:shadow-[0_28px_44px_-18px_rgba(151,116,60,0.3)]",
+            theme === "free" &&
+              "border border-black/10 bg-[linear-gradient(180deg,#1f2937_0%,#111827_100%)] text-white shadow-[0_16px_28px_-18px_rgba(15,23,42,0.28)] hover:brightness-[1.03] hover:shadow-[0_24px_36px_-18px_rgba(15,23,42,0.38)]",
             actionDisabled && "opacity-100",
           )}
           onClick={onAction}
           disabled={actionDisabled}
         >
-          {actionLabel}
+          <span>{actionLabel}</span>
         </Button>
 
         {optionItems?.length ? (
@@ -397,9 +442,12 @@ export function PlanCard({
                 aria-label={`${title} plan credits`}
                 className={cn(
                   "h-[3.5rem] rounded-[1rem] border px-4 text-left text-[0.95rem] font-semibold shadow-[0_18px_40px_-30px_rgba(15,23,42,0.35)] [&>svg]:size-4 [&>svg]:opacity-55",
-                  isDark
-                    ? "border-transparent bg-white text-[#383838]"
-                    : "border-[#8eb5ff] bg-[linear-gradient(180deg,#bfe6ff_0%,#ffffff_72%)] text-[#1b2b44]",
+                  theme === "plus" &&
+                    "border-[#d5e2fb] bg-[linear-gradient(180deg,#ffffff_0%,#f1f6ff_100%)] text-[#243247]",
+                  theme === "pro" &&
+                    "border-[#eadac0] bg-[linear-gradient(180deg,#fffdfa_0%,#faf2e5_100%)] text-[#4a3821]",
+                  theme === "free" &&
+                    "border-[#8eb5ff] bg-[linear-gradient(180deg,#bfe6ff_0%,#ffffff_72%)] text-[#1b2b44]",
                 )}
               >
                 <SelectValue />
@@ -407,9 +455,9 @@ export function PlanCard({
               <SelectContent
                 className={cn(
                   "rounded-[1.4rem] border p-2 shadow-[0_24px_60px_-36px_rgba(15,23,42,0.45)]",
-                  isDark
-                    ? "border-slate-200 bg-white"
-                    : "border-[#8eb5ff] bg-[#f6fbff]",
+                  theme === "plus" && "border-[#d5e2fb] bg-white",
+                  theme === "pro" && "border-[#eadac0] bg-white",
+                  theme === "free" && "border-[#8eb5ff] bg-[#f6fbff]",
                 )}
               >
                 {optionItems.map((option) => (
@@ -436,10 +484,18 @@ export function PlanCard({
               <Plus
                 className={cn(
                   "mt-1.5 h-3 w-3 shrink-0",
-                  isDark ? "text-[#7fb4ff]" : "text-[#4588ee]",
+                  theme === "plus" && "text-[#6d92d0]",
+                  theme === "pro" && "text-[#b78c4f]",
+                  theme === "free" && "text-[#4588ee]",
                 )}
               />
-              <span className={cn(isDark ? "text-white/84" : "text-[#607698]")}>
+              <span
+                className={cn(
+                  theme === "plus" && "text-[#617693]",
+                  theme === "pro" && "text-[#6c5a45]",
+                  theme === "free" && "text-[#607698]",
+                )}
+              >
                 {feature}
               </span>
             </div>

--- a/apps/client/src/components/layout/contents/SubscriptionContent.tsx
+++ b/apps/client/src/components/layout/contents/SubscriptionContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ShieldAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,7 +15,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import {
-  FREE_PLAN_FEATURES,
   PlanCard,
   buildPlanFeatures,
   formatCredits,
@@ -22,6 +22,7 @@ import {
   formatMoney,
   formatPlanCredits,
   formatPlanOptionLabel,
+  getFreePlanFeatures,
   getPlanCardTheme,
   getPlanDescription,
   groupPlanProducts,
@@ -233,6 +234,7 @@ export function SubscriptionContent({
   workspaceIdFromSearch,
   view,
 }: SubscriptionContentProps) {
+  const { t } = useTranslation("workspace");
   const navigate = useNavigate();
   const { selectedWorkspaceId } = useWorkspaceStore();
   const workspaceId = workspaceIdFromSearch || selectedWorkspaceId || undefined;
@@ -772,27 +774,30 @@ export function SubscriptionContent({
           <div className="relative mx-auto flex w-full max-w-[1120px] flex-col gap-4 px-4 py-5 sm:px-5 lg:px-6">
             {subscription?.cancelAtPeriodEnd ? (
               <div className="rounded-full border border-amber-200 bg-amber-50/90 px-5 py-3 text-sm text-amber-800">
-                The current subscription will end on{" "}
-                {formatDate(subscription.currentPeriodEnd)}.
+                {t("billing.page.subscriptionEnds", {
+                  date: formatDate(subscription.currentPeriodEnd),
+                })}
               </div>
             ) : null}
 
             <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
               <div className="max-w-3xl">
                 <div className="text-sm font-medium uppercase tracking-[0.22em] text-[#7e91b2]">
-                  {currentWorkspace.name} workspace billing
+                  {t("billing.page.workspaceBilling", {
+                    workspace: currentWorkspace.name,
+                  })}
                 </div>
                 <h1 className="mt-3 text-3xl font-semibold tracking-[-0.05em] text-[#111b35] sm:text-4xl">
-                  Choose your plan
+                  {t("billing.page.heading")}
                 </h1>
                 <p className="mt-2 max-w-2xl text-sm text-[#6a7d9e] sm:text-base">
-                  Select the plan that fits your workload.
+                  {t("billing.page.subheading")}
                 </p>
               </div>
 
               <div className="flex flex-wrap items-center gap-3 xl:justify-end">
                 <div className="rounded-full border border-white/80 bg-white/80 px-5 py-3 text-sm font-medium text-[#6a7d9e] shadow-[0_18px_40px_-32px_rgba(15,23,42,0.4)] backdrop-blur">
-                  1 USD = 1,000 credits across all plans.
+                  {t("billing.page.exchangeRate")}
                 </div>
                 <Button
                   variant="outline"
@@ -800,20 +805,24 @@ export function SubscriptionContent({
                   onClick={() => void handleManageBilling("plans")}
                   disabled={portal.isPending}
                 >
-                  Manage billing
+                  {t("billing.page.actions.manageBilling")}
                 </Button>
               </div>
             </div>
 
             <div className="grid gap-6 xl:grid-cols-3">
               <PlanCard
-                badge="Free"
-                title="Free"
+                badge={t("billing.plans.free.title")}
+                title={t("billing.plans.free.title")}
                 priceAmount="$0"
-                priceCycle="month"
+                priceCycle={formatInterval("month", 1)}
                 description={getPlanDescription("free")}
-                features={FREE_PLAN_FEATURES}
-                actionLabel={subscription ? "Choose Free" : "Current plan"}
+                features={getFreePlanFeatures()}
+                actionLabel={
+                  subscription
+                    ? t("billing.page.actions.chooseFree")
+                    : t("billing.page.actions.currentPlan")
+                }
                 actionDisabled={!subscription}
                 onAction={
                   subscription
@@ -855,7 +864,11 @@ export function SubscriptionContent({
                     description={getPlanDescription(group.title)}
                     features={buildPlanFeatures(selectedProduct)}
                     actionLabel={
-                      isCurrentPlan ? "Current plan" : `Choose ${group.title}`
+                      isCurrentPlan
+                        ? t("billing.page.actions.currentPlan")
+                        : t("billing.page.actions.choosePlan", {
+                            plan: group.title,
+                          })
                     }
                     actionDisabled={isCurrentPlan}
                     onAction={
@@ -888,8 +901,8 @@ export function SubscriptionContent({
 
             {planGroups.length === 0 ? (
               <SectionMessage
-                title="No paid plans configured"
-                description="Billing Hub does not currently expose any paid subscription products."
+                title={t("billing.page.emptyPaidPlans.title")}
+                description={t("billing.page.emptyPaidPlans.description")}
               />
             ) : null}
 
@@ -947,16 +960,19 @@ export function SubscriptionContent({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Subscription Required</AlertDialogTitle>
+            <AlertDialogTitle>
+              {t("billing.page.subscriptionRequired.title")}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              You need an active subscription before purchasing credits. Please
-              subscribe to a plan first.
+              {t("billing.page.subscriptionRequired.description")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>
+              {t("billing.page.subscriptionRequired.cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction onClick={() => navigateToView("plans")}>
-              View Plans
+              {t("billing.page.subscriptionRequired.viewPlans")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import { changeLanguage } from "@/i18n/loadLanguage";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockWorkspaceStore = vi.hoisted(() => vi.fn());
@@ -36,8 +38,12 @@ vi.mock("@/lib/open-external-url", () => ({
 import { SubscriptionContent } from "../SubscriptionContent";
 
 describe("SubscriptionContent", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+
+    if (i18n.language !== "en") {
+      await changeLanguage("en");
+    }
 
     mockWorkspaceStore.mockReturnValue({
       selectedWorkspaceId: "ws-1",
@@ -300,6 +306,62 @@ describe("SubscriptionContent", () => {
       plusLabel.compareDocumentPosition(proLabel) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("renders the updated plan copy in Chinese", async () => {
+    await changeLanguage("zh-CN");
+
+    mockUseWorkspaceBillingOverview.mockReturnValue({
+      data: {
+        account: {
+          id: "acct_1",
+          ownerExternalId: "tenant:ws-1",
+          ownerType: "organization",
+          ownerName: "Alpha",
+          balance: 3000,
+          quota: 0,
+          quotaExpiresAt: null,
+          effectiveQuota: 0,
+          available: 3000,
+          creditLimit: 0,
+          status: "active",
+          metadata: null,
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+        subscription: null,
+        subscriptionProducts: [
+          {
+            stripePriceId: "price_plus",
+            name: "Plus Plan",
+            type: "subscription",
+            credits: 40000,
+            amountCents: 4000,
+            interval: "month",
+            intervalCount: 1,
+            active: true,
+            metadata: null,
+            display: {
+              badge: "Plus Plan",
+              description: "Best for flexible usage.",
+              features: ["Shared billing"],
+              sortOrder: 1,
+            },
+          },
+        ],
+        creditProducts: [],
+        recentTransactions: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SubscriptionContent />);
+
+    expect(await screen.findByText("选择你的方案")).toBeInTheDocument();
+    expect(screen.getByText("免费版")).toBeInTheDocument();
+    expect(screen.getByText("4,000 一次性点数")).toBeInTheDocument();
+    expect(screen.getByText("每月 40,000 点数")).toBeInTheDocument();
   });
 
   it("renders custom amount top-up and sends amountCents to checkout", async () => {

--- a/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
@@ -228,6 +228,80 @@ describe("SubscriptionContent", () => {
     ).toBeTruthy();
   });
 
+  it("renders plus before pro on the plan page", async () => {
+    mockUseWorkspaceBillingOverview.mockReturnValue({
+      data: {
+        account: {
+          id: "acct_1",
+          ownerExternalId: "tenant:ws-1",
+          ownerType: "organization",
+          ownerName: "Alpha",
+          balance: 3000,
+          quota: 0,
+          quotaExpiresAt: null,
+          effectiveQuota: 0,
+          available: 3000,
+          creditLimit: 0,
+          status: "active",
+          metadata: null,
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+        subscription: null,
+        subscriptionProducts: [
+          {
+            stripePriceId: "price_pro",
+            name: "Pro Plan",
+            type: "subscription",
+            credits: 200000,
+            amountCents: 20000,
+            interval: "month",
+            intervalCount: 1,
+            active: true,
+            metadata: null,
+            display: {
+              badge: "Pro Plan",
+              description: "Best for sustained team usage.",
+              features: ["Advanced controls"],
+              sortOrder: 1,
+            },
+          },
+          {
+            stripePriceId: "price_plus",
+            name: "Plus Plan",
+            type: "subscription",
+            credits: 40000,
+            amountCents: 4000,
+            interval: "month",
+            intervalCount: 1,
+            active: true,
+            metadata: null,
+            display: {
+              badge: "Plus Plan",
+              description: "Best for flexible usage.",
+              features: ["Shared billing"],
+              sortOrder: 2,
+            },
+          },
+        ],
+        creditProducts: [],
+        recentTransactions: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SubscriptionContent />);
+
+    const plusLabel = await screen.findByText("Plus Plan");
+    const proLabel = screen.getByText("Pro Plan");
+
+    expect(
+      plusLabel.compareDocumentPosition(proLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("renders custom amount top-up and sends amountCents to checkout", async () => {
     mockUseWorkspaceBillingOverview.mockReturnValue({
       data: {

--- a/apps/client/src/i18n/locales/en/workspace.json
+++ b/apps/client/src/i18n/locales/en/workspace.json
@@ -44,5 +44,90 @@
   "maxWorkspacesReached": "You can create a maximum of {{max}} workspaces. Please contact the administrator or reach out via our <discordLink>Discord</discordLink> for assistance.",
   "workspaceFull": "This workspace has reached the maximum of {{max}} members",
   "workspaceFullInvite": "Unable to join — this workspace has reached its member limit. Please contact the workspace administrator or reach out via our <discordLink>Discord</discordLink>.",
-  "expires": "Expires {{date}}"
+  "expires": "Expires {{date}}",
+  "billing": {
+    "interval": {
+      "day_one": "day",
+      "day_other": "{{count}} days",
+      "week_one": "week",
+      "week_other": "{{count}} weeks",
+      "month_one": "month",
+      "month_other": "{{count}} months",
+      "year_one": "year",
+      "year_other": "{{count}} years"
+    },
+    "plans": {
+      "creditsLabel": "{{credits}} credits",
+      "monthlyCredits": "{{credits}} credits per month",
+      "planCreditsWithCycle": "{{credits}} credits / {{cycle}}",
+      "creditsConfiguredInBillingHub": "Credits configured in Billing Hub",
+      "free": {
+        "title": "Free Plan",
+        "description": "Essential access to core models, research, and agent workflows.",
+        "features": {
+          "oneTimeCredits": "4,000 one-time credits",
+          "coreModels": "Access to core models",
+          "basicResearch": "Basic research",
+          "fileMemory": "Intelligent file and memory management",
+          "agentTools": "20+ tools for agents",
+          "multiAgent": "Multi-agent tasks",
+          "beta": "Early access to select beta features"
+        }
+      },
+      "plus": {
+        "description": "For regular usage with advanced models and premium agent tools.",
+        "features": {
+          "modelAccess": "Access to top frontier models, including GPT-5.4, Claude Opus 4.6, and Gemini 3.1 Pro",
+          "nanoBanana": "Nano Banana 2 included",
+          "fileMemory": "Intelligent file and memory management",
+          "premiumTools": "Access all premium tools for agents",
+          "multiAgent": "Concurrent multi-agent tasks",
+          "beta": "Early access to beta features",
+          "support": "Dedicated customer support"
+        }
+      },
+      "pro": {
+        "description": "For heavy workloads that need more credits and higher concurrency.",
+        "features": {
+          "modelAccess": "Access to top frontier models, including GPT-5.4, Claude Opus 4.6, and Gemini 3.1 Pro",
+          "nanoBanana": "Nano Banana 2 included",
+          "fileMemory": "Intelligent management of all files and memory",
+          "premiumTools": "Access all premium tools for agents",
+          "multiAgent": "High-concurrency multi-agent tasks",
+          "beta": "Early access to beta features",
+          "support": "Dedicated customer support"
+        }
+      },
+      "generic": {
+        "description": "Flexible billing for growing teams.",
+        "features": {
+          "sharedBilling": "Shared workspace billing controls for owners and admins",
+          "managedThroughBillingHub": "Managed through Billing Hub checkout and portal"
+        }
+      }
+    },
+    "page": {
+      "workspaceBilling": "{{workspace}} workspace billing",
+      "heading": "Choose your plan",
+      "subheading": "Select the plan that fits your workload.",
+      "exchangeRate": "1 USD = 1,000 credits across all plans.",
+      "subscriptionEnds": "The current subscription will end on {{date}}.",
+      "emptyPaidPlans": {
+        "title": "No paid plans configured",
+        "description": "Billing Hub does not currently expose any paid subscription products."
+      },
+      "actions": {
+        "manageBilling": "Manage billing",
+        "chooseFree": "Choose Free",
+        "currentPlan": "Current plan",
+        "choosePlan": "Choose {{plan}}"
+      },
+      "subscriptionRequired": {
+        "title": "Subscription Required",
+        "description": "You need an active subscription before purchasing credits. Please subscribe to a plan first.",
+        "cancel": "Cancel",
+        "viewPlans": "View Plans"
+      }
+    }
+  }
 }

--- a/apps/client/src/i18n/locales/zh-CN/workspace.json
+++ b/apps/client/src/i18n/locales/zh-CN/workspace.json
@@ -44,5 +44,90 @@
   "maxWorkspacesReached": "每位用户最多只能创建 {{max}} 个工作空间，请联系管理员或通过 <discordLink>Discord</discordLink> 获取帮助。",
   "workspaceFull": "该工作空间已达到 {{max}} 人的成员上限",
   "workspaceFullInvite": "无法加入——该工作空间已达到成员上限，请联系工作空间管理员或通过 <discordLink>Discord</discordLink> 联系我们。",
-  "expires": "{{date}} 过期"
+  "expires": "{{date}} 过期",
+  "billing": {
+    "interval": {
+      "day_one": "天",
+      "day_other": "{{count}} 天",
+      "week_one": "周",
+      "week_other": "{{count}} 周",
+      "month_one": "月",
+      "month_other": "{{count}} 个月",
+      "year_one": "年",
+      "year_other": "{{count}} 年"
+    },
+    "plans": {
+      "creditsLabel": "{{credits}} 点数",
+      "monthlyCredits": "每月 {{credits}} 点数",
+      "planCreditsWithCycle": "{{credits}} 点数 / {{cycle}}",
+      "creditsConfiguredInBillingHub": "点数额度在 Billing Hub 中配置",
+      "free": {
+        "title": "免费版",
+        "description": "提供核心模型、研究和智能体工作流的基础能力。",
+        "features": {
+          "oneTimeCredits": "4,000 一次性点数",
+          "coreModels": "访问核心模型",
+          "basicResearch": "基础研究",
+          "fileMemory": "智能文件与记忆管理",
+          "agentTools": "20+ 个智能体工具",
+          "multiAgent": "多智能体任务",
+          "beta": "抢先体验精选 Beta 功能"
+        }
+      },
+      "plus": {
+        "description": "适合日常使用，提供高级模型与付费智能体工具。",
+        "features": {
+          "modelAccess": "可访问顶级前沿模型，包括 GPT-5.4、Claude Opus 4.6 和 Gemini 3.1 Pro",
+          "nanoBanana": "包含 Nano Banana 2",
+          "fileMemory": "智能文件与记忆管理",
+          "premiumTools": "可使用全部高级智能体工具",
+          "multiAgent": "支持并发多智能体任务",
+          "beta": "抢先体验 Beta 功能",
+          "support": "专属客户支持"
+        }
+      },
+      "pro": {
+        "description": "适合高负载场景，提供更高额度和更高并发能力。",
+        "features": {
+          "modelAccess": "可访问顶级前沿模型，包括 GPT-5.4、Claude Opus 4.6 和 Gemini 3.1 Pro",
+          "nanoBanana": "包含 Nano Banana 2",
+          "fileMemory": "全面智能管理所有文件与记忆",
+          "premiumTools": "可使用全部高级智能体工具",
+          "multiAgent": "高并发多智能体任务",
+          "beta": "抢先体验 Beta 功能",
+          "support": "专属客户支持"
+        }
+      },
+      "generic": {
+        "description": "为成长中的团队提供更灵活的计费方案。",
+        "features": {
+          "sharedBilling": "为所有者和管理员提供共享工作空间计费控制",
+          "managedThroughBillingHub": "通过 Billing Hub 结账和门户统一管理"
+        }
+      }
+    },
+    "page": {
+      "workspaceBilling": "{{workspace}} 工作空间计费",
+      "heading": "选择你的方案",
+      "subheading": "选择最适合你当前工作负载的套餐。",
+      "exchangeRate": "所有套餐均为 1 美元 = 1,000 点数。",
+      "subscriptionEnds": "当前订阅将于 {{date}} 结束。",
+      "emptyPaidPlans": {
+        "title": "暂未配置付费方案",
+        "description": "Billing Hub 当前还没有暴露任何可订阅的付费产品。"
+      },
+      "actions": {
+        "manageBilling": "管理计费",
+        "chooseFree": "选择免费版",
+        "currentPlan": "当前方案",
+        "choosePlan": "选择 {{plan}}"
+      },
+      "subscriptionRequired": {
+        "title": "需要订阅",
+        "description": "购买点数前需要先开通一个有效订阅，请先选择并订阅套餐。",
+        "cancel": "取消",
+        "viewPlans": "查看方案"
+      }
+    }
+  }
 }

--- a/apps/client/src/routes/_authenticated/onboarding.tsx
+++ b/apps/client/src/routes/_authenticated/onboarding.tsx
@@ -113,7 +113,7 @@ export const Route = createFileRoute("/_authenticated/onboarding")({
 function OnboardingRoute() {
   const navigate = useNavigate();
   const search = Route.useSearch();
-  const { t: rawT, i18n } = useTranslation("onboarding");
+  const { t: rawT, i18n } = useTranslation(["onboarding", "workspace"]);
   const t = rawT as unknown as TranslateFn;
   const selectedWorkspaceId = useSelectedWorkspaceId();
   const { data: workspaces = [] } = useUserWorkspaces();

--- a/apps/client/src/routes/_authenticated/onboarding.tsx
+++ b/apps/client/src/routes/_authenticated/onboarding.tsx
@@ -906,20 +906,6 @@ function OnboardingRoute() {
               </p>
             </div>
 
-            {currentStep === 6 && (
-              <div className="mt-2 grid max-w-[320px] gap-2 rounded-[24px] border border-slate-200/90 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(243,247,253,0.84))] p-5 text-slate-700 shadow-[0_18px_42px_rgba(100,116,139,0.1)]">
-                <strong className="text-base text-slate-800">
-                  {workspace?.name ?? t("workspaceFallback")}
-                </strong>
-                <p className="text-sm leading-6 text-slate-600/85">
-                  {t("plan.note")}
-                </p>
-                <span className="text-sm leading-6 text-slate-500">
-                  {t("welcome")}
-                </span>
-              </div>
-            )}
-
             {currentStep > 1 && (
               <div className="mt-auto hidden lg:flex">
                 <GhostButton
@@ -1783,6 +1769,18 @@ function StepSix({
 
   return (
     <div className="grid gap-6">
+      {!checkoutCompleted ? (
+        <div className="flex w-full justify-end">
+          <GhostButton
+            onClick={onContinueWithoutPlan}
+            disabled={checkoutPending}
+            className="bg-white/86 text-slate-600"
+          >
+            {t("actions.continueWithoutPlan")}
+          </GhostButton>
+        </div>
+      ) : null}
+
       {checkoutCompleted ? (
         <div className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-700">
           {t("plan.success")}
@@ -1844,8 +1842,8 @@ function StepSix({
         </div>
       ) : null}
 
-      <StepActionDock>
-        {checkoutCompleted ? (
+      {checkoutCompleted ? (
+        <StepActionDock>
           <ContinueButton
             onClick={onFinish}
             disabled={checkoutPending}
@@ -1853,16 +1851,8 @@ function StepSix({
           >
             {t("actions.finish")}
           </ContinueButton>
-        ) : (
-          <GhostButton
-            onClick={onContinueWithoutPlan}
-            disabled={checkoutPending}
-            className="bg-white/86 text-slate-600"
-          >
-            {t("actions.continueWithoutPlan")}
-          </GhostButton>
-        )}
-      </StepActionDock>
+        </StepActionDock>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a new Plus plan tier between Free and Pro in billing
- Internationalize plan features and apply per-tier theming to plan cards
- Relocate continue-without-plan button in onboarding step 6
- Use PostHog default reset to preserve device id

## Test plan
- [ ] Verify plan cards render correctly for Free / Plus / Pro tiers in EN and zh-CN
- [ ] Verify onboarding step 6 continue-without-plan button placement
- [ ] Verify PostHog identity behavior on logout preserves device id
- [ ] Run SubscriptionContent tests