### PR TITLE
feat(billing): open workspace billing overview to all members

### DIFF
--- a/apps/client/src/components/layout/contents/HomeMainContent.tsx
+++ b/apps/client/src/components/layout/contents/HomeMainContent.tsx
@@ -373,10 +373,7 @@ export function HomeMainContent() {
   const { agents, updateAgentModel, updatingAgentUserId } =
     useDashboardAgents(directChannels);
   const billingSummary = useWorkspaceBillingSummary(workspaceId ?? undefined);
-  const billingOverview = useWorkspaceBillingOverview(
-    workspaceId ?? undefined,
-    billingSummary.data?.managementAllowed ?? false,
-  );
+  const billingOverview = useWorkspaceBillingOverview(workspaceId ?? undefined);
   const [prompt, setPrompt] = useState("");
   const [selectedAgentUserId, setSelectedAgentUserId] = useState<string | null>(
     null,
@@ -395,12 +392,9 @@ export function HomeMainContent() {
     !!selectedAgent && updatingAgentUserId === selectedAgent.userId;
   const currentPlanLabel =
     billingSummary.data?.subscription?.product.name || t("dashboardPlan");
-  const creditsLabel =
-    billingSummary.data?.managementAllowed && billingOverview.data?.account
-      ? formatDashboardCredits(
-          getWorkspaceCredits(billingOverview.data.account),
-        )
-      : "—";
+  const creditsLabel = billingOverview.data?.account
+    ? formatDashboardCredits(getWorkspaceCredits(billingOverview.data.account))
+    : "—";
 
   useEffect(() => {
     setSelectedAgentUserId((current) => {

--- a/apps/client/src/components/layout/contents/SubscriptionContent.tsx
+++ b/apps/client/src/components/layout/contents/SubscriptionContent.tsx
@@ -252,7 +252,7 @@ export function SubscriptionContent({
   const canManageBilling =
     currentWorkspace?.role === "owner" || currentWorkspace?.role === "admin";
 
-  const overview = useWorkspaceBillingOverview(workspaceId, canManageBilling);
+  const overview = useWorkspaceBillingOverview(workspaceId);
   const checkout = useCreateWorkspaceBillingCheckout(workspaceId);
   const portal = useCreateWorkspaceBillingPortal(workspaceId);
 

--- a/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
@@ -328,4 +328,29 @@ describe("HomeMainContent", () => {
     expect(screen.getByText("Free plan")).toBeInTheDocument();
     expect(screen.getByText("—")).toBeInTheDocument();
   });
+
+  it("shows the workspace credit balance to non-managing members", () => {
+    // Members cannot manage billing but must still see the balance they
+    // themselves consume when sending messages or running agents.
+    mockUseWorkspaceBillingSummary.mockReturnValue({
+      data: {
+        subscription: { product: { name: "Starter" } },
+        managementAllowed: false,
+      },
+    });
+    mockUseWorkspaceBillingOverview.mockReturnValue({
+      data: {
+        account: {
+          balance: 1000,
+          grantBalance: 200,
+          effectiveQuota: 50,
+        },
+      },
+    });
+
+    renderWithProviders(<HomeMainContent />);
+
+    expect(screen.getByText("1,250")).toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+  });
 });

--- a/apps/client/src/hooks/useWorkspaceBilling.ts
+++ b/apps/client/src/hooks/useWorkspaceBilling.ts
@@ -1,14 +1,11 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import workspaceApi from "@/services/api/workspace";
 
-export function useWorkspaceBillingOverview(
-  workspaceId: string | undefined,
-  enabled = true,
-) {
+export function useWorkspaceBillingOverview(workspaceId: string | undefined) {
   return useQuery({
     queryKey: ["workspace-billing-overview", workspaceId],
     queryFn: () => workspaceApi.getBillingOverview(workspaceId!),
-    enabled: !!workspaceId && enabled,
+    enabled: !!workspaceId,
   });
 }
 

--- a/apps/server/apps/gateway/src/billing-hub/billing-hub.service.spec.ts
+++ b/apps/server/apps/gateway/src/billing-hub/billing-hub.service.spec.ts
@@ -269,4 +269,136 @@ describe('BillingHubService', () => {
       service.getWorkspaceSubscription('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14'),
     ).rejects.toBeInstanceOf(ServiceUnavailableException);
   });
+
+  describe('getWorkspaceOverview', () => {
+    const workspaceId = '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14';
+
+    // Dispatches mock responses based on the upstream URL so tests stay
+    // robust to the parallel-call order inside getWorkspaceOverview.
+    function installOverviewFetchMock() {
+      (global.fetch as jest.Mock).mockImplementation((url: any) => {
+        const urlString = String(url);
+        let data: unknown;
+
+        if (urlString.includes('/api/billing/account/transactions')) {
+          data = {
+            transactions: [
+              {
+                id: 'txn_1',
+                accountId: 'acct_1',
+                type: 'charge',
+                amount: -100,
+                balanceBefore: 500,
+                balanceAfter: 400,
+                operatorExternalId: 'user:op_1',
+                agentId: null,
+                referenceType: 'message',
+                referenceId: 'msg_1',
+                description: 'LLM usage',
+                createdAt: '2026-04-01T00:00:00.000Z',
+                productName: null,
+                paymentAmountCents: null,
+                invoiceId: 'in_1',
+              },
+            ],
+          };
+        } else if (urlString.includes('/api/billing/account')) {
+          data = {
+            account: {
+              id: 'acct_1',
+              ownerExternalId: `tenant:${workspaceId}`,
+              ownerType: 'organization',
+              ownerName: 'Team9',
+              balance: 400,
+              grantBalance: 0,
+              quota: 0,
+              quotaExpiresAt: null,
+              effectiveQuota: 0,
+              available: 400,
+              creditLimit: 0,
+              status: 'active',
+              metadata: null,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-04-01T00:00:00.000Z',
+            },
+          };
+        } else if (urlString.includes('/api/billing/stripe/subscription')) {
+          data = { subscription: null };
+        } else if (urlString.includes('/api/billing/stripe/products')) {
+          data = [];
+        } else {
+          throw new Error(`Unexpected URL in overview test: ${urlString}`);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ success: true, data })),
+        });
+      });
+    }
+
+    it('returns transactions when the caller is the workspace owner', async () => {
+      installOverviewFetchMock();
+
+      const overview = await service.getWorkspaceOverview(workspaceId, 'owner');
+
+      expect(overview.recentTransactions).toHaveLength(1);
+      expect(overview.recentTransactions[0].id).toBe('txn_1');
+      expect(overview.account?.balance).toBe(400);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/billing/account/transactions'),
+        expect.anything(),
+      );
+    });
+
+    it('returns transactions when the caller is a workspace admin', async () => {
+      installOverviewFetchMock();
+
+      const overview = await service.getWorkspaceOverview(workspaceId, 'admin');
+
+      expect(overview.recentTransactions).toHaveLength(1);
+    });
+
+    it('omits transactions and skips the transactions fetch for regular members', async () => {
+      installOverviewFetchMock();
+
+      const overview = await service.getWorkspaceOverview(
+        workspaceId,
+        'member',
+      );
+
+      expect(overview.recentTransactions).toEqual([]);
+      // Members still see account balance and plan info
+      expect(overview.account?.balance).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/billing/account/transactions'),
+        expect.anything(),
+      );
+    });
+
+    it('omits transactions for guests', async () => {
+      installOverviewFetchMock();
+
+      const overview = await service.getWorkspaceOverview(workspaceId, 'guest');
+
+      expect(overview.recentTransactions).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/billing/account/transactions'),
+        expect.anything(),
+      );
+    });
+
+    it('defaults to the restricted view when no role is provided', async () => {
+      installOverviewFetchMock();
+
+      const overview = await service.getWorkspaceOverview(workspaceId);
+
+      expect(overview.recentTransactions).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/billing/account/transactions'),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/apps/server/apps/gateway/src/billing-hub/billing-hub.service.ts
+++ b/apps/server/apps/gateway/src/billing-hub/billing-hub.service.ts
@@ -119,6 +119,8 @@ export interface WorkspaceBillingOverview {
 
 type BillingView = 'plans' | 'credits';
 
+type WorkspaceRole = 'owner' | 'admin' | 'member' | 'guest';
+
 @Injectable()
 export class BillingHubService {
   private readonly logger = new Logger(BillingHubService.name);
@@ -205,7 +207,13 @@ export class BillingHubService {
 
   async getWorkspaceOverview(
     workspaceId: string,
+    role?: WorkspaceRole,
   ): Promise<WorkspaceBillingOverview> {
+    // Transaction history carries audit data (invoice IDs, operator IDs)
+    // that should stay scoped to billing managers; balance and plan info
+    // stay visible to every workspace member.
+    const canViewTransactions = role === 'owner' || role === 'admin';
+
     const [
       account,
       subscription,
@@ -217,7 +225,9 @@ export class BillingHubService {
       this.getWorkspaceSubscription(workspaceId),
       this.listSubscriptionProducts(),
       this.listOneTimeProducts(),
-      this.listWorkspaceTransactions(workspaceId),
+      canViewTransactions
+        ? this.listWorkspaceTransactions(workspaceId)
+        : Promise.resolve<WorkspaceBillingTransaction[]>([]),
     ]);
 
     return {

--- a/apps/server/apps/gateway/src/workspace/workspace-billing.controller.spec.ts
+++ b/apps/server/apps/gateway/src/workspace/workspace-billing.controller.spec.ts
@@ -101,22 +101,61 @@ describe('WorkspaceBillingController', () => {
     );
   });
 
-  it('delegates overview loading to BillingHubService', async () => {
-    await controller.getOverview('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14');
-
-    expect(billingHubService.getWorkspaceOverview).toHaveBeenCalledWith(
+  it('forwards the requesting workspace role to BillingHubService for overview', async () => {
+    await controller.getOverview('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14', {
+      workspaceRole: 'owner',
+    });
+    expect(billingHubService.getWorkspaceOverview).toHaveBeenLastCalledWith(
       '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      'owner',
+    );
+
+    await controller.getOverview('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14', {
+      workspaceRole: 'admin',
+    });
+    expect(billingHubService.getWorkspaceOverview).toHaveBeenLastCalledWith(
+      '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      'admin',
+    );
+
+    await controller.getOverview('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14', {
+      workspaceRole: 'member',
+    });
+    expect(billingHubService.getWorkspaceOverview).toHaveBeenLastCalledWith(
+      '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      'member',
+    );
+
+    await controller.getOverview('72ecfcd7-d495-43a4-8b8a-8fda2d9cec14', {
+      workspaceRole: 'guest',
+    });
+    expect(billingHubService.getWorkspaceOverview).toHaveBeenLastCalledWith(
+      '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      'guest',
     );
   });
 
-  it('marks overview, checkout and portal endpoints as owner/admin only', () => {
+  it('forwards undefined role when workspaceRole is missing from the request', async () => {
+    await controller.getOverview(
+      '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      {} as { workspaceRole?: string },
+    );
+    expect(billingHubService.getWorkspaceOverview).toHaveBeenLastCalledWith(
+      '72ecfcd7-d495-43a4-8b8a-8fda2d9cec14',
+      undefined,
+    );
+  });
+
+  it('does not gate overview reads behind owner/admin metadata', () => {
     expect(
       Reflect.getMetadata(
         WORKSPACE_ROLES_KEY,
         WorkspaceBillingController.prototype.getOverview,
       ),
-    ).toEqual(['owner', 'admin']);
+    ).toBeUndefined();
+  });
 
+  it('still restricts checkout and portal mutations to owners and admins', () => {
     expect(
       Reflect.getMetadata(
         WORKSPACE_ROLES_KEY,

--- a/apps/server/apps/gateway/src/workspace/workspace-billing.controller.ts
+++ b/apps/server/apps/gateway/src/workspace/workspace-billing.controller.ts
@@ -49,10 +49,22 @@ export class WorkspaceBillingController {
   }
 
   @Get(':workspaceId/billing/overview')
-  @UseGuards(AuthGuard, WorkspaceGuard, WorkspaceRoleGuard)
-  @WorkspaceRoles('owner', 'admin')
-  async getOverview(@Param('workspaceId', ParseUUIDPipe) workspaceId: string) {
-    return this.billingHubService.getWorkspaceOverview(workspaceId);
+  @UseGuards(AuthGuard, WorkspaceGuard)
+  async getOverview(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: string,
+    @Req() request: { workspaceRole?: string },
+  ) {
+    // Every workspace member can read the overview; the service filters
+    // audit-sensitive fields (transaction history) for non-managers.
+    return this.billingHubService.getWorkspaceOverview(
+      workspaceId,
+      request.workspaceRole as
+        | 'owner'
+        | 'admin'
+        | 'member'
+        | 'guest'
+        | undefined,
+    );
   }
 
   @Post(':workspaceId/billing/checkout')


### PR DESCRIPTION
## Summary
- Remove owner/admin role gate on `GET /v1/workspaces/:id/billing/overview` so every workspace member can read the balance and plan they themselves consume. Mutations (checkout, portal) still require owner/admin.
- Move the audit boundary into the service: `BillingHubService.getWorkspaceOverview(workspaceId, role?)` still restricts `recentTransactions` (invoice IDs, operator IDs) to owner/admin and skips the upstream fetch for other roles.
- Drop the `enabled` short-circuit in the `useWorkspaceBillingOverview` hook and the `managementAllowed` gate on the dashboard credit label, so non-managing members see the actual balance instead of an em dash.

## Motivation
Non-managing members still consume the workspace balance (messages, agents), so hiding that number from them was a UX defect, not a security boundary. Payment-method and transaction-history endpoints remain protected.

## Test plan
- [x] Backend unit tests: role branching for `getWorkspaceOverview` (owner/admin/member/guest/undefined) and role forwarding in the controller, plus regression checks that checkout/portal still require owner/admin. 19/19 green.
- [x] Frontend unit tests: new assertion that a non-managing member with an account sees the formatted credits (and no em dash). 17/17 green.
- [x] End-to-end smoke in the running app once Billing Hub upstream was brought up locally.