### PR TITLE
fix(test): wrap MessageAttachments test in QueryClientProvider

### DIFF
--- a/apps/client/src/components/channel/__tests__/MessageAttachments.test.tsx
+++ b/apps/client/src/components/channel/__tests__/MessageAttachments.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MessageAttachments } from "../MessageAttachments";
 import { fileApi } from "@/services/api/file";
 import type { MessageAttachment } from "@/types/im";
@@ -9,6 +10,25 @@ vi.mock("@/services/api/file", () => ({
     getDownloadUrl: vi.fn(),
   },
 }));
+
+function renderWithQuery(ui: React.ReactElement) {
+  // Fresh client per render so cached download URLs from one test don't
+  // leak into the next. retry:false short-circuits TanStack's exponential
+  // back-off so failed-query assertions stay deterministic.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+  return {
+    ...result,
+    rerender: (next: React.ReactElement) =>
+      result.rerender(
+        <QueryClientProvider client={queryClient}>{next}</QueryClientProvider>,
+      ),
+  };
+}
 
 function makeImageAttachment(
   overrides: Partial<MessageAttachment> = {},
@@ -45,7 +65,7 @@ describe("MessageAttachments", () => {
         expiresAt: "2026-04-03T00:00:00Z",
       });
 
-    const { rerender } = render(
+    const { rerender } = renderWithQuery(
       <MessageAttachments attachments={[makeImageAttachment()]} />,
     );
 


### PR DESCRIPTION
## Summary
- Pre-existing CI failure on dev: `apps/client/src/components/channel/__tests__/MessageAttachments.test.tsx > reloads the preview when the file key changes in the same slot` failed with `No QueryClient set, use QueryClientProvider to set one`
- `MessageAttachments` uses `useQuery` (via `useFileDownloadUrl`) to fetch signed download URLs (commit \`a6231705\` introduced this) but the test rendered the component bare without a `QueryClientProvider`
- This PR wraps the test in a fresh-per-render `QueryClient` + `QueryClientProvider`, mirroring the existing helper pattern in `MessageItem.avatar.test.tsx` and `MessageItem.agent-event.test.tsx`
- Also wraps `rerender` so the second render shares the same client

Surfaced while working on team9 PR #34 — CI was red on every PR because dev itself is red. Fixing here unblocks the routine-creation PR's CI signal.

## Test plan
- [x] `pnpm --filter '@team9/client' test -- MessageAttachments` → 1 passed (was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)