### PR TITLE
feat(gateway/routines): carry creator's language in routine-creation

### DIFF
--- a/apps/server/apps/gateway/src/applications/applications.module.ts
+++ b/apps/server/apps/gateway/src/applications/applications.module.ts
@@ -5,6 +5,7 @@ import { WebsocketModule } from '../im/websocket/websocket.module.js';
 import { RedisModule } from '@team9/redis';
 import { ClawHiveModule } from '@team9/claw-hive';
 import { AiClientModule } from '@team9/ai-client';
+import { UsersModule } from '../im/users/users.module.js';
 import { ApplicationsController } from './applications.controller.js';
 import { ApplicationsService } from './applications.service.js';
 import { InstalledApplicationsController } from './installed-applications.controller.js';
@@ -27,6 +28,7 @@ import {
     RedisModule,
     ClawHiveModule,
     AiClientModule,
+    UsersModule,
   ],
   controllers: [
     ApplicationsController,

--- a/apps/server/apps/gateway/src/applications/applications.module.ts
+++ b/apps/server/apps/gateway/src/applications/applications.module.ts
@@ -28,7 +28,7 @@ import {
     RedisModule,
     ClawHiveModule,
     AiClientModule,
-    UsersModule,
+    forwardRef(() => UsersModule),
   ],
   controllers: [
     ApplicationsController,

--- a/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
@@ -26,6 +26,7 @@ import { ClawHiveService } from '@team9/claw-hive';
 import { RedisService } from '@team9/redis';
 import { ChannelsService } from '../im/channels/channels.service.js';
 import { InstalledApplicationsService } from './installed-applications.service.js';
+import { UsersService } from '../im/users/users.service.js';
 import type {
   CreateCommonStaffDto,
   UpdateCommonStaffDto,
@@ -259,6 +260,7 @@ describe('CommonStaffService', () => {
   };
   let channelsService: { createDirectChannel: MockFn };
   let installedApplicationsService: { findById: MockFn };
+  let usersService: { getLocalePreferences: MockFn };
 
   beforeEach(async () => {
     db = mockDb();
@@ -293,6 +295,12 @@ describe('CommonStaffService', () => {
       findById: jest.fn<any>().mockResolvedValue(makeInstalledApp()),
     };
 
+    usersService = {
+      getLocalePreferences: jest
+        .fn<any>()
+        .mockResolvedValue({ language: null, timeZone: null }),
+    };
+
     // Default: streamText returns text stream (for generatePersona)
     // Candidate tests override with mockStreamTextWithOutputReturn
     mockStreamText.mockReset();
@@ -311,6 +319,7 @@ describe('CommonStaffService', () => {
           provide: InstalledApplicationsService,
           useValue: installedApplicationsService,
         },
+        { provide: UsersService, useValue: usersService },
         {
           provide: RedisService,
           useValue: {
@@ -524,26 +533,10 @@ describe('CommonStaffService', () => {
       });
 
       it("includes the mentor's persisted language + timeZone in team9Context when set", async () => {
-        // Stub the private `getUserLocale` helper directly — the DB query
-        // mock queue is shared with earlier createStaff steps and threading
-        // a locale-shaped row through it is fragile. The contract we care
-        // about here is "whatever getUserLocale returns gets spread into
-        // team9Context", so stubbing the helper is both cleaner and
-        // tighter.
-        const getUserLocaleSpy = jest
-          .spyOn(
-            service as unknown as {
-              getUserLocale: (userId: string) => Promise<{
-                language: string | null;
-                timeZone: string | null;
-              }>;
-            },
-            'getUserLocale',
-          )
-          .mockResolvedValue({
-            language: 'pt-BR',
-            timeZone: 'America/Sao_Paulo',
-          });
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: 'pt-BR',
+          timeZone: 'America/Sao_Paulo',
+        });
 
         const dto = makeCreateDto({
           agenticBootstrap: true,
@@ -551,9 +544,11 @@ describe('CommonStaffService', () => {
         });
         await service.createStaff(INSTALLED_APP_ID, TENANT_ID, OWNER_ID, dto);
 
-        // The helper must be called with the MENTOR id, not the owner —
-        // common-staff mentor can differ from the creator of the bot.
-        expect(getUserLocaleSpy).toHaveBeenCalledWith(MENTOR_ID);
+        // The service must call getLocalePreferences with the MENTOR id, not the
+        // owner — common-staff mentor can differ from the creator of the bot.
+        expect(usersService.getLocalePreferences).toHaveBeenCalledWith(
+          MENTOR_ID,
+        );
 
         const call = clawHiveService.sendInput.mock.calls[0];
         const event = call[1] as {
@@ -568,23 +563,11 @@ describe('CommonStaffService', () => {
           language: 'pt-BR',
           timeZone: 'America/Sao_Paulo',
         });
-
-        getUserLocaleSpy.mockRestore();
       });
 
       it('omits language and timeZone from team9Context when the mentor has no preferences', async () => {
-        const getUserLocaleSpy = jest
-          .spyOn(
-            service as unknown as {
-              getUserLocale: (userId: string) => Promise<{
-                language: string | null;
-                timeZone: string | null;
-              }>;
-            },
-            'getUserLocale',
-          )
-          .mockResolvedValue({ language: null, timeZone: null });
-
+        // Default mock already returns { language: null, timeZone: null } —
+        // no override needed.
         const dto = makeCreateDto({
           agenticBootstrap: true,
           mentorId: MENTOR_ID,
@@ -597,8 +580,6 @@ describe('CommonStaffService', () => {
         };
         expect(event.payload.team9Context).not.toHaveProperty('language');
         expect(event.payload.team9Context).not.toHaveProperty('timeZone');
-
-        getUserLocaleSpy.mockRestore();
       });
 
       it('does not trigger sendInput when agenticBootstrap=false', async () => {

--- a/apps/server/apps/gateway/src/applications/common-staff.service.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.service.ts
@@ -18,6 +18,7 @@ import { BotService } from '../bot/bot.service.js';
 import { ChannelsService } from '../im/channels/channels.service.js';
 import { InstalledApplicationsService } from './installed-applications.service.js';
 import { StaffService, type StaffBotResult } from './staff.service.js';
+import { UsersService } from '../im/users/users.service.js';
 import type {
   CreateCommonStaffDto,
   UpdateCommonStaffDto,
@@ -45,33 +46,8 @@ export class CommonStaffService {
     private readonly channelsService: ChannelsService,
     private readonly installedApplicationsService: InstalledApplicationsService,
     private readonly staffService: StaffService,
+    private readonly usersService: UsersService,
   ) {}
-
-  /**
-   * Read a user's persisted locale preferences for bootstrap event payloads.
-   *
-   * Both columns are nullable; this helper returns `{ language: null, timeZone: null }`
-   * when the user row does not exist or has not yet reported preferences.
-   * Callers pass the returned values into `team9Context` only when non-null
-   * so the agent-side default ("unknown → English") kicks in cleanly.
-   */
-  private async getUserLocale(
-    userId: string,
-  ): Promise<{ language: string | null; timeZone: string | null }> {
-    const rows = await this.db
-      .select({
-        language: schema.users.language,
-        timeZone: schema.users.timeZone,
-      })
-      .from(schema.users)
-      .where(eq(schema.users.id, userId))
-      .limit(1);
-    const row = rows[0];
-    return {
-      language: row?.language ?? null,
-      timeZone: row?.timeZone ?? null,
-    };
-  }
 
   /**
    * Create a new common-staff bot for a workspace.
@@ -202,7 +178,8 @@ export class CommonStaffService {
           // agent can greet them in the right language and format times in
           // the right zone. Both columns are nullable; when unset the agent
           // falls back to English + no zone hint.
-          const locale = await this.getUserLocale(effectiveMentorId);
+          const locale =
+            await this.usersService.getLocalePreferences(effectiveMentorId);
 
           const sessionId = `team9/${tenantId}/${result.agentId}/dm/${mentorDmChannel.id}`;
           await this.clawHiveService.sendInput(

--- a/apps/server/apps/gateway/src/applications/personal-staff.service.spec.ts
+++ b/apps/server/apps/gateway/src/applications/personal-staff.service.spec.ts
@@ -28,6 +28,7 @@ import { ClawHiveService } from '@team9/claw-hive';
 import { RedisService } from '@team9/redis';
 import { ChannelsService } from '../im/channels/channels.service.js';
 import { InstalledApplicationsService } from './installed-applications.service.js';
+import { UsersService } from '../im/users/users.service.js';
 import type {
   CreatePersonalStaffDto,
   UpdatePersonalStaffDto,
@@ -213,6 +214,7 @@ describe('PersonalStaffService', () => {
   };
   let channelsService: { createDirectChannelsBatch: MockFn };
   let installedApplicationsService: { findById: MockFn };
+  let usersService: { getLocalePreferences: MockFn };
 
   beforeEach(async () => {
     db = mockDb();
@@ -245,6 +247,12 @@ describe('PersonalStaffService', () => {
       findById: jest.fn<any>().mockResolvedValue(makeInstalledApp()),
     };
 
+    usersService = {
+      getLocalePreferences: jest
+        .fn<any>()
+        .mockResolvedValue({ language: null, timeZone: null }),
+    };
+
     mockStreamText.mockReset();
     mockStreamText.mockReturnValue(mockStreamTextReturn(['Hello', ' world']));
 
@@ -269,6 +277,7 @@ describe('PersonalStaffService', () => {
           provide: InstalledApplicationsService,
           useValue: installedApplicationsService,
         },
+        { provide: UsersService, useValue: usersService },
       ],
     }).compile();
 
@@ -614,18 +623,17 @@ describe('PersonalStaffService', () => {
       });
 
       it("includes the owner's persisted language + timeZone in team9Context when set", async () => {
-        // Queue two results: (1) findPersonalStaffBot must see no existing
-        // bot, (2) getUserLocale must see the mentor's preferences row.
-        // `mockResolvedValueOnce` values are consumed FIFO before the
-        // sticky `mockResolvedValue([])` default from the describe-level
-        // beforeEach.
-        db.limit.mockResolvedValueOnce([]);
-        db.limit.mockResolvedValueOnce([
-          { language: 'zh-CN', timeZone: 'Asia/Shanghai' },
-        ]);
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: 'zh-CN',
+          timeZone: 'Asia/Shanghai',
+        });
 
         const dto = makeCreateDto();
         await service.createStaff(INSTALLED_APP_ID, TENANT_ID, OWNER_ID, dto);
+
+        expect(usersService.getLocalePreferences).toHaveBeenCalledWith(
+          OWNER_ID,
+        );
 
         const call = clawHiveService.sendInput.mock.calls[0];
         const event = call[1] as {
@@ -643,7 +651,7 @@ describe('PersonalStaffService', () => {
       });
 
       it('omits language and timeZone from team9Context when the owner has no preferences set', async () => {
-        // Default db.limit mock returns [] → getUserLocale returns nulls →
+        // Default usersService.getLocalePreferences mock returns { language: null, timeZone: null } →
         // neither key is spread into team9Context.
         const dto = makeCreateDto();
         await service.createStaff(INSTALLED_APP_ID, TENANT_ID, OWNER_ID, dto);

--- a/apps/server/apps/gateway/src/applications/personal-staff.service.ts
+++ b/apps/server/apps/gateway/src/applications/personal-staff.service.ts
@@ -18,6 +18,7 @@ import { ClawHiveService } from '@team9/claw-hive';
 import { ChannelsService } from '../im/channels/channels.service.js';
 import { InstalledApplicationsService } from './installed-applications.service.js';
 import { StaffService, type StaffBotResult } from './staff.service.js';
+import { UsersService } from '../im/users/users.service.js';
 import type {
   CreatePersonalStaffDto,
   UpdatePersonalStaffDto,
@@ -55,6 +56,7 @@ export class PersonalStaffService {
     private readonly channelsService: ChannelsService,
     private readonly installedApplicationsService: InstalledApplicationsService,
     private readonly staffService: StaffService,
+    private readonly usersService: UsersService,
   ) {}
 
   /**
@@ -98,32 +100,6 @@ export class PersonalStaffService {
       .limit(1);
 
     return rows[0] ?? null;
-  }
-
-  /**
-   * Read a user's persisted locale preferences for bootstrap event payloads.
-   *
-   * Both columns are nullable; this helper returns `{ language: null, timeZone: null }`
-   * when the user row does not exist or has not yet reported preferences.
-   * Callers pass the returned values into `team9Context` only when non-null
-   * so the agent-side default ("unknown → English") kicks in cleanly.
-   */
-  private async getUserLocale(
-    userId: string,
-  ): Promise<{ language: string | null; timeZone: string | null }> {
-    const rows = await this.db
-      .select({
-        language: schema.users.language,
-        timeZone: schema.users.timeZone,
-      })
-      .from(schema.users)
-      .where(eq(schema.users.id, userId))
-      .limit(1);
-    const row = rows[0];
-    return {
-      language: row?.language ?? null,
-      timeZone: row?.timeZone ?? null,
-    };
   }
 
   /**
@@ -295,7 +271,7 @@ export class PersonalStaffService {
           // agent can greet them in the right language and format times in
           // the right zone. Both columns are nullable; when unset the agent
           // falls back to English + no zone hint.
-          const locale = await this.getUserLocale(ownerId);
+          const locale = await this.usersService.getLocalePreferences(ownerId);
 
           const sessionId = `team9/${tenantId}/${result.agentId}/dm/${ownerDmChannel.id}`;
           await this.clawHiveService.sendInput(

--- a/apps/server/apps/gateway/src/im/users/users.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/users/users.service.spec.ts
@@ -694,6 +694,52 @@ describe('UsersService', () => {
     });
   });
 
+  describe('getLocalePreferences', () => {
+    it('returns both fields when the user has language and timeZone set', async () => {
+      db.__state.selectResults.push([
+        { language: 'zh-CN', timeZone: 'Asia/Shanghai' },
+      ]);
+
+      const result = await service.getLocalePreferences('user-1');
+
+      expect(result).toEqual({ language: 'zh-CN', timeZone: 'Asia/Shanghai' });
+    });
+
+    it('returns { language: null, timeZone: null } when the user row does not exist', async () => {
+      db.__state.selectResults.push([]);
+
+      const result = await service.getLocalePreferences('missing-user');
+
+      expect(result).toEqual({ language: null, timeZone: null });
+    });
+
+    it('returns the null-correct tuple when only language is set', async () => {
+      db.__state.selectResults.push([{ language: 'zh-CN', timeZone: null }]);
+
+      const result = await service.getLocalePreferences('user-1');
+
+      expect(result).toEqual({ language: 'zh-CN', timeZone: null });
+    });
+
+    it('returns the null-correct tuple when only timeZone is set', async () => {
+      db.__state.selectResults.push([
+        { language: null, timeZone: 'America/Sao_Paulo' },
+      ]);
+
+      const result = await service.getLocalePreferences('user-1');
+
+      expect(result).toEqual({ language: null, timeZone: 'America/Sao_Paulo' });
+    });
+
+    it('returns { language: null, timeZone: null } when the user has neither field set', async () => {
+      db.__state.selectResults.push([{ language: null, timeZone: null }]);
+
+      const result = await service.getLocalePreferences('user-1');
+
+      expect(result).toEqual({ language: null, timeZone: null });
+    });
+  });
+
   describe('UpdateUserDto validation', () => {
     it('accepts usernames with underscores as well as lowercase letters, numbers, and hyphens', async () => {
       const dto = Object.assign(new UpdateUserDto(), {

--- a/apps/server/apps/gateway/src/im/users/users.service.ts
+++ b/apps/server/apps/gateway/src/im/users/users.service.ts
@@ -435,6 +435,35 @@ export class UsersService {
       .map((row) => this.mapUserResponse(row));
   }
 
+  /**
+   * Read a user's persisted locale preferences for agent session contexts.
+   *
+   * Both `users.language` and `users.timeZone` are nullable. Callers pass
+   * the returned values into `team9Context` only when non-null, so the
+   * agent-side default ("unknown → English, no zone hint") kicks in cleanly
+   * for users who have never reported preferences.
+   *
+   * Returns `{ language: null, timeZone: null }` when the user row does
+   * not exist — callers should not assume the user is present.
+   */
+  async getLocalePreferences(
+    userId: string,
+  ): Promise<{ language: string | null; timeZone: string | null }> {
+    const rows = await this.db
+      .select({
+        language: schema.users.language,
+        timeZone: schema.users.timeZone,
+      })
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1);
+    const row = rows[0];
+    return {
+      language: row?.language ?? null,
+      timeZone: row?.timeZone ?? null,
+    };
+  }
+
   async getMultipleByIds(ids: string[]): Promise<UserResponse[]> {
     if (ids.length === 0) return [];
 

--- a/apps/server/apps/gateway/src/im/users/users.service.ts
+++ b/apps/server/apps/gateway/src/im/users/users.service.ts
@@ -445,6 +445,15 @@ export class UsersService {
    *
    * Returns `{ language: null, timeZone: null }` when the user row does
    * not exist — callers should not assume the user is present.
+   *
+   * **Values are format-guaranteed at the write boundary.** `UpdateUserDto`
+   * enforces strict regex on both fields (BCP 47 for `language`, IANA for
+   * `timeZone`) plus length caps — see `im/users/dto/update-user.dto.ts`.
+   * No other write path mutates these columns today (auth / bot / onboarding
+   * create paths leave both null). Downstream consumers that interpolate
+   * these values into system prompts can therefore rely on the absence of
+   * newlines, backticks, or other control characters without re-sanitizing
+   * here. If a new write path is added, it MUST apply the same validation.
    */
   async getLocalePreferences(
     userId: string,

--- a/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
+++ b/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
@@ -25,6 +25,7 @@ import { BotService } from '../../bot/bot.service.js';
 import { RoutineTriggersService } from '../routine-triggers.service.js';
 import { AmqpConnection } from '@team9/rabbitmq';
 import { WEBSOCKET_GATEWAY } from '../../shared/constants/injection-tokens.js';
+import { UsersService } from '../../im/users/users.service.js';
 
 // ── helpers ──────────────────────────────────────────────────────────
 
@@ -145,6 +146,10 @@ describe('Routine Creation Flow — integration', () => {
   };
   let botsService: { getBotById: MockFn };
   let wsGateway: { broadcastToWorkspace: MockFn };
+  // Mocked at boundary because DB fixture seeding for `users.language` is not
+  // the feature under test here. The creator returns zh-CN to verify the
+  // language flows through to team9Context.language on createSession.
+  let usersService: { getLocalePreferences: MockFn };
 
   beforeEach(async () => {
     db = mockDb();
@@ -191,6 +196,11 @@ describe('Routine Creation Flow — integration', () => {
     wsGateway = {
       broadcastToWorkspace: jest.fn<any>().mockResolvedValue(undefined),
     };
+    usersService = {
+      getLocalePreferences: jest
+        .fn<any>()
+        .mockResolvedValue({ language: 'zh-CN', timeZone: null }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -204,6 +214,7 @@ describe('Routine Creation Flow — integration', () => {
         { provide: ClawHiveService, useValue: clawHiveService },
         { provide: BotService, useValue: botsService },
         { provide: WEBSOCKET_GATEWAY, useValue: wsGateway },
+        { provide: UsersService, useValue: usersService },
       ],
     }).compile();
 
@@ -515,6 +526,7 @@ describe('Routine Creation Flow — integration', () => {
           creatorUserId: USER_ID,
           creationChannelId: CHANNEL_ID,
           isCreationChannel: true,
+          language: 'zh-CN',
         }),
       }),
       TENANT_ID,

--- a/apps/server/apps/gateway/src/routines/routines.module.ts
+++ b/apps/server/apps/gateway/src/routines/routines.module.ts
@@ -20,7 +20,7 @@ import { RoutinesStreamController } from './routines-stream.controller.js';
     forwardRef(() => WebsocketModule),
     forwardRef(() => ChannelsModule),
     ClawHiveModule,
-    UsersModule,
+    forwardRef(() => UsersModule),
   ],
   controllers: [
     RoutinesController,

--- a/apps/server/apps/gateway/src/routines/routines.module.ts
+++ b/apps/server/apps/gateway/src/routines/routines.module.ts
@@ -4,6 +4,7 @@ import { DocumentsModule } from '../documents/documents.module.js';
 import { WebsocketModule } from '../im/websocket/websocket.module.js';
 import { ChannelsModule } from '../im/channels/channels.module.js';
 import { ClawHiveModule } from '@team9/claw-hive';
+import { UsersModule } from '../im/users/users.module.js';
 import { RoutinesController } from './routines.controller.js';
 import { RoutinesService } from './routines.service.js';
 import { RoutineBotController } from './routine-bot.controller.js';
@@ -19,6 +20,7 @@ import { RoutinesStreamController } from './routines-stream.controller.js';
     forwardRef(() => WebsocketModule),
     forwardRef(() => ChannelsModule),
     ClawHiveModule,
+    UsersModule,
   ],
   controllers: [
     RoutinesController,

--- a/apps/server/apps/gateway/src/routines/routines.service.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.spec.ts
@@ -19,6 +19,7 @@ import {
   RABBITMQ_EXCHANGES,
   RABBITMQ_ROUTING_KEYS,
 } from '@team9/rabbitmq';
+import { UsersService } from '../im/users/users.service.js';
 
 // ── helpers ──────────────────────────────────────────────────────────
 
@@ -94,6 +95,7 @@ describe('RoutinesService — TaskCast integration', () => {
   };
   let botsService: { getBotById: MockFn };
   let wsGateway: { broadcastToWorkspace: MockFn };
+  let usersService: { getLocalePreferences: MockFn };
 
   beforeEach(async () => {
     db = mockDb();
@@ -140,6 +142,11 @@ describe('RoutinesService — TaskCast integration', () => {
     wsGateway = {
       broadcastToWorkspace: jest.fn<any>().mockResolvedValue(undefined),
     };
+    usersService = {
+      getLocalePreferences: jest
+        .fn<any>()
+        .mockResolvedValue({ language: null, timeZone: null }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -153,6 +160,7 @@ describe('RoutinesService — TaskCast integration', () => {
         { provide: ClawHiveService, useValue: clawHiveService },
         { provide: BotService, useValue: botsService },
         { provide: WEBSOCKET_GATEWAY, useValue: wsGateway },
+        { provide: UsersService, useValue: usersService },
       ],
     }).compile();
 
@@ -3804,6 +3812,93 @@ describe('RoutinesService — TaskCast integration', () => {
         .calls[0] as [string, { payload: Record<string, unknown> }, string];
       expect(payload[1].payload.documentContent).toBeNull();
     });
+
+    describe('creator language propagation', () => {
+      beforeEach(() => {
+        usersService.getLocalePreferences.mockReset();
+      });
+
+      it("includes creator's language + timeZone in team9Context when both are set", async () => {
+        mockGetRoutine();
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: 'zh-CN',
+          timeZone: 'Asia/Shanghai',
+        });
+
+        await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
+
+        const createSessionCall = (clawHiveService.createSession as jest.Mock)
+          .mock.calls[0];
+        const sessionArgs = createSessionCall[1] as {
+          team9Context: Record<string, unknown>;
+        };
+        expect(sessionArgs.team9Context).toMatchObject({
+          language: 'zh-CN',
+          timeZone: 'Asia/Shanghai',
+        });
+        expect(usersService.getLocalePreferences).toHaveBeenCalledWith(USER_ID);
+      });
+
+      it('omits language when only timeZone is set', async () => {
+        mockGetRoutine();
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: null,
+          timeZone: 'Asia/Shanghai',
+        });
+
+        await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
+
+        const sessionArgs = (clawHiveService.createSession as jest.Mock).mock
+          .calls[0][1] as {
+          team9Context: Record<string, unknown>;
+        };
+        expect(sessionArgs.team9Context).not.toHaveProperty('language');
+        expect(sessionArgs.team9Context).toMatchObject({
+          timeZone: 'Asia/Shanghai',
+        });
+      });
+
+      it('omits timeZone when only language is set', async () => {
+        mockGetRoutine();
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: 'zh-CN',
+          timeZone: null,
+        });
+
+        await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
+
+        const sessionArgs = (clawHiveService.createSession as jest.Mock).mock
+          .calls[0][1] as {
+          team9Context: Record<string, unknown>;
+        };
+        expect(sessionArgs.team9Context).toMatchObject({ language: 'zh-CN' });
+        expect(sessionArgs.team9Context).not.toHaveProperty('timeZone');
+      });
+
+      it('omits both language and timeZone when creator has neither set', async () => {
+        mockGetRoutine();
+        usersService.getLocalePreferences.mockResolvedValue({
+          language: null,
+          timeZone: null,
+        });
+
+        await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
+
+        const sessionArgs = (clawHiveService.createSession as jest.Mock).mock
+          .calls[0][1] as {
+          team9Context: Record<string, unknown>;
+        };
+        expect(sessionArgs.team9Context).not.toHaveProperty('language');
+        expect(sessionArgs.team9Context).not.toHaveProperty('timeZone');
+        // Existing fields remain intact.
+        expect(sessionArgs.team9Context).toMatchObject({
+          routineId: expect.any(String),
+          creatorUserId: expect.any(String),
+          creationChannelId: expect.any(String),
+          isCreationChannel: true,
+        });
+      });
+    });
   });
 });
 
@@ -3882,6 +3977,7 @@ describe('RoutinesService — completeCreation race guard', () => {
   let amqpConnection: { publish: MockFn };
   let taskCastService: { transitionStatus: MockFn; publishEvent: MockFn };
   let wsGateway: { broadcastToWorkspace: MockFn };
+  let usersService: { getLocalePreferences: MockFn };
 
   beforeEach(async () => {
     db = mockDb();
@@ -3930,6 +4026,11 @@ describe('RoutinesService — completeCreation race guard', () => {
         .fn<any>()
         .mockResolvedValue({ botId: 'bot-1', userId: 'user-1' }),
     };
+    usersService = {
+      getLocalePreferences: jest
+        .fn<any>()
+        .mockResolvedValue({ language: null, timeZone: null }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -3943,6 +4044,7 @@ describe('RoutinesService — completeCreation race guard', () => {
         { provide: ClawHiveService, useValue: clawHiveService },
         { provide: BotService, useValue: botsService },
         { provide: WEBSOCKET_GATEWAY, useValue: wsGateway },
+        { provide: UsersService, useValue: usersService },
       ],
     }).compile();
 

--- a/apps/server/apps/gateway/src/routines/routines.service.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.spec.ts
@@ -3814,10 +3814,6 @@ describe('RoutinesService — TaskCast integration', () => {
     });
 
     describe('creator language propagation', () => {
-      beforeEach(() => {
-        usersService.getLocalePreferences.mockReset();
-      });
-
       it("includes creator's language + timeZone in team9Context when both are set", async () => {
         mockGetRoutine();
         usersService.getLocalePreferences.mockResolvedValue({
@@ -3897,6 +3893,36 @@ describe('RoutinesService — TaskCast integration', () => {
           creationChannelId: expect.any(String),
           isCreationChannel: true,
         });
+      });
+
+      it('rolls back claim + channel when getLocalePreferences rejects', async () => {
+        mockGetRoutine();
+        // Claim succeeds, but the locale read throws (transient DB issue).
+        usersService.getLocalePreferences.mockRejectedValue(
+          new Error('db down'),
+        );
+
+        await expect(
+          service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID),
+        ).rejects.toThrow('db down');
+
+        // Speculative channel must be hard-deleted.
+        expect(
+          channelsService.hardDeleteRoutineSessionChannel,
+        ).toHaveBeenCalledWith(CHANNEL_ID, TENANT_ID);
+
+        // Routine creation columns cleared (claimed = true before getLocalePreferences throws)
+        expect(db.set).toHaveBeenCalledWith(
+          expect.objectContaining({
+            creationChannelId: null,
+            creationSessionId: null,
+          }),
+        );
+
+        // Kickoff MUST NOT have happened — the locale read runs after the
+        // claim but before createSession/sendInput.
+        expect(clawHiveService.createSession).not.toHaveBeenCalled();
+        expect(clawHiveService.sendInput).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/server/apps/gateway/src/routines/routines.service.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.ts
@@ -51,6 +51,7 @@ import type { RetryExecutionDto } from './dto/trigger.dto.js';
 import type { CompleteCreationDto } from './dto/complete-creation.dto.js';
 import type { CreateWithCreationTaskDto } from './dto/with-creation-task.dto.js';
 import { TaskCastService } from './taskcast.service.js';
+import { UsersService } from '../im/users/users.service.js';
 
 // ── Filter types ────────────────────────────────────────────────────
 
@@ -78,6 +79,7 @@ export class RoutinesService {
     private readonly channelsService: ChannelsService,
     private readonly clawHiveService: ClawHiveService,
     private readonly botsService: BotService,
+    private readonly usersService: UsersService,
   ) {}
 
   // ── CRUD ────────────────────────────────────────────────────────
@@ -1304,11 +1306,15 @@ export class RoutinesService {
 
       claimed = true;
 
+      const locale = await this.usersService.getLocalePreferences(userId);
+
       const team9Context: Record<string, unknown> = {
         routineId,
         creatorUserId: userId,
         creationChannelId: channel.id,
         isCreationChannel: true,
+        ...(locale.language ? { language: locale.language } : {}),
+        ...(locale.timeZone ? { timeZone: locale.timeZone } : {}),
       };
 
       await this.clawHiveService.createSession(


### PR DESCRIPTION
## Summary

- Promotes the duplicated private `getUserLocale(userId)` helper (previously inlined in `CommonStaffService` and `PersonalStaffService`) into a public [`UsersService.getLocalePreferences(userId)`](apps/server/apps/gateway/src/im/users/users.service.ts) returning `{ language: string | null; timeZone: string | null }`.
- Migrates `CommonStaffService` and `PersonalStaffService` to consume the new method; drops their private duplicates. `ApplicationsModule` now imports `UsersModule`.
- `RoutinesService.startCreationSession` reads the creator's locale via `UsersService.getLocalePreferences(userId)` and spreads non-null `language` / `timeZone` into the `team9Context` passed to `ClawHiveService.createSession`. Null values are omitted from the object (never stored as `null`). `RoutinesModule` now imports `UsersModule`.
- Rollback hygiene: the locale read runs inside the existing `startCreationSession` try/catch, so a DB failure cleanly hard-deletes the speculative channel and clears `creation_channel_id` / `creation_session_id` on the routine row. Covered by a new bad-case test.

Paired with [team9ai/agent-pi PR #53](https://github.com/team9ai/agent-pi/pull/53), which consumes `team9Context.language` to inject a locale directive into the routine-creation system prompt. Either side can deploy independently; when both ship, the routine-creation agent greets in the creator's preferred language instead of defaulting to English.

**Spec:** lives in the agent-pi repo at \`docs/superpowers/specs/2026-04-17-routine-creation-user-language-design.md\`.

## Test plan

- [ ] \`cd apps/server/apps/gateway && pnpm test -- src/im/users/users.service.spec.ts\` — 61/61 pass (56 existing + 5 new locale-preferences cases)
- [ ] \`cd apps/server/apps/gateway && pnpm test -- src/applications/\` — 317/317 pass (migration specs updated to mock \`UsersService.getLocalePreferences\`)
- [ ] \`cd apps/server/apps/gateway && pnpm test -- src/routines/\` — 293/293 pass (+ 5 new cases: 4 locale-shape unit tests + 1 bad-case rollback test, + 1 integration assertion on \`createSession\`'s \`team9Context.language\`)
- [ ] \`cd apps/server/apps/gateway && pnpm test\` — 1999/1999 pass across 107 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)