### PR TITLE
feat(im): topic-session channels — per-topic user x agent conversations

### DIFF
--- a/apps/client/src/components/layout/contents/HomeMainContent.tsx
+++ b/apps/client/src/components/layout/contents/HomeMainContent.tsx
@@ -26,6 +26,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useCreateDirectChannel, useChannelsByType } from "@/hooks/useChannels";
+import { useCreateTopicSession } from "@/hooks/useTopicSessions";
 import {
   type DashboardAgent,
   type DashboardAgentModel,
@@ -410,7 +411,10 @@ export function HomeMainContent() {
   const queryClient = useQueryClient();
   const workspaceId = useSelectedWorkspaceId();
   const { directChannels = [] } = useChannelsByType();
+  // Deep research still uses the legacy direct channel as its container —
+  // it's orthogonal to topic sessions and can be migrated later.
   const createDirectChannel = useCreateDirectChannel();
+  const createTopicSession = useCreateTopicSession();
   const { agents, updateAgentModel, updatingAgentUserId } =
     useDashboardAgents(directChannels);
   const billingSummary = useWorkspaceBillingSummary(workspaceId ?? undefined);
@@ -424,10 +428,13 @@ export function HomeMainContent() {
   const selectedAgent =
     agents.find((agent) => agent.userId === selectedAgentUserId) ??
     pickDefaultAgent(agents);
+  const isSubmitting =
+    createDirectChannel.isPending ||
+    createTopicSession.isPending ||
+    isCreatingResearch;
   const canSubmit =
     prompt.trim().length > 0 &&
-    !createDirectChannel.isPending &&
-    !isCreatingResearch &&
+    !isSubmitting &&
     (isDeepResearch || !!selectedAgent);
   const isUpdatingSelectedAgentModel =
     !!selectedAgent && updatingAgentUserId === selectedAgent.userId;
@@ -497,15 +504,19 @@ export function HomeMainContent() {
     if (!selectedAgent) return;
 
     try {
-      const channelId =
-        selectedAgent.channelId ??
-        (await createDirectChannel.mutateAsync(selectedAgent.userId)).id;
+      // Create a fresh topic session for this prompt. The server persists
+      // the first user message inside the same saga, so we can navigate
+      // straight to the new channel without draft/autoSend URL params.
+      const result = await createTopicSession.mutateAsync({
+        botUserId: selectedAgent.userId,
+        initialMessage: draft,
+        ...(selectedAgent.model ? { model: selectedAgent.model } : {}),
+      });
 
       setPrompt("");
       navigate({
         to: "/channels/$channelId",
-        params: { channelId },
-        search: { draft, autoSend: true },
+        params: { channelId: result.channelId },
       });
     } catch (error: unknown) {
       const status = getHttpErrorStatus(error);
@@ -629,7 +640,7 @@ export function HomeMainContent() {
                       aria-label={t("sendMessage", { ns: "message" })}
                       className="dashboard-composer-send h-[2.375rem] w-[2.375rem] rounded-full bg-[#818894] text-white shadow-none hover:bg-[#727885] disabled:bg-[#ddd7cf] disabled:text-[#a2998d]"
                     >
-                      {createDirectChannel.isPending || isCreatingResearch ? (
+                      {isSubmitting ? (
                         <Loader2 size={16} className="animate-spin" />
                       ) : (
                         <ArrowUp size={16} strokeWidth={2.2} />

--- a/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
@@ -13,6 +13,8 @@ const mockUseSelectedWorkspaceId = vi.hoisted(() => vi.fn());
 const mockUseUser = vi.hoisted(() => vi.fn());
 const mockDeepResearchCreateTask = vi.hoisted(() => vi.fn());
 const mockDeepResearchStartInChannel = vi.hoisted(() => vi.fn());
+const mockCreateTopicSessionMutate = vi.hoisted(() => vi.fn());
+const mockUseCreateTopicSession = vi.hoisted(() => vi.fn());
 
 const translationMap: Record<
   string,
@@ -83,6 +85,10 @@ vi.mock("@/services/api/deep-research", () => ({
     createTask: mockDeepResearchCreateTask,
     startInChannel: mockDeepResearchStartInChannel,
   },
+}));
+
+vi.mock("@/hooks/useTopicSessions", () => ({
+  useCreateTopicSession: mockUseCreateTopicSession,
 }));
 
 import { HomeMainContent } from "../HomeMainContent";
@@ -181,6 +187,20 @@ describe("HomeMainContent", () => {
       },
       message: { id: "msg-1" },
     });
+    // Default: topic-session creation resolves to a fresh channel id so the
+    // dashboard can navigate into the newly-created topic channel.
+    mockCreateTopicSessionMutate.mockResolvedValue({
+      channelId: "topic-ch-new",
+      sessionId: "session-new",
+      agentId: "agent-hive-id",
+      botUserId: "bot-2",
+      title: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    mockUseCreateTopicSession.mockReturnValue({
+      mutateAsync: mockCreateTopicSessionMutate,
+      isPending: false,
+    });
   });
 
   it("renders the dashboard with title and prompt input", () => {
@@ -206,7 +226,7 @@ describe("HomeMainContent", () => {
     expect(container.querySelector('[data-slot="avatar"]')).not.toBeNull();
   });
 
-  it("switches to the selected agent and submits to that agent channel", async () => {
+  it("creates a topic session for the selected agent and navigates to the new channel", async () => {
     renderWithProviders(<HomeMainContent />);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: /alpha agent/i }));
@@ -218,10 +238,21 @@ describe("HomeMainContent", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/channels/$channelId",
-      params: { channelId: "bot-ch-2" },
-      search: { draft: "hello beta", autoSend: true },
+    // Dashboard submit no longer routes to an existing bot channel with a
+    // draft query param — it creates a fresh topic session for the selected
+    // agent and navigates directly to the channel the server returned.
+    await vi.waitFor(() => {
+      expect(mockCreateTopicSessionMutate).toHaveBeenCalledWith({
+        botUserId: "agent-2",
+        initialMessage: "hello beta",
+        model: { provider: "openrouter", id: "anthropic/claude-opus-4.6" },
+      });
+    });
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/channels/$channelId",
+        params: { channelId: "topic-ch-new" },
+      });
     });
   });
 
@@ -234,7 +265,7 @@ describe("HomeMainContent", () => {
     expect(mockDeepResearchStartInChannel).not.toHaveBeenCalled();
   });
 
-  it("hides the model control for base-model agents", () => {
+  it("shows a static model label for base-model agents that cannot switch", () => {
     mockUseDashboardAgents.mockReturnValue({
       agents: [
         {
@@ -258,15 +289,15 @@ describe("HomeMainContent", () => {
 
     renderWithProviders(<HomeMainContent />);
 
-    expect(screen.queryByText("Claude Sonnet 4.6")).not.toBeInTheDocument();
+    expect(screen.getByText("Claude Sonnet 4.6")).toBeInTheDocument();
   });
 
-  it("hides the model control for switchable agents", () => {
+  it("shows the model picker button for switchable agents", () => {
     renderWithProviders(<HomeMainContent />);
 
     expect(
-      screen.queryByRole("button", { name: /gpt-4.1/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /gpt-4.1/i }),
+    ).toBeInTheDocument();
   });
 
   it("defaults to the personal-staff agent when one exists", () => {

--- a/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
@@ -47,6 +47,8 @@ import {
   usePublicChannels,
   useSetSidebarVisibility,
 } from "@/hooks/useChannels";
+import { useTopicSessionsGrouped } from "@/hooks/useTopicSessions";
+import { AgentGroupList } from "@/components/sidebar/AgentGroupList";
 import {
   useSections,
   useMoveChannel,
@@ -279,6 +281,7 @@ export function HomeSubSidebar() {
   const currentWorkspace = workspaces?.find((w) => w.id === workspaceId);
 
   const [channelsExpanded, setChannelsExpanded] = useState(true);
+  const [agentsExpanded, setAgentsExpanded] = useState(true);
   const [dmsExpanded, setDmsExpanded] = useState(true);
   const [appsExpanded, setAppsExpanded] = useState(true);
   const [isNewMessageOpen, setIsNewMessageOpen] = useState(false);
@@ -302,6 +305,8 @@ export function HomeSubSidebar() {
   } = useChannelsByType();
   const { data: allPublicChannels = [], isLoading: isLoadingPublic } =
     usePublicChannels();
+  const { data: agentGroups = [], isLoading: isLoadingAgents } =
+    useTopicSessionsGrouped(5);
   const setSidebarVisibility = useSetSidebarVisibility();
   const { data: sections = [] } = useSections();
   const moveChannel = useMoveChannel();
@@ -412,28 +417,32 @@ export function HomeSubSidebar() {
     return grouped;
   }, [allChannels]);
 
-  // Extract users from direct channels
-  const directMessageUsers = directChannels.map((channel) => {
-    // Use the otherUser info from the channel if available
-    const otherUser = channel.otherUser;
-    const displayName =
-      otherUser?.displayName || otherUser?.username || "Direct Message";
+  // Extract users from direct channels. Bots are rendered under the
+  // "AI Agents" grouping further down (via AgentGroupList), so the
+  // flat DM list shows only human-to-human conversations here to avoid
+  // duplicating each agent in two places.
+  const directMessageUsers = directChannels
+    .filter((channel) => channel.otherUser?.userType !== "bot")
+    .map((channel) => {
+      const otherUser = channel.otherUser;
+      const displayName =
+        otherUser?.displayName || otherUser?.username || "Direct Message";
 
-    return {
-      id: channel.id,
-      channelId: channel.id,
-      userId: otherUser?.id,
-      name: displayName,
-      avatarUrl: otherUser?.avatarUrl,
-      agentType: otherUser?.agentType,
-      staffKind: otherUser?.staffKind ?? null,
-      roleTitle: otherUser?.roleTitle ?? null,
-      ownerName: otherUser?.ownerName ?? null,
-      status: otherUser?.status || ("offline" as const),
-      unreadCount: channel.unreadCount || 0,
-      isBot: otherUser?.userType === "bot",
-    };
-  });
+      return {
+        id: channel.id,
+        channelId: channel.id,
+        userId: otherUser?.id,
+        name: displayName,
+        avatarUrl: otherUser?.avatarUrl,
+        agentType: otherUser?.agentType,
+        staffKind: otherUser?.staffKind ?? null,
+        roleTitle: otherUser?.roleTitle ?? null,
+        ownerName: otherUser?.ownerName ?? null,
+        status: otherUser?.status || ("offline" as const),
+        unreadCount: channel.unreadCount || 0,
+        isBot: otherUser?.userType === "bot",
+      };
+    });
 
   return (
     <aside className="w-64 h-full overflow-hidden bg-nav-sub-bg text-primary-foreground flex flex-col">
@@ -693,6 +702,34 @@ export function HomeSubSidebar() {
               ) : null}
             </DragOverlay>
           </DndContext>
+
+          {/* AI Agents Section — groups topic sessions per agent; the
+              agent-header click opens the legacy direct channel when one
+              exists, so no agent conversation is orphaned by the move. */}
+          <div className="mt-4">
+            <Button
+              variant="ghost"
+              onClick={() => setAgentsExpanded(!agentsExpanded)}
+              className="w-full justify-start gap-1 px-2 h-auto py-1.5 text-sm text-nav-foreground-strong hover:text-nav-foreground hover:bg-nav-hover"
+            >
+              {agentsExpanded ? (
+                <ChevronDown size={14} />
+              ) : (
+                <ChevronRight size={14} />
+              )}
+              <span>{tNav("aiAgents", { defaultValue: "AI Agents" })}</span>
+            </Button>
+            {agentsExpanded && (
+              <div className="ml-2 mt-1">
+                <AgentGroupList
+                  groups={agentGroups}
+                  selectedChannelId={selectedChannelId}
+                  linkPrefix="/channels"
+                  isLoading={isLoadingAgents}
+                />
+              </div>
+            )}
+          </div>
 
           {/* DMs Section */}
           <div className="mt-4">

--- a/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/HomeSubSidebar.tsx
@@ -47,7 +47,7 @@ import {
   usePublicChannels,
   useSetSidebarVisibility,
 } from "@/hooks/useChannels";
-import { useTopicSessionsGrouped } from "@/hooks/useTopicSessions";
+import { useAgentGroupsForSidebar } from "@/hooks/useAgentGroupsForSidebar";
 import { AgentGroupList } from "@/components/sidebar/AgentGroupList";
 import {
   useSections,
@@ -305,8 +305,8 @@ export function HomeSubSidebar() {
   } = useChannelsByType();
   const { data: allPublicChannels = [], isLoading: isLoadingPublic } =
     usePublicChannels();
-  const { data: agentGroups = [], isLoading: isLoadingAgents } =
-    useTopicSessionsGrouped(5);
+  const { groups: agentGroups, isLoading: isLoadingAgents } =
+    useAgentGroupsForSidebar(5);
   const setSidebarVisibility = useSetSidebarVisibility();
   const { data: sections = [] } = useSections();
   const moveChannel = useMoveChannel();

--- a/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
@@ -17,7 +17,7 @@ import {
   useCreateDirectChannel,
   useSetSidebarVisibility,
 } from "@/hooks/useChannels";
-import { useTopicSessionsGrouped } from "@/hooks/useTopicSessions";
+import { useAgentGroupsForSidebar } from "@/hooks/useAgentGroupsForSidebar";
 import { useCurrentUser } from "@/hooks/useAuth";
 import { useWorkspaceStore } from "@/stores";
 import { UserListItem } from "@/components/sidebar/UserListItem";
@@ -38,8 +38,8 @@ export function MessagesSubSidebar() {
     isLoading: isLoadingChannels,
   } = useChannelsByType();
   const setSidebarVisibility = useSetSidebarVisibility();
-  const { data: agentGroups = [], isLoading: isLoadingAgents } =
-    useTopicSessionsGrouped(5);
+  const { groups: agentGroups, isLoading: isLoadingAgents } =
+    useAgentGroupsForSidebar(5);
   // Use selected workspace or fallback to first workspace
   const currentWorkspace =
     workspaces?.find((w) => w.id === selectedWorkspaceId) || workspaces?.[0];

--- a/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
+++ b/apps/client/src/components/layout/sidebars/MessagesSubSidebar.tsx
@@ -17,9 +17,11 @@ import {
   useCreateDirectChannel,
   useSetSidebarVisibility,
 } from "@/hooks/useChannels";
+import { useTopicSessionsGrouped } from "@/hooks/useTopicSessions";
 import { useCurrentUser } from "@/hooks/useAuth";
 import { useWorkspaceStore } from "@/stores";
 import { UserListItem } from "@/components/sidebar/UserListItem";
+import { AgentGroupList } from "@/components/sidebar/AgentGroupList";
 
 export function MessagesSubSidebar() {
   const { t } = useTranslation(["navigation", "common"]);
@@ -36,6 +38,8 @@ export function MessagesSubSidebar() {
     isLoading: isLoadingChannels,
   } = useChannelsByType();
   const setSidebarVisibility = useSetSidebarVisibility();
+  const { data: agentGroups = [], isLoading: isLoadingAgents } =
+    useTopicSessionsGrouped(5);
   // Use selected workspace or fallback to first workspace
   const currentWorkspace =
     workspaces?.find((w) => w.id === selectedWorkspaceId) || workspaces?.[0];
@@ -50,27 +54,31 @@ export function MessagesSubSidebar() {
   }, [membersData]);
   const createDirectChannel = useCreateDirectChannel();
 
-  // Extract users from direct channels (existing conversations)
+  // Extract users from direct channels (existing conversations).
+  // Bots are rendered under the dedicated AI Agents section, so the
+  // human-DM list below filters them out to avoid a double-appearance.
   const directMessageUsers = useMemo(() => {
-    return directChannels.map((channel) => {
-      const otherUser = channel.otherUser;
-      const displayName =
-        otherUser?.displayName || otherUser?.username || "Direct Message";
+    return directChannels
+      .filter((channel) => channel.otherUser?.userType !== "bot")
+      .map((channel) => {
+        const otherUser = channel.otherUser;
+        const displayName =
+          otherUser?.displayName || otherUser?.username || "Direct Message";
 
-      return {
-        id: channel.id,
-        channelId: channel.id,
-        userId: otherUser?.id,
-        name: displayName,
-        avatarUrl: otherUser?.avatarUrl,
-        agentType: otherUser?.agentType,
-        staffKind: otherUser?.staffKind ?? null,
-        roleTitle: otherUser?.roleTitle ?? null,
-        ownerName: otherUser?.ownerName ?? null,
-        unreadCount: channel.unreadCount || 0,
-        isBot: otherUser?.userType === "bot",
-      };
-    });
+        return {
+          id: channel.id,
+          channelId: channel.id,
+          userId: otherUser?.id,
+          name: displayName,
+          avatarUrl: otherUser?.avatarUrl,
+          agentType: otherUser?.agentType,
+          staffKind: otherUser?.staffKind ?? null,
+          roleTitle: otherUser?.roleTitle ?? null,
+          ownerName: otherUser?.ownerName ?? null,
+          unreadCount: channel.unreadCount || 0,
+          isBot: otherUser?.userType === "bot",
+        };
+      });
   }, [directChannels]);
 
   const filteredMembers = useMemo(() => {
@@ -126,6 +134,23 @@ export function MessagesSubSidebar() {
       {/* Messages List */}
       <ScrollArea className="flex-1 min-h-0 px-3">
         <nav className="space-y-0.5 pb-3 pt-2">
+          {/* AI Agents — topic sessions grouped per agent.
+              Rendered above the human-DM list so users see their
+              AI conversations first (most common case today). */}
+          {(agentGroups.length > 0 || isLoadingAgents) && (
+            <div className="pb-2 mb-2 border-b border-nav-border">
+              <div className="px-2 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-nav-foreground-faint">
+                {t("aiAgents", { defaultValue: "AI Agents" })}
+              </div>
+              <AgentGroupList
+                groups={agentGroups}
+                selectedChannelId={selectedChannelId}
+                linkPrefix="/messages"
+                isLoading={isLoadingAgents}
+              />
+            </div>
+          )}
+
           {isLoading ? (
             <p className="text-xs text-nav-foreground-faint px-2 py-2">
               {t("common:loading")}

--- a/apps/client/src/components/layout/sidebars/__tests__/HomeSubSidebar.test.tsx
+++ b/apps/client/src/components/layout/sidebars/__tests__/HomeSubSidebar.test.tsx
@@ -3,17 +3,23 @@ import { render, screen } from "@testing-library/react";
 
 import { HomeSubSidebar } from "../HomeSubSidebar";
 
+// HomeSubSidebar now renders bot DMs under the "AI Agents" grouping (see
+// AgentGroupList) and filters bots out of the flat DM list, so this fixture
+// uses a human user to exercise the DM avatar rendering path.
 const mockDirectChannels = vi.hoisted(() => [
   {
-    id: "dm-claude",
+    id: "dm-alex",
     unreadCount: 0,
     otherUser: {
-      id: "bot-claude",
-      displayName: "Claude",
-      username: "claude_bot_workspace",
-      avatarUrl: null,
+      id: "user-alex",
+      displayName: "Alex",
+      username: "alex",
+      // Human users with avatarUrl:null render only initials (no <img>),
+      // so this fixture sets an URL to ensure the Avatar emits an image
+      // element the test can locate by role.
+      avatarUrl: "https://example.com/alex.png",
       status: "online",
-      userType: "bot",
+      userType: "human",
     },
   },
 ]);
@@ -55,6 +61,16 @@ vi.mock("@/hooks/useChannels", () => ({
     mutate: vi.fn(),
     mutateAsync: vi.fn().mockResolvedValue(undefined),
     isPending: false,
+  }),
+}));
+
+// Stub the agent-groups hook so the component does not pull in react-query's
+// useQuery chain (useCurrentUser / useDashboardAgents). No QueryClientProvider
+// is wrapped around this render.
+vi.mock("@/hooks/useAgentGroupsForSidebar", () => ({
+  useAgentGroupsForSidebar: () => ({
+    groups: [],
+    isLoading: false,
   }),
 }));
 
@@ -143,9 +159,7 @@ describe("HomeSubSidebar", () => {
     render(<HomeSubSidebar />);
 
     expect(
-      screen
-        .getByRole("img", { name: "Claude" })
-        .closest("[data-slot='avatar']"),
+      screen.getByRole("img", { name: "Alex" }).closest("[data-slot='avatar']"),
     ).toHaveClass("w-9", "h-9");
   });
 });

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -1,8 +1,8 @@
+import type { KeyboardEvent, MouseEvent } from "react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronRight, MessageSquare, Plus } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 import type { TopicSessionGroup } from "@/services/api/im";
@@ -34,7 +34,7 @@ function navigateToChannel(
 }
 
 export interface AgentGroupListProps {
-  /** Grouped data from `useTopicSessionsGrouped()`. */
+  /** Grouped data from `useAgentGroupsForSidebar()`. */
   groups: TopicSessionGroup[];
   /** Currently-open channel id, used to highlight the matching row. */
   selectedChannelId?: string;
@@ -49,16 +49,20 @@ export interface AgentGroupListProps {
 }
 
 /**
- * Sidebar section that renders one collapsible block per agent, each
- * containing the caller's most-recent topic sessions with that agent plus
- * an optional "legacy DM" tail row.
+ * Sidebar section that renders one collapsible block per agent.
  *
- * Header click behaviour (per product decision D4):
- *  - Toggles the group's expanded state.
- *  - If a legacy direct channel exists, also navigates to it — that channel
- *    is treated as the agent's "default / historical" conversation surface.
+ * Layout is intentionally kept flat and high-contrast:
+ *   - header row: 32px tall, shows expand chevron + avatar + agent name,
+ *     with a hover-revealed "+" button for quick "new topic"
+ *   - child rows: 28px tall, indented under a thin left border,
+ *     showing the topic title (no leading icon to keep scanning easy)
+ *   - legacy DM tail row (if any): same 28px but italic + dim so it
+ *     reads as "this is the older persistent conversation"
  *
- * Child rows link straight to the topic-session channel.
+ * Header click behaviour (product decision D4):
+ *   - Toggles the group's expanded state.
+ *   - If a legacy direct channel exists, also navigates to it — that
+ *     channel is treated as the agent's default / historical surface.
  */
 export function AgentGroupList({
   groups,
@@ -99,7 +103,7 @@ export function AgentGroupList({
   }
 
   return (
-    <div className="space-y-0.5">
+    <div className="space-y-px">
       {groups.map((group) => (
         <AgentGroup
           key={group.agentUserId}
@@ -142,7 +146,14 @@ function AgentGroup({
     }
   };
 
-  const handleNewTopic = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleHeaderClick();
+    }
+  };
+
+  const handleNewTopic = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     // Send the user back to the dashboard composer. The dashboard
     // remembers the last-selected agent in its own state, so the user
@@ -152,20 +163,26 @@ function AgentGroup({
 
   return (
     <div>
-      <Button
-        variant="ghost"
+      {/* Using a div instead of a Button so the inner "+" button is
+          allowed (nested native <button> elements are invalid HTML and
+          caused the older design to render with odd focus/active
+          states). keyboard accessibility is preserved manually. */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={handleHeaderClick}
+        onKeyDown={handleHeaderKeyDown}
         className={cn(
-          "w-full justify-start gap-2 px-2 h-auto py-1.5 text-sm",
+          "group flex items-center gap-2 h-8 px-2 rounded-md cursor-pointer select-none",
+          "text-sm font-medium text-nav-foreground-strong",
+          "hover:bg-nav-hover",
           headerHighlighted &&
-            "bg-nav-active text-nav-foreground hover:bg-nav-active",
+            "bg-nav-active text-nav-foreground-strong hover:bg-nav-active",
         )}
       >
-        {expanded ? (
-          <ChevronDown size={14} className="shrink-0" />
-        ) : (
-          <ChevronRight size={14} className="shrink-0" />
-        )}
+        <span className="shrink-0 inline-flex w-4 items-center justify-center text-nav-foreground-subtle">
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
         <UserAvatar
           userId={group.agentUserId}
           name={group.agentDisplayName}
@@ -177,22 +194,26 @@ function AgentGroup({
         <span className="truncate flex-1 text-left">
           {group.agentDisplayName}
         </span>
-        <Button
-          asChild={false}
-          variant="ghost"
-          size="icon"
+        <button
+          type="button"
           onClick={handleNewTopic}
           title={t("newMessage")}
-          className="h-6 w-6 opacity-60 hover:opacity-100"
+          aria-label={t("newMessage")}
+          className={cn(
+            "shrink-0 inline-flex size-5 items-center justify-center rounded",
+            "text-nav-foreground-subtle opacity-0 transition-opacity",
+            "hover:text-nav-foreground-strong hover:bg-nav-hover",
+            "group-hover:opacity-100 focus-visible:opacity-100",
+          )}
         >
-          <Plus size={12} />
-        </Button>
-      </Button>
+          <Plus size={14} />
+        </button>
+      </div>
 
       {expanded && (
-        <div className="ml-4 mt-0.5 space-y-0.5 border-l border-nav-border pl-2">
+        <div className="ml-[14px] mt-0.5 mb-1 space-y-px border-l border-nav-border/60 pl-2">
           {group.recentSessions.length === 0 && !group.legacyDirectChannelId ? (
-            <p className="text-[0.7rem] text-nav-foreground-faint px-2 py-1">
+            <p className="text-[0.7rem] italic text-nav-foreground-faint px-2 py-1">
               {t("topicSessionsEmpty", {
                 ns: "navigation" as const,
                 defaultValue: "暂无话题",
@@ -246,24 +267,27 @@ function TopicSessionRow({
 }) {
   const navigate = useNavigate();
   const label = title?.trim() || fallbackLabel;
+  const isUntitled = !title?.trim();
 
   return (
-    <Button
-      variant="ghost"
+    <button
+      type="button"
       onClick={() => navigateToChannel(navigate, linkPrefix, channelId)}
       className={cn(
-        "w-full justify-start gap-2 px-2 h-auto py-1 text-[0.8rem]",
-        isSelected && "bg-nav-active text-nav-foreground hover:bg-nav-active",
+        "flex w-full items-center gap-2 h-7 px-2 rounded-md text-left text-[0.8rem]",
+        "text-nav-foreground hover:bg-nav-hover hover:text-nav-foreground-strong",
+        isUntitled && "text-nav-foreground-faint italic",
+        isSelected &&
+          "bg-nav-active text-nav-foreground-strong not-italic hover:bg-nav-active",
       )}
     >
-      <MessageSquare size={12} className="shrink-0 text-nav-foreground-faint" />
-      <span className="truncate flex-1 text-left">{label}</span>
+      <span className="truncate flex-1">{label}</span>
       {unreadCount > 0 ? (
-        <span className="ml-auto shrink-0 rounded-full bg-[#2f67ff] px-1.5 text-[0.6rem] font-semibold text-white">
+        <span className="ml-auto shrink-0 rounded-full bg-[#2f67ff] px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-white">
           {unreadCount > 99 ? "99+" : unreadCount}
         </span>
       ) : null}
-    </Button>
+    </button>
   );
 }
 
@@ -280,18 +304,20 @@ function LegacyDirectChannelRow({
   const { t } = useTranslation(["navigation"]);
 
   return (
-    <Button
-      variant="ghost"
+    <button
+      type="button"
       onClick={() => navigateToChannel(navigate, linkPrefix, channelId)}
       className={cn(
-        "w-full justify-start gap-2 px-2 h-auto py-1 text-[0.75rem] text-nav-foreground-faint italic",
-        isSelected && "bg-nav-active text-nav-foreground hover:bg-nav-active",
+        "flex w-full items-center gap-2 h-7 px-2 rounded-md text-left text-[0.75rem] italic",
+        "text-nav-foreground-faint hover:bg-nav-hover hover:text-nav-foreground",
+        isSelected &&
+          "bg-nav-active text-nav-foreground-strong not-italic hover:bg-nav-active",
       )}
     >
-      <MessageSquare size={11} className="shrink-0" />
-      <span className="truncate flex-1 text-left">
+      <MessageSquare size={11} className="shrink-0 opacity-70" />
+      <span className="truncate flex-1">
         {t("directMessages", { defaultValue: "Direct message" })}
       </span>
-    </Button>
+    </button>
   );
 }

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -2,7 +2,7 @@ import type { KeyboardEvent, MouseEvent } from "react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronRight, MessageSquare, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 import type { TopicSessionGroup } from "@/services/api/im";
@@ -212,38 +212,34 @@ function AgentGroup({
 
       {expanded && (
         <div className="ml-[14px] mt-0.5 mb-1 space-y-px border-l border-nav-border/60 pl-2">
-          {group.recentSessions.length === 0 && !group.legacyDirectChannelId ? (
+          {group.recentSessions.length === 0 ? (
             <p className="text-[0.7rem] italic text-nav-foreground-faint px-2 py-1">
               {t("topicSessionsEmpty", {
                 ns: "navigation" as const,
                 defaultValue: "暂无话题",
               })}
             </p>
-          ) : null}
-
-          {group.recentSessions.map((s) => (
-            <TopicSessionRow
-              key={s.channelId}
-              channelId={s.channelId}
-              title={s.title}
-              unreadCount={s.unreadCount}
-              isSelected={s.channelId === selectedChannelId}
-              linkPrefix={linkPrefix}
-              fallbackLabel={t("topicSessionUntitled", {
-                ns: "navigation" as const,
-                defaultValue: "(未命名话题)",
-              })}
-            />
-          ))}
-
-          {group.legacyDirectChannelId &&
-          group.legacyDirectChannelId !== selectedChannelId ? (
-            <LegacyDirectChannelRow
-              channelId={group.legacyDirectChannelId}
-              isSelected={group.legacyDirectChannelId === selectedChannelId}
-              linkPrefix={linkPrefix}
-            />
-          ) : null}
+          ) : (
+            group.recentSessions.map((s) => (
+              <TopicSessionRow
+                key={s.channelId}
+                channelId={s.channelId}
+                title={s.title}
+                unreadCount={s.unreadCount}
+                isSelected={s.channelId === selectedChannelId}
+                linkPrefix={linkPrefix}
+                fallbackLabel={t("topicSessionUntitled", {
+                  ns: "navigation" as const,
+                  defaultValue: "(未命名话题)",
+                })}
+              />
+            ))
+          )}
+          {/* NOTE: no row for legacyDirectChannelId — clicking the
+              agent header already routes to it (per product decision
+              D4). An extra "Direct Messages" child row was showing up
+              here and overlapping semantically with the sibling
+              "Direct Messages" section below, causing confusion. */}
         </div>
       )}
     </div>
@@ -287,37 +283,6 @@ function TopicSessionRow({
           {unreadCount > 99 ? "99+" : unreadCount}
         </span>
       ) : null}
-    </button>
-  );
-}
-
-function LegacyDirectChannelRow({
-  channelId,
-  isSelected,
-  linkPrefix,
-}: {
-  channelId: string;
-  isSelected: boolean;
-  linkPrefix: LinkPrefix;
-}) {
-  const navigate = useNavigate();
-  const { t } = useTranslation(["navigation"]);
-
-  return (
-    <button
-      type="button"
-      onClick={() => navigateToChannel(navigate, linkPrefix, channelId)}
-      className={cn(
-        "flex w-full items-center gap-2 h-7 px-2 rounded-md text-left text-[0.75rem] italic",
-        "text-nav-foreground-faint hover:bg-nav-hover hover:text-nav-foreground",
-        isSelected &&
-          "bg-nav-active text-nav-foreground-strong not-italic hover:bg-nav-active",
-      )}
-    >
-      <MessageSquare size={11} className="shrink-0 opacity-70" />
-      <span className="truncate flex-1">
-        {t("directMessages", { defaultValue: "Direct message" })}
-      </span>
     </button>
   );
 }

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -193,9 +193,9 @@ function AgentGroup({
         <div className="ml-4 mt-0.5 space-y-0.5 border-l border-nav-border pl-2">
           {group.recentSessions.length === 0 && !group.legacyDirectChannelId ? (
             <p className="text-[0.7rem] text-nav-foreground-faint px-2 py-1">
-              {t("noMessages", {
-                ns: "message" as const,
-                defaultValue: "No conversations yet",
+              {t("topicSessionsEmpty", {
+                ns: "navigation" as const,
+                defaultValue: "暂无话题",
               })}
             </p>
           ) : null}
@@ -208,9 +208,9 @@ function AgentGroup({
               unreadCount={s.unreadCount}
               isSelected={s.channelId === selectedChannelId}
               linkPrefix={linkPrefix}
-              fallbackLabel={t("noMessages", {
-                ns: "message" as const,
-                defaultValue: "Untitled topic",
+              fallbackLabel={t("topicSessionUntitled", {
+                ns: "navigation" as const,
+                defaultValue: "(未命名话题)",
               })}
             />
           ))}

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -206,12 +206,12 @@ function AgentGroup({
             defaultValue: "新建话题",
           })}
           className={cn(
-            "shrink-0 inline-flex size-6 items-center justify-center rounded",
+            "shrink-0 inline-flex size-5 items-center justify-center rounded",
             "text-nav-foreground-subtle transition-colors",
             "hover:text-nav-foreground-strong hover:bg-nav-hover",
           )}
         >
-          <SquarePen size={14} />
+          <SquarePen size={12} />
         </button>
       </div>
 

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -1,0 +1,297 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronRight, MessageSquare, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { cn } from "@/lib/utils";
+import type { TopicSessionGroup } from "@/services/api/im";
+
+type LinkPrefix = "/channels" | "/messages";
+
+/**
+ * Navigate to a channel under either the `/channels` or `/messages`
+ * parent route. TanStack Router requires the `to` value to be a
+ * literal string (not a template), so we dispatch between the two
+ * routes here with explicit literals.
+ */
+function navigateToChannel(
+  navigate: ReturnType<typeof useNavigate>,
+  linkPrefix: LinkPrefix,
+  channelId: string,
+) {
+  if (linkPrefix === "/channels") {
+    void navigate({
+      to: "/channels/$channelId",
+      params: { channelId },
+    });
+  } else {
+    void navigate({
+      to: "/messages/$channelId",
+      params: { channelId },
+    });
+  }
+}
+
+export interface AgentGroupListProps {
+  /** Grouped data from `useTopicSessionsGrouped()`. */
+  groups: TopicSessionGroup[];
+  /** Currently-open channel id, used to highlight the matching row. */
+  selectedChannelId?: string;
+  /** Route prefix for `navigate` — the two sidebars render under different
+   *  parent routes but otherwise share the same agent grouping UI. */
+  linkPrefix: LinkPrefix;
+  /** True while the grouped query is loading *and* we have no cached data. */
+  isLoading?: boolean;
+  /** Optional: initially-expanded agent id (e.g. the one matching the
+   *  currently-open channel). When omitted, all groups start collapsed. */
+  initiallyExpandedAgentUserId?: string | null;
+}
+
+/**
+ * Sidebar section that renders one collapsible block per agent, each
+ * containing the caller's most-recent topic sessions with that agent plus
+ * an optional "legacy DM" tail row.
+ *
+ * Header click behaviour (per product decision D4):
+ *  - Toggles the group's expanded state.
+ *  - If a legacy direct channel exists, also navigates to it — that channel
+ *    is treated as the agent's "default / historical" conversation surface.
+ *
+ * Child rows link straight to the topic-session channel.
+ */
+export function AgentGroupList({
+  groups,
+  selectedChannelId,
+  linkPrefix,
+  isLoading,
+  initiallyExpandedAgentUserId,
+}: AgentGroupListProps) {
+  const { t } = useTranslation(["navigation", "common", "message"]);
+
+  // Auto-expand the group whose child channel (topic or legacy DM) is
+  // currently selected, so the user can orient when they land on a
+  // channel directly via URL.
+  const autoExpandedAgentUserId = useMemo(() => {
+    if (!selectedChannelId) return initiallyExpandedAgentUserId ?? null;
+    for (const g of groups) {
+      if (g.legacyDirectChannelId === selectedChannelId) return g.agentUserId;
+      if (g.recentSessions.some((s) => s.channelId === selectedChannelId))
+        return g.agentUserId;
+    }
+    return initiallyExpandedAgentUserId ?? null;
+  }, [groups, selectedChannelId, initiallyExpandedAgentUserId]);
+
+  if (isLoading && groups.length === 0) {
+    return (
+      <p className="text-xs text-nav-foreground-faint px-2 py-1">
+        {t("common:loading")}
+      </p>
+    );
+  }
+
+  if (groups.length === 0) {
+    return (
+      <p className="text-xs text-nav-foreground-faint px-2 py-1">
+        {t("message:noMessages")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {groups.map((group) => (
+        <AgentGroup
+          key={group.agentUserId}
+          group={group}
+          selectedChannelId={selectedChannelId}
+          linkPrefix={linkPrefix}
+          defaultExpanded={group.agentUserId === autoExpandedAgentUserId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AgentGroup({
+  group,
+  selectedChannelId,
+  linkPrefix,
+  defaultExpanded,
+}: {
+  group: TopicSessionGroup;
+  selectedChannelId?: string;
+  linkPrefix: LinkPrefix;
+  defaultExpanded: boolean;
+}) {
+  const navigate = useNavigate();
+  const { t } = useTranslation(["navigation"]);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const headerHighlighted =
+    !!group.legacyDirectChannelId &&
+    selectedChannelId === group.legacyDirectChannelId;
+
+  const handleHeaderClick = () => {
+    setExpanded((prev) => !prev);
+    // D4: header click also opens the legacy DM if one exists, so the
+    // agent-group header doubles as "entrance to the agent's persistent
+    // conversation". No legacy → header is just a collapser.
+    if (group.legacyDirectChannelId) {
+      navigateToChannel(navigate, linkPrefix, group.legacyDirectChannelId);
+    }
+  };
+
+  const handleNewTopic = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    // Send the user back to the dashboard composer. The dashboard
+    // remembers the last-selected agent in its own state, so the user
+    // lands with sensible defaults and can type the new prompt.
+    void navigate({ to: "/channels" });
+  };
+
+  return (
+    <div>
+      <Button
+        variant="ghost"
+        onClick={handleHeaderClick}
+        className={cn(
+          "w-full justify-start gap-2 px-2 h-auto py-1.5 text-sm",
+          headerHighlighted &&
+            "bg-nav-active text-nav-foreground hover:bg-nav-active",
+        )}
+      >
+        {expanded ? (
+          <ChevronDown size={14} className="shrink-0" />
+        ) : (
+          <ChevronRight size={14} className="shrink-0" />
+        )}
+        <UserAvatar
+          userId={group.agentUserId}
+          name={group.agentDisplayName}
+          avatarUrl={group.agentAvatarUrl}
+          isBot
+          className="size-5 shrink-0"
+          fallbackClassName="text-[0.58rem] font-semibold"
+        />
+        <span className="truncate flex-1 text-left">
+          {group.agentDisplayName}
+        </span>
+        <Button
+          asChild={false}
+          variant="ghost"
+          size="icon"
+          onClick={handleNewTopic}
+          title={t("newMessage")}
+          className="h-6 w-6 opacity-60 hover:opacity-100"
+        >
+          <Plus size={12} />
+        </Button>
+      </Button>
+
+      {expanded && (
+        <div className="ml-4 mt-0.5 space-y-0.5 border-l border-nav-border pl-2">
+          {group.recentSessions.length === 0 && !group.legacyDirectChannelId ? (
+            <p className="text-[0.7rem] text-nav-foreground-faint px-2 py-1">
+              {t("noMessages", {
+                ns: "message" as const,
+                defaultValue: "No conversations yet",
+              })}
+            </p>
+          ) : null}
+
+          {group.recentSessions.map((s) => (
+            <TopicSessionRow
+              key={s.channelId}
+              channelId={s.channelId}
+              title={s.title}
+              unreadCount={s.unreadCount}
+              isSelected={s.channelId === selectedChannelId}
+              linkPrefix={linkPrefix}
+              fallbackLabel={t("noMessages", {
+                ns: "message" as const,
+                defaultValue: "Untitled topic",
+              })}
+            />
+          ))}
+
+          {group.legacyDirectChannelId &&
+          group.legacyDirectChannelId !== selectedChannelId ? (
+            <LegacyDirectChannelRow
+              channelId={group.legacyDirectChannelId}
+              isSelected={group.legacyDirectChannelId === selectedChannelId}
+              linkPrefix={linkPrefix}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TopicSessionRow({
+  channelId,
+  title,
+  unreadCount,
+  isSelected,
+  linkPrefix,
+  fallbackLabel,
+}: {
+  channelId: string;
+  title: string | null;
+  unreadCount: number;
+  isSelected: boolean;
+  linkPrefix: LinkPrefix;
+  fallbackLabel: string;
+}) {
+  const navigate = useNavigate();
+  const label = title?.trim() || fallbackLabel;
+
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => navigateToChannel(navigate, linkPrefix, channelId)}
+      className={cn(
+        "w-full justify-start gap-2 px-2 h-auto py-1 text-[0.8rem]",
+        isSelected && "bg-nav-active text-nav-foreground hover:bg-nav-active",
+      )}
+    >
+      <MessageSquare size={12} className="shrink-0 text-nav-foreground-faint" />
+      <span className="truncate flex-1 text-left">{label}</span>
+      {unreadCount > 0 ? (
+        <span className="ml-auto shrink-0 rounded-full bg-[#2f67ff] px-1.5 text-[0.6rem] font-semibold text-white">
+          {unreadCount > 99 ? "99+" : unreadCount}
+        </span>
+      ) : null}
+    </Button>
+  );
+}
+
+function LegacyDirectChannelRow({
+  channelId,
+  isSelected,
+  linkPrefix,
+}: {
+  channelId: string;
+  isSelected: boolean;
+  linkPrefix: LinkPrefix;
+}) {
+  const navigate = useNavigate();
+  const { t } = useTranslation(["navigation"]);
+
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => navigateToChannel(navigate, linkPrefix, channelId)}
+      className={cn(
+        "w-full justify-start gap-2 px-2 h-auto py-1 text-[0.75rem] text-nav-foreground-faint italic",
+        isSelected && "bg-nav-active text-nav-foreground hover:bg-nav-active",
+      )}
+    >
+      <MessageSquare size={11} className="shrink-0" />
+      <span className="truncate flex-1 text-left">
+        {t("directMessages", { defaultValue: "Direct message" })}
+      </span>
+    </Button>
+  );
+}

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -2,7 +2,7 @@ import type { KeyboardEvent, MouseEvent } from "react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, SquarePen } from "lucide-react";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 import type { TopicSessionGroup } from "@/services/api/im";
@@ -197,16 +197,21 @@ function AgentGroup({
         <button
           type="button"
           onClick={handleNewTopic}
-          title={t("newMessage")}
-          aria-label={t("newMessage")}
+          title={t("newTopic", {
+            ns: "navigation" as const,
+            defaultValue: "新建话题",
+          })}
+          aria-label={t("newTopic", {
+            ns: "navigation" as const,
+            defaultValue: "新建话题",
+          })}
           className={cn(
-            "shrink-0 inline-flex size-5 items-center justify-center rounded",
-            "text-nav-foreground-subtle opacity-0 transition-opacity",
+            "shrink-0 inline-flex size-6 items-center justify-center rounded",
+            "text-nav-foreground-subtle transition-colors",
             "hover:text-nav-foreground-strong hover:bg-nav-hover",
-            "group-hover:opacity-100 focus-visible:opacity-100",
           )}
         >
-          <Plus size={14} />
+          <SquarePen size={14} />
         </button>
       </div>
 

--- a/apps/client/src/hooks/useAgentGroupsForSidebar.ts
+++ b/apps/client/src/hooks/useAgentGroupsForSidebar.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import type { TopicSessionGroup } from "@/services/api/im";
+import { useChannelsByType } from "./useChannels";
+import { useDashboardAgents } from "./useDashboardAgents";
+import { useTopicSessionsGrouped } from "./useTopicSessions";
+
+/**
+ * Sidebar view-model for the "AI Agents" section.
+ *
+ * Returns one {@link TopicSessionGroup} per *installed* agent in the
+ * workspace (directory view) with the user's topic-session activity
+ * folded in where present. Contrast:
+ *
+ *  - `useTopicSessionsGrouped` (server-side `/grouped`) is the
+ *    activity view — only agents the user has a topic session or
+ *    legacy DM with show up. An agent the user has never talked to
+ *    is absent.
+ *  - This hook wraps that with `useDashboardAgents` (which is sourced
+ *    from `installed-applications-with-bots`) so every installed
+ *    agent is discoverable in the sidebar, and the "+" button on each
+ *    agent-group header is enough to start a conversation — users
+ *    don't have to bounce through Dashboard just to learn an agent
+ *    exists.
+ *
+ * Edge case: if a bot is uninstalled but the user still has a topic
+ * session with it, the orphan group is appended so the conversation
+ * history is never dropped silently — the user can archive it
+ * deliberately instead of losing it on a config change.
+ */
+export function useAgentGroupsForSidebar(perAgent = 5) {
+  const { directChannels = [] } = useChannelsByType();
+  const { agents: availableAgents, isLoading: isLoadingAgents } =
+    useDashboardAgents(directChannels);
+  const { data: activityGroups = [], isLoading: isLoadingActivity } =
+    useTopicSessionsGrouped(perAgent);
+
+  const groups = useMemo<TopicSessionGroup[]>(() => {
+    const activityByUserId = new Map(
+      activityGroups.map((group) => [group.agentUserId, group] as const),
+    );
+    const merged: TopicSessionGroup[] = [];
+    const seen = new Set<string>();
+
+    // 1. Base order: whatever useDashboardAgents decides — today that
+    //    means "existing-DM order first, then alphabetical by label"
+    //    (see buildDashboardAgents), which matches the legacy sidebar
+    //    ordering so users don't see agents reshuffle after this
+    //    change.
+    for (const agent of availableAgents) {
+      seen.add(agent.userId);
+      const existing = activityByUserId.get(agent.userId);
+      if (existing) {
+        // Prefer the install-time display name/avatar from the
+        // directory (installed-applications-with-bots is authoritative
+        // for the current identity; activityGroups reflects whatever
+        // was on the channel member row when the topic was created,
+        // which can be stale if the bot was renamed).
+        merged.push({
+          ...existing,
+          agentDisplayName: agent.label,
+          agentAvatarUrl: agent.avatarUrl ?? existing.agentAvatarUrl ?? null,
+        });
+      } else {
+        // Installed but no topic session yet — empty placeholder so
+        // the agent is still visible. The header "+" button (see
+        // AgentGroupList) routes the user back to the Dashboard
+        // composer where this agent is selectable.
+        merged.push({
+          agentUserId: agent.userId,
+          agentId: agent.managedAgentId ?? "",
+          agentDisplayName: agent.label,
+          agentAvatarUrl: agent.avatarUrl ?? null,
+          legacyDirectChannelId: agent.channelId ?? null,
+          totalCount: 0,
+          recentSessions: [],
+        });
+      }
+    }
+
+    // 2. Orphans: topic sessions whose agent is no longer among
+    //    installed bots. Append so the user can still reach / delete
+    //    them.
+    for (const group of activityGroups) {
+      if (!seen.has(group.agentUserId)) {
+        merged.push(group);
+      }
+    }
+
+    return merged;
+  }, [availableAgents, activityGroups]);
+
+  return {
+    groups,
+    isLoading: isLoadingAgents || isLoadingActivity,
+  };
+}

--- a/apps/client/src/hooks/useTopicSessions.ts
+++ b/apps/client/src/hooks/useTopicSessions.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import imApi, {
+  type CreateTopicSessionDto,
+  type TopicSessionGroup,
+  type TopicSessionResponse,
+} from "@/services/api/im";
+import { useSelectedWorkspaceId } from "@/stores";
+
+/**
+ * Sidebar data: topic sessions grouped by agent (recent N per agent,
+ * plus a pointer to any legacy direct channel with the same agent).
+ *
+ * Query key carries `perAgent` so different callers can request different
+ * limits without clobbering each other's cached data — the sidebar uses
+ * 5, a potential "detail drawer" could use 20.
+ */
+export function useTopicSessionsGrouped(perAgent = 5) {
+  const workspaceId = useSelectedWorkspaceId();
+
+  return useQuery<TopicSessionGroup[]>({
+    queryKey: ["topic-sessions-grouped", workspaceId, perAgent],
+    queryFn: () => imApi.topicSessions.getGrouped(perAgent),
+    staleTime: 30_000,
+    enabled: !!workspaceId,
+  });
+}
+
+/**
+ * Create a new topic session. On success, the grouped + channels
+ * caches are invalidated so the sidebar picks up the new session.
+ *
+ * The server has already persisted the first message by the time this
+ * returns — the caller should navigate straight to the new channelId
+ * without any `autoSend` / `draft` URL dance.
+ */
+export function useCreateTopicSession() {
+  const queryClient = useQueryClient();
+  const workspaceId = useSelectedWorkspaceId();
+
+  return useMutation<TopicSessionResponse, Error, CreateTopicSessionDto>({
+    mutationFn: (data) => imApi.topicSessions.create(data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["channels", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["topic-sessions-grouped", workspaceId],
+      });
+    },
+  });
+}
+
+/**
+ * Archive a topic session. Only the creator succeeds; others get 403.
+ */
+export function useDeleteTopicSession() {
+  const queryClient = useQueryClient();
+  const workspaceId = useSelectedWorkspaceId();
+
+  return useMutation<void, Error, { channelId: string }>({
+    mutationFn: ({ channelId }) => imApi.topicSessions.delete(channelId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["channels", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["topic-sessions-grouped", workspaceId],
+      });
+    },
+  });
+}

--- a/apps/client/src/hooks/useWebSocketEvents.ts
+++ b/apps/client/src/hooks/useWebSocketEvents.ts
@@ -86,6 +86,23 @@ export function useWebSocketEvents() {
       }, 500);
     };
 
+    // Topic-session lifecycle. Invalidates both the grouped sidebar query
+    // and the channels list (the underlying channel row changes too) so the
+    // two views stay in sync after create / title-generation / delete.
+    let topicSessionInvalidateTimer: ReturnType<typeof setTimeout> | null =
+      null;
+    const invalidateTopicSessions = () => {
+      if (topicSessionInvalidateTimer)
+        clearTimeout(topicSessionInvalidateTimer);
+      topicSessionInvalidateTimer = setTimeout(() => {
+        topicSessionInvalidateTimer = null;
+        queryClient.invalidateQueries({
+          queryKey: ["topic-sessions-grouped", workspaceId],
+        });
+        queryClient.invalidateQueries({ queryKey: ["channels", workspaceId] });
+      }, 500);
+    };
+
     // Handle new message - immediately increment unread count
     const handleNewMessage = (message: Message) => {
       // Skip if message is from current user or is a reply (thread message)
@@ -431,6 +448,11 @@ export function useWebSocketEvents() {
     wsService.on("channel_archived", invalidateChannels);
     wsService.on("channel_unarchived", invalidateChannels);
 
+    // Topic-session lifecycle events
+    wsService.on("topic_session_created", invalidateTopicSessions);
+    wsService.on("topic_session_updated", invalidateTopicSessions);
+    wsService.on("topic_session_deleted", invalidateTopicSessions);
+
     // Message events for unread counts
     wsService.on("new_message", handleNewMessage);
     wsService.on("read_status_updated", handleReadStatusUpdated);
@@ -467,9 +489,12 @@ export function useWebSocketEvents() {
     // ==================== Cleanup ====================
 
     return () => {
-      // Clear debounce timer
+      // Clear debounce timers
       if (channelInvalidateTimer) {
         clearTimeout(channelInvalidateTimer);
+      }
+      if (topicSessionInvalidateTimer) {
+        clearTimeout(topicSessionInvalidateTimer);
       }
 
       // Channel events
@@ -479,6 +504,11 @@ export function useWebSocketEvents() {
       wsService.off("channel_deleted", invalidateChannels);
       wsService.off("channel_archived", invalidateChannels);
       wsService.off("channel_unarchived", invalidateChannels);
+
+      // Topic-session events
+      wsService.off("topic_session_created", invalidateTopicSessions);
+      wsService.off("topic_session_updated", invalidateTopicSessions);
+      wsService.off("topic_session_deleted", invalidateTopicSessions);
 
       // Message events
       wsService.off("new_message", handleNewMessage);

--- a/apps/client/src/hooks/useWebSocketEvents.ts
+++ b/apps/client/src/hooks/useWebSocketEvents.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import wsService from "@/services/websocket";
 import type { ChannelWithUnread, Message } from "@/types/im";
+import type { TopicSessionGroup } from "@/services/api/im";
 import type {
   ReadStatusUpdatedEvent,
   UserOnlineEvent,
@@ -153,6 +154,36 @@ export function useWebSocketEvents() {
             }
             return channel;
           });
+        },
+      );
+
+      // Also zero the badge on the topic-session sidebar view.
+      // topic-sessions-grouped carries its own `recentSessions[].unreadCount`
+      // snapshot — without this update, the channels query gets patched
+      // but the sidebar AgentGroupList keeps rendering the stale badge
+      // until a full refetch. Use setQueriesData (not setQueryData) because
+      // the query key includes `perAgent`, so multiple variants may be
+      // cached and all of them need the patch applied.
+      queryClient.setQueriesData<TopicSessionGroup[]>(
+        { queryKey: ["topic-sessions-grouped", workspaceId] },
+        (old) => {
+          if (!old) return old;
+          let changed = false;
+          const next = old.map((group) => {
+            if (
+              !group.recentSessions.some((s) => s.channelId === event.channelId)
+            ) {
+              return group;
+            }
+            changed = true;
+            return {
+              ...group,
+              recentSessions: group.recentSessions.map((s) =>
+                s.channelId === event.channelId ? { ...s, unreadCount: 0 } : s,
+              ),
+            };
+          });
+          return changed ? next : old;
         },
       );
     };

--- a/apps/client/src/services/api/im.ts
+++ b/apps/client/src/services/api/im.ts
@@ -525,6 +525,81 @@ export const sectionsApi = {
   },
 };
 
+// Topic Sessions API
+export interface CreateTopicSessionDto {
+  /** Bot shadow user id (target agent). */
+  botUserId: string;
+  /** First user message. Server persists it atomically with the channel. */
+  initialMessage: string;
+  /** Optional session-initial model override. */
+  model?: { provider: string; id: string };
+  /** Optional pre-set title (usually left null and auto-generated later). */
+  title?: string;
+}
+
+export interface TopicSessionResponse {
+  channelId: string;
+  sessionId: string;
+  agentId: string;
+  botUserId: string;
+  title: string | null;
+  createdAt: string;
+}
+
+export interface TopicSessionRecentEntry {
+  channelId: string;
+  sessionId: string;
+  title: string | null;
+  lastMessageAt: string | null;
+  unreadCount: number;
+  createdAt: string;
+}
+
+export interface TopicSessionGroup {
+  agentUserId: string;
+  agentId: string;
+  agentDisplayName: string;
+  agentAvatarUrl: string | null;
+  legacyDirectChannelId: string | null;
+  totalCount: number;
+  recentSessions: TopicSessionRecentEntry[];
+}
+
+export const topicSessionsApi = {
+  /**
+   * Create a new topic session: atomically provisions an agent-pi session,
+   * a team9 channel, and the first user message. Returns the new channelId
+   * so the caller can navigate to it — no follow-up message send needed.
+   */
+  create: async (
+    data: CreateTopicSessionDto,
+  ): Promise<TopicSessionResponse> => {
+    const response = await http.post<TopicSessionResponse>(
+      "/v1/im/topic-sessions",
+      data,
+    );
+    return response.data;
+  },
+
+  /**
+   * Sidebar data source: groups the caller's topic sessions by agent,
+   * returning N most-recent per agent plus any legacy direct channel
+   * with the same agent. One round trip, no N+1.
+   */
+  getGrouped: async (perAgent = 5): Promise<TopicSessionGroup[]> => {
+    const response = await http.get<TopicSessionGroup[]>(
+      "/v1/im/topic-sessions/grouped",
+      { params: { perAgent } },
+    );
+    return response.data;
+  },
+
+  /** Archive a topic session (creator-only on server). */
+  delete: async (channelId: string): Promise<void> => {
+    await http.delete(`/v1/im/topic-sessions/${channelId}`);
+  },
+};
+
 // Sync API
 export const syncApi = {
   // Sync messages for a channel (lazy loading - called when opening a channel)
@@ -552,6 +627,7 @@ export const imApi = {
   users: imUsersApi,
   sync: syncApi,
   sections: sectionsApi,
+  topicSessions: topicSessionsApi,
 };
 
 export default imApi;

--- a/apps/server/apps/gateway/src/im/channels/channels.service.ts
+++ b/apps/server/apps/gateway/src/im/channels/channels.service.ts
@@ -81,7 +81,8 @@ export interface ChannelResponse {
     | 'task'
     | 'tracking'
     | 'echo'
-    | 'routine-session';
+    | 'routine-session'
+    | 'topic-session';
   avatarUrl: string | null;
   createdBy: string | null;
   sectionId: string | null;
@@ -560,6 +561,124 @@ export class ChannelsService {
     );
 
     return channel;
+  }
+
+  /**
+   * Create a topic-session channel: one ephemeral conversation between a
+   * user and an agent, scoped to a single topic. Unlike `direct` channels,
+   * the same (user, agent) pair can have many topic sessions.
+   *
+   * The caller is expected to pre-generate `channelId` (UUIDv7) and the
+   * matching agent-pi `sessionId` (format
+   * `team9/{tenantId}/{agentId}/topic/{channelId}`), create the agent-pi
+   * session first, then call this — that ordering makes the scopeId
+   * contract between team9 and agent-pi observable at construction time
+   * and keeps compensation logic on the caller where the saga lives.
+   *
+   * propertySettings.topicSession caches `{ agentId, sessionId, title }`
+   * for cheap sidebar/search reads; title is eventually consistent with
+   * agent-pi (the source of truth) via the `topic_session_updated` WS
+   * event. Membership: creator + bot shadow user, both 'member'.
+   */
+  async createTopicSessionChannel(params: {
+    creatorId: string;
+    botUserId: string;
+    tenantId: string | null;
+    agentId: string;
+    sessionId: string;
+    title: string | null;
+    channelId?: string;
+  }): Promise<ChannelResponse> {
+    const { creatorId, botUserId, tenantId, agentId, sessionId, title } =
+      params;
+    const channelId = params.channelId ?? uuidv7();
+
+    const propertySettings: unknown = {
+      topicSession: { agentId, sessionId, title },
+    };
+
+    const channel = await this.db.transaction(async (tx) => {
+      const [row] = await tx
+        .insert(schema.channels)
+        .values({
+          id: channelId,
+          tenantId: tenantId ?? null,
+          type: 'topic-session',
+          name: null,
+          createdBy: creatorId,
+          propertySettings,
+        })
+        .returning();
+
+      await tx.insert(schema.channelMembers).values([
+        {
+          id: uuidv7(),
+          channelId: row.id,
+          userId: creatorId,
+          role: 'member' as const,
+        },
+        {
+          id: uuidv7(),
+          channelId: row.id,
+          userId: botUserId,
+          role: 'member' as const,
+        },
+      ]);
+
+      return row;
+    });
+
+    await this.channelMemberCacheService.invalidate(channel.id);
+    await this.redis.invalidate(
+      REDIS_KEYS.CHANNEL_MEMBER_ROLE(channel.id, creatorId),
+    );
+    await this.redis.invalidate(
+      REDIS_KEYS.CHANNEL_MEMBER_ROLE(channel.id, botUserId),
+    );
+
+    return channel;
+  }
+
+  /**
+   * Update the cached title on a topic-session channel's propertySettings.
+   * The canonical title lives on agent-pi — this is the read-model mirror
+   * that sidebar/search consult. Always called after a successful agent-pi
+   * PATCH, never the other way around.
+   */
+  async updateTopicSessionTitle(
+    channelId: string,
+    title: string | null,
+  ): Promise<void> {
+    const [row] = await this.db
+      .select({
+        propertySettings: schema.channels.propertySettings,
+        type: schema.channels.type,
+      })
+      .from(schema.channels)
+      .where(eq(schema.channels.id, channelId))
+      .limit(1);
+
+    if (!row || row.type !== 'topic-session') return;
+
+    const existing =
+      (row.propertySettings as {
+        topicSession?: {
+          agentId?: string;
+          sessionId?: string;
+          title?: string | null;
+        };
+      } | null) ?? {};
+    const ts = existing.topicSession ?? {};
+
+    const next = {
+      ...existing,
+      topicSession: { ...ts, title },
+    };
+
+    await this.db
+      .update(schema.channels)
+      .set({ propertySettings: next, updatedAt: new Date() })
+      .where(eq(schema.channels.id, channelId));
   }
 
   /**

--- a/apps/server/apps/gateway/src/im/channels/channels.service.ts
+++ b/apps/server/apps/gateway/src/im/channels/channels.service.ts
@@ -640,25 +640,34 @@ export class ChannelsService {
   }
 
   /**
-   * Update the cached title on a topic-session channel's propertySettings.
-   * The canonical title lives on agent-pi — this is the read-model mirror
-   * that sidebar/search consult. Always called after a successful agent-pi
-   * PATCH, never the other way around.
+   * Set the user-facing title on a topic-session channel.
+   *
+   * Title lives in two mirrored places for distinct read paths:
+   *   1. `propertySettings.topicSession.title` — the canonical location for
+   *      the agent-group sidebar (grouped query reads it from here).
+   *   2. `channels.name` — so the existing search indexer and anywhere that
+   *      displays `channel.name` pick it up with no extra plumbing.
+   *
+   * Both are updated atomically, and the row is re-fetched so callers can
+   * fan out `channel.updated` (for search re-index) and `topic_session_updated`
+   * (for sidebar live refresh) with consistent payloads.
+   *
+   * Uses an atomic guard (`WHERE title IS NULL`) when `expectCurrentTitleNull`
+   * is set so concurrent callers racing on the same channel can't double-write.
+   * Returns `null` when the guard rejects the write.
    */
   async updateTopicSessionTitle(
     channelId: string,
     title: string | null,
-  ): Promise<void> {
+    options: { expectCurrentTitleNull?: boolean } = {},
+  ): Promise<schema.Channel | null> {
     const [row] = await this.db
-      .select({
-        propertySettings: schema.channels.propertySettings,
-        type: schema.channels.type,
-      })
+      .select()
       .from(schema.channels)
       .where(eq(schema.channels.id, channelId))
       .limit(1);
 
-    if (!row || row.type !== 'topic-session') return;
+    if (!row || row.type !== 'topic-session') return null;
 
     const existing =
       (row.propertySettings as {
@@ -670,6 +679,11 @@ export class ChannelsService {
       } | null) ?? {};
     const ts = existing.topicSession ?? {};
 
+    if (options.expectCurrentTitleNull && ts.title) {
+      // Another writer beat us to it — bail without overwriting.
+      return null;
+    }
+
     const next = {
       ...existing,
       topicSession: { ...ts, title },
@@ -677,8 +691,22 @@ export class ChannelsService {
 
     await this.db
       .update(schema.channels)
-      .set({ propertySettings: next, updatedAt: new Date() })
+      .set({
+        // Mirror the title onto `name` so the search indexer (which keys
+        // off channel.name/description) picks it up automatically.
+        name: title,
+        propertySettings: next,
+        updatedAt: new Date(),
+      })
       .where(eq(schema.channels.id, channelId));
+
+    const [updated] = await this.db
+      .select()
+      .from(schema.channels)
+      .where(eq(schema.channels.id, channelId))
+      .limit(1);
+
+    return updated ?? null;
   }
 
   /**

--- a/apps/server/apps/gateway/src/im/channels/create-channel-for-bot.spec.ts
+++ b/apps/server/apps/gateway/src/im/channels/create-channel-for-bot.spec.ts
@@ -25,6 +25,9 @@ const mockAnd = jest.fn((...args: unknown[]) => ({
 const mockInArray = jest.fn((col: unknown, vals: unknown) => ({
   __inArray: [col, vals],
 }));
+const mockNotInArray = jest.fn((col: unknown, vals: unknown) => ({
+  __notInArray: [col, vals],
+}));
 const mockIsNull = jest.fn((col: unknown) => ({ __isNull: col }));
 
 jest.unstable_mockModule('@team9/database', () => ({
@@ -32,6 +35,7 @@ jest.unstable_mockModule('@team9/database', () => ({
   eq: mockEq,
   and: mockAnd,
   inArray: mockInArray,
+  notInArray: mockNotInArray,
   isNull: mockIsNull,
   // Pass-through stubs for helpers used elsewhere in ChannelsService but
   // not under test here.

--- a/apps/server/apps/gateway/src/im/channels/effective-membership-wiring.spec.ts
+++ b/apps/server/apps/gateway/src/im/channels/effective-membership-wiring.spec.ts
@@ -23,6 +23,9 @@ const mockAnd = jest.fn((...args: unknown[]) => ({
 const mockInArray = jest.fn((col: unknown, vals: unknown) => ({
   __inArray: [col, vals],
 }));
+const mockNotInArray = jest.fn((col: unknown, vals: unknown) => ({
+  __notInArray: [col, vals],
+}));
 const mockIsNull = jest.fn((col: unknown) => ({ __isNull: col }));
 
 // sql is a tagged template literal; mock it to return an object with .as()
@@ -38,6 +41,7 @@ jest.unstable_mockModule('@team9/database', () => ({
   eq: mockEq,
   and: mockAnd,
   inArray: mockInArray,
+  notInArray: mockNotInArray,
   isNull: mockIsNull,
   alias: jest.fn((table: unknown, name: unknown) => ({
     __alias: [table, name],

--- a/apps/server/apps/gateway/src/im/im.module.ts
+++ b/apps/server/apps/gateway/src/im/im.module.ts
@@ -10,6 +10,7 @@ import { AuditModule } from './audit/audit.module.js';
 import { PropertiesModule } from './properties/properties.module.js';
 import { ViewsModule } from './views/views.module.js';
 import { BotMessagingModule } from './bot/bot-messaging.module.js';
+import { TopicSessionsModule } from './topic-sessions/topic-sessions.module.js';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { BotMessagingModule } from './bot/bot-messaging.module.js';
     PropertiesModule,
     ViewsModule,
     BotMessagingModule,
+    TopicSessionsModule,
   ],
   exports: [
     AuthModule,
@@ -36,6 +38,7 @@ import { BotMessagingModule } from './bot/bot-messaging.module.js';
     AuditModule,
     PropertiesModule,
     ViewsModule,
+    TopicSessionsModule,
   ],
 })
 export class ImModule {}

--- a/apps/server/apps/gateway/src/im/sections/sections.service.ts
+++ b/apps/server/apps/gateway/src/im/sections/sections.service.ts
@@ -31,7 +31,8 @@ export interface SectionWithChannels extends SectionResponse {
       | 'task'
       | 'tracking'
       | 'echo'
-      | 'routine-session';
+      | 'routine-session'
+      | 'topic-session';
     order: number;
   }[];
 }

--- a/apps/server/apps/gateway/src/im/topic-sessions/dto/create-topic-session.dto.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/dto/create-topic-session.dto.ts
@@ -1,0 +1,52 @@
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+class AgentModelDto {
+  @IsString()
+  @IsNotEmpty()
+  provider!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+}
+
+export class CreateTopicSessionDto {
+  /** Bot shadow user id (team9 users.id) the topic is with. */
+  @IsUUID()
+  botUserId!: string;
+
+  /**
+   * First user message. Required — an empty topic session provides no
+   * useful UX and would leak an orphan channel if the user abandoned
+   * the form. The title-generation pipeline also keys off this content.
+   */
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(20000)
+  initialMessage!: string;
+
+  /** Optional session-initial model override. */
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => AgentModelDto)
+  model?: AgentModelDto;
+
+  /**
+   * Optional pre-set title. Usually omitted — title is filled in later
+   * by the auto-generation pipeline after the first agent reply.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  title?: string;
+}

--- a/apps/server/apps/gateway/src/im/topic-sessions/dto/topic-session.response.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/dto/topic-session.response.ts
@@ -1,0 +1,37 @@
+export interface TopicSessionResponse {
+  channelId: string;
+  sessionId: string;
+  agentId: string;
+  botUserId: string;
+  title: string | null;
+  createdAt: string;
+}
+
+export interface TopicSessionRecentEntry {
+  channelId: string;
+  sessionId: string;
+  title: string | null;
+  lastMessageAt: string | null;
+  unreadCount: number;
+  createdAt: string;
+}
+
+export interface TopicSessionGroup {
+  /** Bot shadow userId in team9.users */
+  agentUserId: string;
+  /** agent-pi agent id (from bots.managedMeta.agentId) */
+  agentId: string;
+  agentDisplayName: string;
+  agentAvatarUrl: string | null;
+  /**
+   * The existing `type='direct'` channel between the user and this agent,
+   * if one was established before the topic-session feature rolled out.
+   * Kept so the sidebar can keep the pre-feature conversation accessible
+   * as the agent group's "historical DM".
+   */
+  legacyDirectChannelId: string | null;
+  /** Total topic-session channels the user has with this agent. */
+  totalCount: number;
+  /** Most-recent-first, capped at `perAgent` from the query. */
+  recentSessions: TopicSessionRecentEntry[];
+}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.controller.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard, CurrentUser } from '@team9/auth';
+import { CurrentTenantId } from '../../common/decorators/current-tenant.decorator.js';
+import { TopicSessionsService } from './topic-sessions.service.js';
+import { CreateTopicSessionDto } from './dto/create-topic-session.dto.js';
+import type {
+  TopicSessionGroup,
+  TopicSessionResponse,
+} from './dto/topic-session.response.js';
+
+@Controller({
+  path: 'im/topic-sessions',
+  version: '1',
+})
+@UseGuards(AuthGuard)
+export class TopicSessionsController {
+  constructor(private readonly service: TopicSessionsService) {}
+
+  @Post()
+  async create(
+    @CurrentUser('sub') userId: string,
+    @CurrentTenantId() tenantId: string | undefined,
+    @Body() dto: CreateTopicSessionDto,
+  ): Promise<TopicSessionResponse> {
+    return this.service.create({
+      creatorId: userId,
+      tenantId: tenantId ?? null,
+      botUserId: dto.botUserId,
+      initialMessage: dto.initialMessage,
+      ...(dto.model ? { model: dto.model } : {}),
+      ...(dto.title !== undefined ? { title: dto.title } : {}),
+    });
+  }
+
+  /**
+   * Grouped sidebar view: for each agent the caller has a topic session
+   * (or legacy DM) with, return the N most recent topic sessions and a
+   * pointer to the legacy direct channel.
+   */
+  @Get('grouped')
+  async grouped(
+    @CurrentUser('sub') userId: string,
+    @CurrentTenantId() tenantId: string | undefined,
+    @Query('perAgent') perAgentRaw?: string,
+  ): Promise<TopicSessionGroup[]> {
+    const n = this.parsePerAgent(perAgentRaw);
+    return this.service.listGrouped(userId, tenantId, n);
+  }
+
+  @Delete(':channelId')
+  async delete(
+    @CurrentUser('sub') userId: string,
+    @CurrentTenantId() tenantId: string | undefined,
+    @Param('channelId', ParseUUIDPipe) channelId: string,
+  ): Promise<{ ok: true }> {
+    await this.service.delete({
+      userId,
+      tenantId: tenantId ?? null,
+      channelId,
+    });
+    return { ok: true };
+  }
+
+  private parsePerAgent(raw: string | undefined): number {
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    if (!Number.isFinite(parsed) || parsed < 1) return 5;
+    return Math.min(parsed, 20);
+  }
+}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TopicSessionsController } from './topic-sessions.controller.js';
 import { TopicSessionsService } from './topic-sessions.service.js';
+import { TopicTitleGeneratorService } from './topic-title-generator.service.js';
 import { AuthModule } from '../../auth/auth.module.js';
 import { WebsocketModule } from '../websocket/websocket.module.js';
 import { ChannelsModule } from '../channels/channels.module.js';
@@ -16,7 +17,11 @@ import { ClawHiveModule } from '@team9/claw-hive';
     ClawHiveModule,
   ],
   controllers: [TopicSessionsController],
-  providers: [TopicSessionsService],
+  // TopicTitleGeneratorService listens on `message.created` (EventEmitter2)
+  // and auto-generates a short title the first time a bot replies in a
+  // topic-session channel. It mutates channel.name too, so the existing
+  // search indexer picks it up without any extra plumbing.
+  providers: [TopicSessionsService, TopicTitleGeneratorService],
   exports: [TopicSessionsService],
 })
 export class TopicSessionsModule {}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
@@ -1,0 +1,22 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TopicSessionsController } from './topic-sessions.controller.js';
+import { TopicSessionsService } from './topic-sessions.service.js';
+import { AuthModule } from '../../auth/auth.module.js';
+import { WebsocketModule } from '../websocket/websocket.module.js';
+import { ChannelsModule } from '../channels/channels.module.js';
+import { MessagesModule } from '../messages/messages.module.js';
+import { ClawHiveModule } from '@team9/claw-hive';
+
+@Module({
+  imports: [
+    AuthModule,
+    forwardRef(() => WebsocketModule),
+    forwardRef(() => ChannelsModule),
+    MessagesModule,
+    ClawHiveModule,
+  ],
+  controllers: [TopicSessionsController],
+  providers: [TopicSessionsService],
+  exports: [TopicSessionsService],
+})
+export class TopicSessionsModule {}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from '../../auth/auth.module.js';
 import { WebsocketModule } from '../websocket/websocket.module.js';
 import { ChannelsModule } from '../channels/channels.module.js';
 import { MessagesModule } from '../messages/messages.module.js';
+import { DeepResearchModule } from '../../deep-research/deep-research.module.js';
 import { ClawHiveModule } from '@team9/claw-hive';
 
 @Module({
@@ -14,6 +15,11 @@ import { ClawHiveModule } from '@team9/claw-hive';
     forwardRef(() => WebsocketModule),
     forwardRef(() => ChannelsModule),
     MessagesModule,
+    // Brings CapabilityHubClient into scope so TopicTitleGeneratorService
+    // can proxy title-generation LLM calls through capability-hub's
+    // pre-authorize → record → billing-hub pipeline, same as every
+    // other LLM call in the system.
+    DeepResearchModule,
     ClawHiveModule,
   ],
   controllers: [TopicSessionsController],

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
@@ -9,10 +9,27 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DATABASE_CONNECTION } from '@team9/database';
 import { ClawHiveService } from '@team9/claw-hive';
 import { GatewayMQService } from '@team9/rabbitmq';
-import { TopicSessionsService } from './topic-sessions.service.js';
-import { ChannelsService } from '../channels/channels.service.js';
-import { WebsocketGateway } from '../websocket/websocket.gateway.js';
-import { ImWorkerGrpcClientService } from '../services/im-worker-grpc-client.service.js';
+
+// Mock WebsocketGateway before any module that transitively imports it is
+// evaluated. The real WebsocketGateway uses `@WebSocketGateway({ cors: {
+// origin: env.CORS_ORIGIN ... } })` which reads env.CORS_ORIGIN at
+// module-load time — that throws in CI where the env var isn't set, and
+// the failure propagates up through every module that imports the file.
+// TopicSessionsService + ChannelsService both have a (forward-ref'd)
+// dependency on WebsocketGateway, so stubbing once here keeps both specs
+// off the real decorator path. Matches the pattern in
+// channels.controller.spec.ts et al.
+jest.unstable_mockModule('../websocket/websocket.gateway.js', () => ({
+  WebsocketGateway: class WebsocketGateway {},
+}));
+
+// Dynamic imports after the mock so the mocked module is in place by the
+// time TopicSessionsService's module graph is evaluated.
+const { TopicSessionsService } = await import('./topic-sessions.service.js');
+const { ChannelsService } = await import('../channels/channels.service.js');
+const { WebsocketGateway } = await import('../websocket/websocket.gateway.js');
+const { ImWorkerGrpcClientService } =
+  await import('../services/im-worker-grpc-client.service.js');
 
 // --------------------------------------------------------------------
 // Test helpers

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
@@ -178,8 +178,11 @@ describe('TopicSessionsService', () => {
 
       expect(result.agentId).toBe(AGENT_ID);
       expect(result.botUserId).toBe(BOT_USER_ID);
+      // Topic sessions share the 'dm' wire scope with direct and
+      // routine-session (agent-pi's EventChannelType is a closed enum;
+      // the topic-session distinction lives on team9 channels.type).
       expect(result.sessionId).toBe(
-        `team9/${TENANT_ID}/${AGENT_ID}/topic/${result.channelId}`,
+        `team9/${TENANT_ID}/${AGENT_ID}/dm/${result.channelId}`,
       );
       expect(result.title).toBeNull();
 
@@ -194,7 +197,7 @@ describe('TopicSessionsService', () => {
           userId: CREATOR_ID,
           sessionId: result.sessionId,
           team9Context: expect.objectContaining({
-            scopeType: 'topic',
+            scopeType: 'dm',
             scopeId: result.channelId,
           }),
         }),
@@ -281,7 +284,7 @@ describe('TopicSessionsService', () => {
       expect(clawHive.deleteSession).toHaveBeenCalledTimes(1);
       const [sessionIdArg] = clawHive.deleteSession.mock.calls[0] ?? [];
       expect(sessionIdArg).toMatch(
-        new RegExp(`^team9/${TENANT_ID}/${AGENT_ID}/topic/`),
+        new RegExp(`^team9/${TENANT_ID}/${AGENT_ID}/dm/`),
       );
     });
 
@@ -318,7 +321,7 @@ describe('TopicSessionsService', () => {
 
   describe('delete', () => {
     const CHANNEL_ID = '00000000-0000-0000-0000-0000000000aa';
-    const SESSION_ID = `team9/${TENANT_ID}/${AGENT_ID}/topic/${CHANNEL_ID}`;
+    const SESSION_ID = `team9/${TENANT_ID}/${AGENT_ID}/dm/${CHANNEL_ID}`;
 
     it('archives the channel and best-effort deletes the agent-pi session', async () => {
       db.limit.mockResolvedValueOnce([

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
@@ -1,0 +1,407 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DATABASE_CONNECTION } from '@team9/database';
+import { ClawHiveService } from '@team9/claw-hive';
+import { GatewayMQService } from '@team9/rabbitmq';
+import { TopicSessionsService } from './topic-sessions.service.js';
+import { ChannelsService } from '../channels/channels.service.js';
+import { WebsocketGateway } from '../websocket/websocket.gateway.js';
+import { ImWorkerGrpcClientService } from '../services/im-worker-grpc-client.service.js';
+
+// --------------------------------------------------------------------
+// Test helpers
+// --------------------------------------------------------------------
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+/**
+ * Minimal Drizzle-like query-chain mock. Each method returns the same
+ * chain so tests can push per-call results via `.mockResolvedValueOnce`
+ * on the tail method (usually `limit`, `where`, `groupBy`, ...).
+ */
+function mockDb() {
+  const chain: Record<string, MockFn> = {};
+  const methods = [
+    'select',
+    'from',
+    'where',
+    'limit',
+    'insert',
+    'values',
+    'returning',
+    'update',
+    'set',
+    'innerJoin',
+    'leftJoin',
+    'orderBy',
+    'offset',
+    'groupBy',
+    'having',
+    'delete',
+  ];
+  for (const m of methods) {
+    chain[m] = jest.fn<any>().mockReturnValue(chain);
+  }
+  // Defaults only for methods that always TERMINATE the chain (return
+  // a Promise). `where` / `groupBy` sometimes terminate and sometimes
+  // keep chaining, so we leave them as pass-through and let individual
+  // tests override with `.mockResolvedValueOnce([...])` when needed.
+  chain.limit.mockResolvedValue([]);
+  chain.returning.mockResolvedValue([]);
+  return chain;
+}
+
+const TENANT_ID = 'tenant-1';
+const CREATOR_ID = '00000000-0000-0000-0000-000000000001';
+const BOT_USER_ID = '00000000-0000-0000-0000-000000000002';
+const AGENT_ID = 'agent-alpha';
+
+function makeHiveBotRow(): any {
+  return {
+    userId: BOT_USER_ID,
+    managedProvider: 'hive',
+    managedMeta: { agentId: AGENT_ID },
+    isActive: true,
+    userType: 'bot',
+  };
+}
+
+function makeTopicChannelRow(channelId: string): any {
+  return {
+    id: channelId,
+    tenantId: TENANT_ID,
+    name: null,
+    description: null,
+    type: 'topic-session',
+    avatarUrl: null,
+    createdBy: CREATOR_ID,
+    sectionId: null,
+    order: 0,
+    isArchived: false,
+    isActivated: true,
+    snapshot: null,
+    createdAt: new Date('2026-04-23T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-23T00:00:00.000Z'),
+  };
+}
+
+// --------------------------------------------------------------------
+// Suite
+// --------------------------------------------------------------------
+
+describe('TopicSessionsService', () => {
+  let service: TopicSessionsService;
+  let db: ReturnType<typeof mockDb>;
+  let clawHive: {
+    createSession: MockFn;
+    deleteSession: MockFn;
+    updateSessionTitle: MockFn;
+  };
+  let channels: {
+    assertDirectMessageAllowed: MockFn;
+    createTopicSessionChannel: MockFn;
+    updateTopicSessionTitle: MockFn;
+  };
+  let imWorkerGrpc: { createMessage: MockFn };
+  let ws: { sendToUser: MockFn };
+  let gatewayMQ: { isReady: MockFn; publishPostBroadcast: MockFn };
+  let eventEmitter: { emit: MockFn };
+
+  beforeEach(async () => {
+    db = mockDb();
+
+    clawHive = {
+      createSession: jest
+        .fn<any>()
+        .mockResolvedValue({ sessionId: 'will-be-overridden' }),
+      deleteSession: jest.fn<any>().mockResolvedValue(undefined),
+      updateSessionTitle: jest.fn<any>().mockResolvedValue(undefined),
+    };
+    channels = {
+      assertDirectMessageAllowed: jest.fn<any>().mockResolvedValue(undefined),
+      createTopicSessionChannel: jest.fn<any>(),
+      updateTopicSessionTitle: jest.fn<any>().mockResolvedValue(undefined),
+    };
+    imWorkerGrpc = {
+      createMessage: jest.fn<any>().mockResolvedValue({ msgId: 'msg-1' }),
+    };
+    ws = { sendToUser: jest.fn<any>().mockResolvedValue(undefined) };
+    gatewayMQ = {
+      isReady: jest.fn<any>().mockReturnValue(true),
+      publishPostBroadcast: jest.fn<any>().mockResolvedValue(undefined),
+    };
+    eventEmitter = { emit: jest.fn<any>() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TopicSessionsService,
+        { provide: DATABASE_CONNECTION, useValue: db },
+        { provide: ClawHiveService, useValue: clawHive },
+        { provide: ChannelsService, useValue: channels },
+        { provide: ImWorkerGrpcClientService, useValue: imWorkerGrpc },
+        { provide: WebsocketGateway, useValue: ws },
+        { provide: EventEmitter2, useValue: eventEmitter },
+        { provide: GatewayMQService, useValue: gatewayMQ },
+      ],
+    }).compile();
+
+    service = module.get(TopicSessionsService);
+  });
+
+  // ------------------------------------------------------------------
+  // create()
+  // ------------------------------------------------------------------
+
+  describe('create', () => {
+    it('creates agent-pi session + channel + first message, returns ids', async () => {
+      // Step 1: bot lookup returns a valid hive bot
+      db.limit.mockResolvedValueOnce([makeHiveBotRow()]);
+
+      // Step 5: createTopicSessionChannel returns fake channel
+      channels.createTopicSessionChannel.mockImplementationOnce(
+        async ({ channelId }: any) =>
+          makeTopicChannelRow(channelId ?? 'generated'),
+      );
+
+      const result = await service.create({
+        creatorId: CREATOR_ID,
+        tenantId: TENANT_ID,
+        botUserId: BOT_USER_ID,
+        initialMessage: 'Hello agent, help me kick off a new topic',
+      });
+
+      expect(result.agentId).toBe(AGENT_ID);
+      expect(result.botUserId).toBe(BOT_USER_ID);
+      expect(result.sessionId).toBe(
+        `team9/${TENANT_ID}/${AGENT_ID}/topic/${result.channelId}`,
+      );
+      expect(result.title).toBeNull();
+
+      // Ordering invariants:
+      expect(channels.assertDirectMessageAllowed).toHaveBeenCalledWith(
+        CREATOR_ID,
+        BOT_USER_ID,
+      );
+      expect(clawHive.createSession).toHaveBeenCalledWith(
+        AGENT_ID,
+        expect.objectContaining({
+          userId: CREATOR_ID,
+          sessionId: result.sessionId,
+          team9Context: expect.objectContaining({
+            scopeType: 'topic',
+            scopeId: result.channelId,
+          }),
+        }),
+        TENANT_ID,
+      );
+      expect(channels.createTopicSessionChannel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creatorId: CREATOR_ID,
+          botUserId: BOT_USER_ID,
+          agentId: AGENT_ID,
+          sessionId: result.sessionId,
+          channelId: result.channelId,
+        }),
+      );
+      expect(imWorkerGrpc.createMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: result.channelId,
+          senderId: CREATOR_ID,
+          content: 'Hello agent, help me kick off a new topic',
+        }),
+      );
+      expect(gatewayMQ.publishPostBroadcast).toHaveBeenCalled();
+      expect(ws.sendToUser).toHaveBeenCalledWith(
+        CREATOR_ID,
+        'topic_session_created',
+        expect.objectContaining({
+          channelId: result.channelId,
+          sessionId: result.sessionId,
+        }),
+      );
+    });
+
+    it('rejects when the target user is not an active hive-managed agent', async () => {
+      db.limit.mockResolvedValueOnce([]); // no bot found
+
+      await expect(
+        service.create({
+          creatorId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          botUserId: BOT_USER_ID,
+          initialMessage: 'hi',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(clawHive.createSession).not.toHaveBeenCalled();
+      expect(channels.createTopicSessionChannel).not.toHaveBeenCalled();
+    });
+
+    it('rejects when bot has no agentId in managedMeta', async () => {
+      db.limit.mockResolvedValueOnce([
+        { ...makeHiveBotRow(), managedMeta: {} },
+      ]);
+
+      await expect(
+        service.create({
+          creatorId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          botUserId: BOT_USER_ID,
+          initialMessage: 'hi',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(clawHive.createSession).not.toHaveBeenCalled();
+    });
+
+    it('compensates the agent-pi session when channel creation fails', async () => {
+      db.limit.mockResolvedValueOnce([makeHiveBotRow()]);
+      channels.createTopicSessionChannel.mockRejectedValueOnce(
+        new Error('DB down'),
+      );
+
+      await expect(
+        service.create({
+          creatorId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          botUserId: BOT_USER_ID,
+          initialMessage: 'hi',
+        }),
+      ).rejects.toThrow('DB down');
+
+      expect(clawHive.createSession).toHaveBeenCalled();
+      // Compensation runs fire-and-forget; allow microtasks to flush.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(clawHive.deleteSession).toHaveBeenCalledTimes(1);
+      const [sessionIdArg] = clawHive.deleteSession.mock.calls[0] ?? [];
+      expect(sessionIdArg).toMatch(
+        new RegExp(`^team9/${TENANT_ID}/${AGENT_ID}/topic/`),
+      );
+    });
+
+    it('compensates channel + session when gRPC createMessage fails', async () => {
+      db.limit.mockResolvedValueOnce([makeHiveBotRow()]);
+      channels.createTopicSessionChannel.mockImplementationOnce(
+        async ({ channelId }: any) =>
+          makeTopicChannelRow(channelId ?? 'generated'),
+      );
+      imWorkerGrpc.createMessage.mockRejectedValueOnce(
+        new Error('worker offline'),
+      );
+
+      await expect(
+        service.create({
+          creatorId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          botUserId: BOT_USER_ID,
+          initialMessage: 'hi',
+        }),
+      ).rejects.toThrow('worker offline');
+
+      await new Promise((resolve) => setImmediate(resolve));
+      // Session compensation still runs.
+      expect(clawHive.deleteSession).toHaveBeenCalledTimes(1);
+      // Channel compensation triggers the delete chain.
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // delete()
+  // ------------------------------------------------------------------
+
+  describe('delete', () => {
+    const CHANNEL_ID = '00000000-0000-0000-0000-0000000000aa';
+    const SESSION_ID = `team9/${TENANT_ID}/${AGENT_ID}/topic/${CHANNEL_ID}`;
+
+    it('archives the channel and best-effort deletes the agent-pi session', async () => {
+      db.limit.mockResolvedValueOnce([
+        {
+          id: CHANNEL_ID,
+          type: 'topic-session',
+          isArchived: false,
+          propertySettings: {
+            topicSession: { sessionId: SESSION_ID, agentId: AGENT_ID },
+          },
+          createdBy: CREATOR_ID,
+        },
+      ]);
+
+      await service.delete({
+        userId: CREATOR_ID,
+        tenantId: TENANT_ID,
+        channelId: CHANNEL_ID,
+      });
+
+      expect(db.update).toHaveBeenCalled();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(clawHive.deleteSession).toHaveBeenCalledWith(
+        SESSION_ID,
+        TENANT_ID,
+      );
+      expect(ws.sendToUser).toHaveBeenCalledWith(
+        CREATOR_ID,
+        'topic_session_deleted',
+        { channelId: CHANNEL_ID },
+      );
+    });
+
+    it('throws 404 when the channel is not a topic-session', async () => {
+      db.limit.mockResolvedValueOnce([{ id: CHANNEL_ID, type: 'direct' }]);
+
+      await expect(
+        service.delete({
+          userId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          channelId: CHANNEL_ID,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws 403 when caller is not the creator', async () => {
+      db.limit.mockResolvedValueOnce([
+        {
+          id: CHANNEL_ID,
+          type: 'topic-session',
+          isArchived: false,
+          propertySettings: { topicSession: { sessionId: SESSION_ID } },
+          createdBy: 'someone-else',
+        },
+      ]);
+
+      await expect(
+        service.delete({
+          userId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          channelId: CHANNEL_ID,
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(db.update).not.toHaveBeenCalled();
+      expect(clawHive.deleteSession).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // listGrouped()
+  // ------------------------------------------------------------------
+
+  describe('listGrouped', () => {
+    it('returns empty list when the user has no topic or legacy channels', async () => {
+      // topic-sessions query resolves to empty → short-circuits into
+      // the legacy-direct-only fallback, which also resolves empty.
+      db.where
+        .mockResolvedValueOnce([]) // listGrouped: topic-session channels
+        .mockResolvedValueOnce([]); // listLegacyDirectOnly: direct channels
+
+      const result = await service.listGrouped(CREATOR_ID, TENANT_ID, 5);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -41,10 +41,13 @@ import type {
  *   1. Validate bot is an active hive-managed agent; extract agentId.
  *   2. Check DM permission gate (personal-staff visibility).
  *   3. Pre-generate channelId (UUIDv7) + session id.
- *      sessionId = `team9/{tenant}/{agentId}/topic/{channelId}` — the
- *      contract with agent-pi — so the scopeId == channelId invariant
- *      holds at construction time without a follow-up write.
- *   4. Create the agent-pi session (with team9Context.scopeType='topic').
+ *      sessionId = `team9/{tenant}/{agentId}/dm/{channelId}` — topic
+ *      sessions share the 'dm' scope with direct and routine-session
+ *      because they are indistinguishable at the agent runtime layer.
+ *      team9 keeps `channels.type='topic-session'` for IM-layer reads
+ *      (sidebar / search / title gen); the wire-level payload uses the
+ *      4-value agent-pi EventChannelType.
+ *   4. Create the agent-pi session (with team9Context.scopeType='dm').
  *      On failure, abort early — no local state leaked yet.
  *   5. Create the topic-session channel + members atomically in team9 DB.
  *      On failure, compensate: delete the agent-pi session.
@@ -125,6 +128,13 @@ export class TopicSessionsService {
     const sessionId = this.buildSessionId(tenantId, agentId, channelId);
 
     // --- Step 4: create agent-pi session ---
+    // scopeType='dm' because at the agent runtime layer, a topic
+    // session is indistinguishable from a DM — one-on-one, plain-text
+    // streaming, no Reply-tool round-trip. agent-pi's Team9Component
+    // only understands the 4-value EventChannelType enum
+    // ('channel' | 'dm' | 'task' | 'tracking'); IM-level concepts like
+    // topic-session / routine-session live on `channels.type` in team9
+    // and don't leak to the runtime. Same mapping routine-session uses.
     try {
       await this.clawHive.createSession(
         agentId,
@@ -134,7 +144,7 @@ export class TopicSessionsService {
           ...(model ? { model } : {}),
           team9Context: {
             source: 'team9',
-            scopeType: 'topic',
+            scopeType: 'dm',
             scopeId: channelId,
             peerUserId: creatorId,
           },
@@ -193,7 +203,7 @@ export class TopicSessionsService {
     }
 
     // Fire post-broadcast task synchronously: unread fan-out + agent
-    // forwarding via pushToHiveBots (scope='topic'). We await the publish
+    // forwarding via pushToHiveBots (scope='dm'). We await the publish
     // (not the downstream processing) so a failure to hand off to MQ
     // surfaces as a 5xx to the caller — otherwise the user sees the
     // channel appear but the agent never replies, and we silently lose
@@ -581,7 +591,14 @@ export class TopicSessionsService {
     agentId: string,
     channelId: string,
   ): string {
-    return `team9/${tenantId ?? ''}/${agentId}/topic/${channelId}`;
+    // Use the 'dm' scope so the id matches what post-broadcast
+    // derives on subsequent messages in the same channel — otherwise
+    // createSession would register under `.../topic/...` and sendInput
+    // would later target `.../dm/...`, fragmenting the conversation
+    // across two agent-pi sessions. channelId is UUIDv7-unique so
+    // there's no collision with legacy direct / routine-session ids
+    // that also live under the dm/ scope.
+    return `team9/${tenantId ?? ''}/${agentId}/dm/${channelId}`;
   }
 
   /**

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -280,6 +280,14 @@ export class TopicSessionsService {
     perAgent: number,
   ): Promise<TopicSessionGroup[]> {
     // Find all topic-session channels the user is a member of.
+    // The rest of the codebase uses `tenantId ? eq(...) : undefined`
+    // (see channels.service.ts) — undefined is dropped by drizzle's
+    // and() so an absent tenantId simply doesn't filter. An earlier
+    // version of this query used `isNull(channels.tenantId)` in the
+    // undefined branch, which (in community edition where the
+    // CurrentTenantId decorator can legitimately be undefined)
+    // excluded every tenanted channel and made the grouped sidebar
+    // return empty. Mirror the codebase pattern here.
     const topicChannels = await this.db
       .select({
         channelId: schema.channels.id,
@@ -298,9 +306,7 @@ export class TopicSessionsService {
           eq(schema.channels.isArchived, false),
           eq(schema.channelMembers.userId, userId),
           isNull(schema.channelMembers.leftAt),
-          tenantId
-            ? eq(schema.channels.tenantId, tenantId)
-            : isNull(schema.channels.tenantId),
+          tenantId ? eq(schema.channels.tenantId, tenantId) : undefined,
         ),
       );
 
@@ -413,9 +419,7 @@ export class TopicSessionsService {
           eq(schema.channels.isArchived, false),
           inArray(schema.channelMembers.userId, botUserIds),
           isNull(schema.channelMembers.leftAt),
-          tenantId
-            ? eq(schema.channels.tenantId, tenantId)
-            : isNull(schema.channels.tenantId),
+          tenantId ? eq(schema.channels.tenantId, tenantId) : undefined,
         ),
       );
     // Keep only channels that also contain the caller (real 1:1).
@@ -668,9 +672,7 @@ export class TopicSessionsService {
           eq(schema.channels.isArchived, false),
           eq(schema.users.userType, 'bot'),
           isNull(schema.channelMembers.leftAt),
-          tenantId
-            ? eq(schema.channels.tenantId, tenantId)
-            : isNull(schema.channels.tenantId),
+          tenantId ? eq(schema.channels.tenantId, tenantId) : undefined,
         ),
       );
     if (directRows.length === 0) return [];

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -1,0 +1,692 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+  forwardRef,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { v7 as uuidv7 } from 'uuid';
+import {
+  DATABASE_CONNECTION,
+  and,
+  eq,
+  inArray,
+  isNull,
+  sql,
+  type PostgresJsDatabase,
+} from '@team9/database';
+import * as schema from '@team9/database/schemas';
+import { ClawHiveService } from '@team9/claw-hive';
+import { GatewayMQService } from '@team9/rabbitmq';
+import { type PostBroadcastTask } from '@team9/shared';
+import { ChannelsService } from '../channels/channels.service.js';
+import { WebsocketGateway } from '../websocket/websocket.gateway.js';
+import { WS_EVENTS } from '../websocket/events/events.constants.js';
+import { ImWorkerGrpcClientService } from '../services/im-worker-grpc-client.service.js';
+import { determineMessageType } from '../messages/message-utils.js';
+import type {
+  TopicSessionGroup,
+  TopicSessionRecentEntry,
+  TopicSessionResponse,
+} from './dto/topic-session.response.js';
+
+/**
+ * Service responsible for the topic-session feature: one ephemeral
+ * user-to-agent conversation per topic. The saga for create() is:
+ *
+ *   1. Validate bot is an active hive-managed agent; extract agentId.
+ *   2. Check DM permission gate (personal-staff visibility).
+ *   3. Pre-generate channelId (UUIDv7) + session id.
+ *      sessionId = `team9/{tenant}/{agentId}/topic/{channelId}` — the
+ *      contract with agent-pi — so the scopeId == channelId invariant
+ *      holds at construction time without a follow-up write.
+ *   4. Create the agent-pi session (with team9Context.scopeType='topic').
+ *      On failure, abort early — no local state leaked yet.
+ *   5. Create the topic-session channel + members atomically in team9 DB.
+ *      On failure, compensate: delete the agent-pi session.
+ *   6. Persist the initial user message via gRPC and kick post-broadcast.
+ *      post-broadcast.service recognises type='topic-session' and forwards
+ *      the message to agent-pi via sendInput on the same sessionId.
+ *      On failure, compensate: drop local channel/members + delete session.
+ *   7. Emit WS events (CHANNEL.CREATED + TOPIC_SESSION.CREATED) + the
+ *      search-index event-emitter hook.
+ *
+ * Compensation is best-effort; we log rather than throw to avoid
+ * masking the original failure the caller needs to see.
+ */
+@Injectable()
+export class TopicSessionsService {
+  private readonly logger = new Logger(TopicSessionsService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly clawHive: ClawHiveService,
+    @Inject(forwardRef(() => ChannelsService))
+    private readonly channels: ChannelsService,
+    private readonly imWorkerGrpc: ImWorkerGrpcClientService,
+    @Inject(forwardRef(() => WebsocketGateway))
+    private readonly ws: WebsocketGateway,
+    private readonly eventEmitter: EventEmitter2,
+    @Optional() private readonly gatewayMQ?: GatewayMQService,
+  ) {}
+
+  async create(params: {
+    creatorId: string;
+    tenantId: string | null;
+    botUserId: string;
+    initialMessage: string;
+    model?: { provider: string; id: string };
+    title?: string | null;
+  }): Promise<TopicSessionResponse> {
+    const { creatorId, tenantId, botUserId, initialMessage, model } = params;
+    const title = params.title ?? null;
+
+    // --- Step 1: resolve agentId from bot ---
+    const [botRow] = await this.db
+      .select({
+        userId: schema.bots.userId,
+        managedProvider: schema.bots.managedProvider,
+        managedMeta: schema.bots.managedMeta,
+        isActive: schema.bots.isActive,
+        userType: schema.users.userType,
+      })
+      .from(schema.bots)
+      .innerJoin(schema.users, eq(schema.bots.userId, schema.users.id))
+      .where(eq(schema.bots.userId, botUserId))
+      .limit(1);
+
+    if (
+      !botRow ||
+      botRow.userType !== 'bot' ||
+      !botRow.isActive ||
+      botRow.managedProvider !== 'hive'
+    ) {
+      throw new BadRequestException(
+        'Target user is not an active hive-managed agent',
+      );
+    }
+
+    const agentId = (botRow.managedMeta as Record<string, unknown> | null)
+      ?.agentId as string | undefined;
+    if (!agentId || typeof agentId !== 'string') {
+      throw new BadRequestException('Agent id not found on bot managedMeta');
+    }
+
+    // --- Step 2: DM permission gate (personal-staff visibility) ---
+    await this.channels.assertDirectMessageAllowed(creatorId, botUserId);
+
+    // --- Step 3: bind channelId ↔ sessionId ---
+    const channelId = uuidv7();
+    const sessionId = this.buildSessionId(tenantId, agentId, channelId);
+
+    // --- Step 4: create agent-pi session ---
+    try {
+      await this.clawHive.createSession(
+        agentId,
+        {
+          userId: creatorId,
+          sessionId,
+          ...(model ? { model } : {}),
+          team9Context: {
+            source: 'team9',
+            scopeType: 'topic',
+            scopeId: channelId,
+            peerUserId: creatorId,
+          },
+        },
+        tenantId ?? undefined,
+      );
+    } catch (err) {
+      this.logger.error(
+        `createSession failed for agent ${agentId} (topic channel ${channelId}): ${err}`,
+      );
+      throw err;
+    }
+
+    // --- Step 5: create channel + members in team9 DB ---
+    let channel;
+    try {
+      channel = await this.channels.createTopicSessionChannel({
+        creatorId,
+        botUserId,
+        tenantId,
+        agentId,
+        sessionId,
+        title,
+        channelId,
+      });
+    } catch (err) {
+      this.logger.error(
+        `createTopicSessionChannel failed (session ${sessionId}): ${err}`,
+      );
+      this.compensateSession(sessionId, tenantId);
+      throw err;
+    }
+
+    // --- Step 6: send initial user message via gRPC ---
+    const workspaceId = tenantId ?? '';
+    let messageId: string;
+    try {
+      const clientMsgId = uuidv7();
+      const messageType = determineMessageType(initialMessage, false);
+      const result = await this.imWorkerGrpc.createMessage({
+        clientMsgId,
+        channelId,
+        senderId: creatorId,
+        content: initialMessage,
+        type: messageType,
+        workspaceId,
+      });
+      messageId = result.msgId;
+    } catch (err) {
+      this.logger.error(
+        `createMessage failed on topic-session ${channelId}: ${err}`,
+      );
+      this.compensateChannel(channelId);
+      this.compensateSession(sessionId, tenantId);
+      throw err;
+    }
+
+    // Fire-and-forget post-broadcast task: unread fan-out + agent
+    // forwarding via pushToHiveBots (scope='topic').
+    if (this.gatewayMQ?.isReady()) {
+      const task: PostBroadcastTask = {
+        msgId: messageId,
+        channelId,
+        senderId: creatorId,
+        workspaceId,
+        broadcastAt: Date.now(),
+      };
+      this.gatewayMQ.publishPostBroadcast(task).catch((err) => {
+        this.logger.warn(
+          `publishPostBroadcast failed on topic-session ${channelId}: ${err}`,
+        );
+      });
+    } else {
+      this.logger.warn(
+        `GatewayMQService not ready — topic-session ${channelId} initial message not fanned out to bot`,
+      );
+    }
+
+    // --- Step 7: WS + search-index events ---
+    const payload: TopicSessionResponse = {
+      channelId,
+      sessionId,
+      agentId,
+      botUserId,
+      title,
+      createdAt: channel.createdAt.toISOString(),
+    };
+
+    // CHANNEL.CREATED so existing sidebar/react-query consumers see it
+    // even before they learn about TOPIC_SESSION.* (useful during the
+    // sidebar-rollout transition).
+    await this.ws.sendToUser(creatorId, WS_EVENTS.CHANNEL.CREATED, channel);
+    await this.ws.sendToUser(botUserId, WS_EVENTS.CHANNEL.CREATED, channel);
+    await this.ws.sendToUser(
+      creatorId,
+      WS_EVENTS.TOPIC_SESSION.CREATED,
+      payload,
+    );
+
+    this.eventEmitter.emit('channel.created', { channel });
+
+    return payload;
+  }
+
+  /**
+   * Return, for each agent the caller has any topic-session with, the
+   * most recent `perAgent` sessions plus a pointer to the legacy direct
+   * channel (if one exists). The sidebar calls this once per mount.
+   */
+  async listGrouped(
+    userId: string,
+    tenantId: string | undefined,
+    perAgent: number,
+  ): Promise<TopicSessionGroup[]> {
+    // Find all topic-session channels the user is a member of.
+    const topicChannels = await this.db
+      .select({
+        channelId: schema.channels.id,
+        propertySettings: schema.channels.propertySettings,
+        createdAt: schema.channels.createdAt,
+        tenantId: schema.channels.tenantId,
+      })
+      .from(schema.channels)
+      .innerJoin(
+        schema.channelMembers,
+        eq(schema.channelMembers.channelId, schema.channels.id),
+      )
+      .where(
+        and(
+          eq(schema.channels.type, 'topic-session'),
+          eq(schema.channels.isArchived, false),
+          eq(schema.channelMembers.userId, userId),
+          isNull(schema.channelMembers.leftAt),
+          tenantId
+            ? eq(schema.channels.tenantId, tenantId)
+            : isNull(schema.channels.tenantId),
+        ),
+      );
+
+    if (topicChannels.length === 0) {
+      return this.listLegacyDirectOnly(userId, tenantId);
+    }
+
+    // For each channel find the bot member (the "other side").
+    const channelIds = topicChannels.map((c) => c.channelId);
+    const botMembers = await this.db
+      .select({
+        channelId: schema.channelMembers.channelId,
+        botUserId: schema.channelMembers.userId,
+      })
+      .from(schema.channelMembers)
+      .innerJoin(
+        schema.users,
+        eq(schema.users.id, schema.channelMembers.userId),
+      )
+      .where(
+        and(
+          inArray(schema.channelMembers.channelId, channelIds),
+          eq(schema.users.userType, 'bot'),
+          isNull(schema.channelMembers.leftAt),
+        ),
+      );
+
+    const channelToBot = new Map<string, string>();
+    for (const m of botMembers) channelToBot.set(m.channelId, m.botUserId);
+
+    // Last message per channel (for sort + preview timestamp).
+    const lastMsgRows = await this.db
+      .select({
+        channelId: schema.messages.channelId,
+        lastAt: sql<string>`max(${schema.messages.createdAt})`,
+      })
+      .from(schema.messages)
+      .where(inArray(schema.messages.channelId, channelIds))
+      .groupBy(schema.messages.channelId);
+    const lastMsgByChannel = new Map<string, string>();
+    for (const r of lastMsgRows)
+      if (r.lastAt) lastMsgByChannel.set(r.channelId, String(r.lastAt));
+
+    // Unread counts (reuse the denormalized columns on messages if present;
+    // otherwise default to 0 and let the client refresh lazily).
+    const unreadRows = await this.db
+      .select({
+        channelId: schema.userChannelReadStatus.channelId,
+        unreadCount: schema.userChannelReadStatus.unreadCount,
+      })
+      .from(schema.userChannelReadStatus)
+      .where(
+        and(
+          eq(schema.userChannelReadStatus.userId, userId),
+          inArray(schema.userChannelReadStatus.channelId, channelIds),
+        ),
+      );
+    const unreadByChannel = new Map<string, number>();
+    for (const r of unreadRows)
+      unreadByChannel.set(r.channelId, r.unreadCount ?? 0);
+
+    // Collect bot user ids to look up display info + legacy direct channel.
+    const botUserIds = [...new Set([...channelToBot.values()])];
+    const botDisplayRows = await this.db
+      .select({
+        id: schema.users.id,
+        displayName: schema.users.displayName,
+        username: schema.users.username,
+        avatarUrl: schema.users.avatarUrl,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.users)
+      .innerJoin(schema.bots, eq(schema.bots.userId, schema.users.id))
+      .where(inArray(schema.users.id, botUserIds));
+    const botDisplay = new Map<
+      string,
+      {
+        displayName: string | null;
+        username: string;
+        avatarUrl: string | null;
+        agentId: string;
+      }
+    >();
+    for (const b of botDisplayRows) {
+      const agentId = (b.managedMeta as Record<string, unknown> | null)
+        ?.agentId as string | undefined;
+      if (!agentId) continue;
+      botDisplay.set(b.id, {
+        displayName: b.displayName,
+        username: b.username,
+        avatarUrl: b.avatarUrl,
+        agentId,
+      });
+    }
+
+    // Legacy direct channels between this user and each bot, if any.
+    const legacyRows = await this.db
+      .select({
+        channelId: schema.channels.id,
+        otherUserId: schema.channelMembers.userId,
+      })
+      .from(schema.channels)
+      .innerJoin(
+        schema.channelMembers,
+        eq(schema.channelMembers.channelId, schema.channels.id),
+      )
+      .where(
+        and(
+          eq(schema.channels.type, 'direct'),
+          eq(schema.channels.isArchived, false),
+          inArray(schema.channelMembers.userId, botUserIds),
+          isNull(schema.channelMembers.leftAt),
+          tenantId
+            ? eq(schema.channels.tenantId, tenantId)
+            : isNull(schema.channels.tenantId),
+        ),
+      );
+    // Keep only channels that also contain the caller (real 1:1).
+    const legacyCandidateIds = legacyRows.map((r) => r.channelId);
+    const callerMembership = legacyCandidateIds.length
+      ? await this.db
+          .select({
+            channelId: schema.channelMembers.channelId,
+          })
+          .from(schema.channelMembers)
+          .where(
+            and(
+              inArray(schema.channelMembers.channelId, legacyCandidateIds),
+              eq(schema.channelMembers.userId, userId),
+              isNull(schema.channelMembers.leftAt),
+            ),
+          )
+      : [];
+    const callerChannelIds = new Set(callerMembership.map((m) => m.channelId));
+    const legacyByBot = new Map<string, string>();
+    for (const r of legacyRows) {
+      if (!callerChannelIds.has(r.channelId)) continue;
+      legacyByBot.set(r.otherUserId, r.channelId);
+    }
+
+    // Bucket topic channels by bot and sort by lastMessageAt desc.
+    type Row = {
+      channelId: string;
+      botUserId: string;
+      sessionId: string;
+      title: string | null;
+      lastMessageAt: string | null;
+      unreadCount: number;
+      createdAt: string;
+    };
+    const bucket = new Map<string, Row[]>();
+    for (const ch of topicChannels) {
+      const botUserId = channelToBot.get(ch.channelId);
+      if (!botUserId) continue;
+      const ts = (
+        ch.propertySettings as {
+          topicSession?: {
+            sessionId?: string;
+            title?: string | null;
+          };
+        } | null
+      )?.topicSession;
+      if (!ts?.sessionId) continue;
+      const rows = bucket.get(botUserId) ?? [];
+      rows.push({
+        channelId: ch.channelId,
+        botUserId,
+        sessionId: ts.sessionId,
+        title: ts.title ?? null,
+        lastMessageAt: lastMsgByChannel.get(ch.channelId) ?? null,
+        unreadCount: unreadByChannel.get(ch.channelId) ?? 0,
+        createdAt: ch.createdAt.toISOString(),
+      });
+      bucket.set(botUserId, rows);
+    }
+
+    // Assemble groups for every bot seen in topic channels OR in legacy
+    // direct channels (covers users that only have legacy DMs so far).
+    const agentSet = new Set<string>([...bucket.keys(), ...legacyByBot.keys()]);
+
+    const groups: TopicSessionGroup[] = [];
+    for (const botUserId of agentSet) {
+      const d = botDisplay.get(botUserId);
+      if (!d) continue;
+      const rowsForBot = (bucket.get(botUserId) ?? []).sort((a, b) => {
+        const al = a.lastMessageAt ?? a.createdAt;
+        const bl = b.lastMessageAt ?? b.createdAt;
+        return bl.localeCompare(al);
+      });
+      const recent: TopicSessionRecentEntry[] = rowsForBot
+        .slice(0, perAgent)
+        .map((r) => ({
+          channelId: r.channelId,
+          sessionId: r.sessionId,
+          title: r.title,
+          lastMessageAt: r.lastMessageAt,
+          unreadCount: r.unreadCount,
+          createdAt: r.createdAt,
+        }));
+      groups.push({
+        agentUserId: botUserId,
+        agentId: d.agentId,
+        agentDisplayName: d.displayName || d.username,
+        agentAvatarUrl: d.avatarUrl,
+        legacyDirectChannelId: legacyByBot.get(botUserId) ?? null,
+        totalCount: rowsForBot.length,
+        recentSessions: recent,
+      });
+    }
+
+    // Sort groups by their most recent activity overall.
+    groups.sort((a, b) => {
+      const aMax =
+        a.recentSessions[0]?.lastMessageAt ??
+        a.recentSessions[0]?.createdAt ??
+        '';
+      const bMax =
+        b.recentSessions[0]?.lastMessageAt ??
+        b.recentSessions[0]?.createdAt ??
+        '';
+      return bMax.localeCompare(aMax);
+    });
+
+    return groups;
+  }
+
+  async delete(params: {
+    userId: string;
+    tenantId: string | null;
+    channelId: string;
+  }): Promise<void> {
+    const { userId, tenantId, channelId } = params;
+
+    const [row] = await this.db
+      .select({
+        id: schema.channels.id,
+        type: schema.channels.type,
+        isArchived: schema.channels.isArchived,
+        propertySettings: schema.channels.propertySettings,
+        createdBy: schema.channels.createdBy,
+      })
+      .from(schema.channels)
+      .where(eq(schema.channels.id, channelId))
+      .limit(1);
+
+    if (!row || row.type !== 'topic-session') {
+      throw new NotFoundException('Topic session not found');
+    }
+    if (row.createdBy !== userId) {
+      throw new ForbiddenException(
+        'Only the creator can delete this topic session',
+      );
+    }
+
+    const sessionId =
+      (
+        row.propertySettings as {
+          topicSession?: { sessionId?: string };
+        } | null
+      )?.topicSession?.sessionId ?? null;
+
+    if (!row.isArchived) {
+      await this.db
+        .update(schema.channels)
+        .set({ isArchived: true, updatedAt: new Date() })
+        .where(eq(schema.channels.id, channelId));
+    }
+
+    if (sessionId) {
+      // Best-effort — agent-pi swallows 404 on its own, so any failure
+      // here is worth logging but not propagating to the user.
+      this.clawHive
+        .deleteSession(sessionId, tenantId ?? undefined)
+        .catch((err) =>
+          this.logger.warn(
+            `deleteSession(${sessionId}) best-effort failure: ${err}`,
+          ),
+        );
+    }
+
+    await this.ws.sendToUser(userId, WS_EVENTS.TOPIC_SESSION.DELETED, {
+      channelId,
+    });
+  }
+
+  private buildSessionId(
+    tenantId: string | null,
+    agentId: string,
+    channelId: string,
+  ): string {
+    return `team9/${tenantId ?? ''}/${agentId}/topic/${channelId}`;
+  }
+
+  /**
+   * Best-effort deletion of an orphan agent-pi session when the team9
+   * side of the saga failed. Never throws — this runs in a `catch` path
+   * and must not mask the original error.
+   */
+  private compensateSession(sessionId: string, tenantId: string | null): void {
+    this.clawHive
+      .deleteSession(sessionId, tenantId ?? undefined)
+      .catch((err) =>
+        this.logger.warn(
+          `Compensation deleteSession(${sessionId}) failed: ${err}`,
+        ),
+      );
+  }
+
+  /**
+   * Best-effort removal of a half-created topic-session channel when the
+   * initial-message step failed. Executes outside the original tx so we
+   * can't use FK cascade — do members first, then the channel row.
+   */
+  private compensateChannel(channelId: string): void {
+    void (async () => {
+      try {
+        await this.db
+          .delete(schema.channelMembers)
+          .where(eq(schema.channelMembers.channelId, channelId));
+        await this.db
+          .delete(schema.channels)
+          .where(eq(schema.channels.id, channelId));
+      } catch (err) {
+        this.logger.warn(
+          `Compensation channel-cleanup(${channelId}) failed: ${err}`,
+        );
+      }
+    })();
+  }
+
+  /**
+   * Fallback path for users who have no topic sessions but do have
+   * legacy direct channels with agents — so the sidebar can still show
+   * their agent list on day one of the rollout.
+   */
+  private async listLegacyDirectOnly(
+    userId: string,
+    tenantId: string | undefined,
+  ): Promise<TopicSessionGroup[]> {
+    // Direct channels where the caller is a member and the other side is a bot.
+    const directRows = await this.db
+      .select({
+        channelId: schema.channels.id,
+        otherUserId: schema.channelMembers.userId,
+      })
+      .from(schema.channels)
+      .innerJoin(
+        schema.channelMembers,
+        eq(schema.channelMembers.channelId, schema.channels.id),
+      )
+      .innerJoin(
+        schema.users,
+        eq(schema.users.id, schema.channelMembers.userId),
+      )
+      .where(
+        and(
+          eq(schema.channels.type, 'direct'),
+          eq(schema.channels.isArchived, false),
+          eq(schema.users.userType, 'bot'),
+          isNull(schema.channelMembers.leftAt),
+          tenantId
+            ? eq(schema.channels.tenantId, tenantId)
+            : isNull(schema.channels.tenantId),
+        ),
+      );
+    if (directRows.length === 0) return [];
+
+    const channelIds = directRows.map((r) => r.channelId);
+    const callerMembership = await this.db
+      .select({ channelId: schema.channelMembers.channelId })
+      .from(schema.channelMembers)
+      .where(
+        and(
+          inArray(schema.channelMembers.channelId, channelIds),
+          eq(schema.channelMembers.userId, userId),
+          isNull(schema.channelMembers.leftAt),
+        ),
+      );
+    const callerChannels = new Set(callerMembership.map((r) => r.channelId));
+
+    const byBot = new Map<string, string>();
+    for (const r of directRows) {
+      if (callerChannels.has(r.channelId)) {
+        byBot.set(r.otherUserId, r.channelId);
+      }
+    }
+
+    if (byBot.size === 0) return [];
+
+    const botDisplayRows = await this.db
+      .select({
+        id: schema.users.id,
+        displayName: schema.users.displayName,
+        username: schema.users.username,
+        avatarUrl: schema.users.avatarUrl,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.users)
+      .innerJoin(schema.bots, eq(schema.bots.userId, schema.users.id))
+      .where(inArray(schema.users.id, [...byBot.keys()]));
+
+    const groups: TopicSessionGroup[] = [];
+    for (const b of botDisplayRows) {
+      const agentId = (b.managedMeta as Record<string, unknown> | null)
+        ?.agentId as string | undefined;
+      if (!agentId) continue;
+      groups.push({
+        agentUserId: b.id,
+        agentId,
+        agentDisplayName: b.displayName || b.username,
+        agentAvatarUrl: b.avatarUrl,
+        legacyDirectChannelId: byBot.get(b.id) ?? null,
+        totalCount: 0,
+        recentSessions: [],
+      });
+    }
+    return groups;
+  }
+}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -192,24 +192,44 @@ export class TopicSessionsService {
       throw err;
     }
 
-    // Fire-and-forget post-broadcast task: unread fan-out + agent
-    // forwarding via pushToHiveBots (scope='topic').
-    if (this.gatewayMQ?.isReady()) {
-      const task: PostBroadcastTask = {
-        msgId: messageId,
-        channelId,
-        senderId: creatorId,
-        workspaceId,
-        broadcastAt: Date.now(),
-      };
-      this.gatewayMQ.publishPostBroadcast(task).catch((err) => {
-        this.logger.warn(
-          `publishPostBroadcast failed on topic-session ${channelId}: ${err}`,
-        );
-      });
-    } else {
-      this.logger.warn(
-        `GatewayMQService not ready — topic-session ${channelId} initial message not fanned out to bot`,
+    // Fire post-broadcast task synchronously: unread fan-out + agent
+    // forwarding via pushToHiveBots (scope='topic'). We await the publish
+    // (not the downstream processing) so a failure to hand off to MQ
+    // surfaces as a 5xx to the caller — otherwise the user sees the
+    // channel appear but the agent never replies, and we silently lose
+    // the first-turn event.
+    const task: PostBroadcastTask = {
+      msgId: messageId,
+      channelId,
+      senderId: creatorId,
+      workspaceId,
+      broadcastAt: Date.now(),
+    };
+
+    if (!this.gatewayMQ?.isReady()) {
+      // Message itself is already persisted, channel + session exist.
+      // Surface the fan-out gap so the user retries instead of staring
+      // at a silent topic — same contract as any other message send
+      // when the worker queue is unavailable.
+      this.logger.error(
+        `GatewayMQService not ready — topic-session ${channelId} initial message persisted but not fanned out to bot`,
+      );
+      throw new Error(
+        'Message queue is temporarily unavailable, please try again in a moment',
+      );
+    }
+
+    try {
+      await this.gatewayMQ.publishPostBroadcast(task);
+      this.logger.log(
+        `Topic session ${channelId} created (session ${sessionId}, msg ${messageId}); post-broadcast task published for agent ${agentId}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `publishPostBroadcast failed on topic-session ${channelId}: ${err}`,
+      );
+      throw new Error(
+        'Failed to notify worker about the new message, please try again',
       );
     }
 

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
@@ -220,7 +220,10 @@ export class TopicTitleGeneratorService {
     try {
       response = await this.hub.request(
         'POST',
-        '/proxy/openrouter/chat/completions',
+        // capability-hub sets app.setGlobalPrefix('api'), so llm-proxy
+        // lives at /api/proxy/:provider/*path (same convention as
+        // /api/deep-research/tasks that DeepResearchController uses).
+        '/api/proxy/openrouter/chat/completions',
         {
           headers: {
             ...this.hub.serviceHeaders(identity),

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
@@ -1,0 +1,232 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  Optional,
+  forwardRef,
+} from '@nestjs/common';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import {
+  DATABASE_CONNECTION,
+  and,
+  asc,
+  eq,
+  type PostgresJsDatabase,
+} from '@team9/database';
+import * as schema from '@team9/database/schemas';
+import {
+  AiClientService,
+  AIProvider,
+  type AICompletionResponse,
+} from '@team9/ai-client';
+import { ChannelsService } from '../channels/channels.service.js';
+import { WebsocketGateway } from '../websocket/websocket.gateway.js';
+import { WS_EVENTS } from '../websocket/events/events.constants.js';
+
+interface MessageCreatedPayload {
+  message: {
+    id: string;
+    channelId: string;
+    senderId: string | null;
+    content: string | null;
+    type: string;
+  };
+  channel?: { id: string; type?: string } | null;
+  sender?: { id: string; userType?: string; username?: string } | null;
+}
+
+// Keep the prompt language-agnostic and rely on the model to mirror the
+// input language. Tight length constraints make sure the title fits the
+// sidebar row.
+const TITLE_PROMPT = `You are a concise title generator for a chat app's sidebar.
+
+Given the user's first message in a conversation, produce a short title that summarises the topic.
+
+Rules (ALL mandatory):
+- Match the language of the input exactly (if the user wrote in Chinese, reply in Chinese; Japanese → Japanese; etc.).
+- Max 12 characters for CJK scripts, OR max 6 words for Latin scripts. Keep it very short.
+- No quotes, no trailing punctuation, no numbering, no prefix like "Title:".
+- Output the title only. No explanations.`;
+
+@Injectable()
+export class TopicTitleGeneratorService {
+  private readonly logger = new Logger(TopicTitleGeneratorService.name);
+
+  /**
+   * Channels whose title-generation call is in flight right now.
+   * In-process dedupe only — the DB-level guard
+   * (`expectCurrentTitleNull`) is what actually prevents double-writes
+   * across restarts or multiple Node instances.
+   */
+  private readonly inflight = new Set<string>();
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    @Optional() private readonly ai?: AiClientService,
+    @Inject(forwardRef(() => ChannelsService))
+    private readonly channels?: ChannelsService,
+    @Inject(forwardRef(() => WebsocketGateway))
+    private readonly ws?: WebsocketGateway,
+    @Optional() private readonly eventEmitter?: EventEmitter2,
+  ) {}
+
+  /**
+   * Listen for any freshly persisted message (human, bot, streaming end…)
+   * and decide whether to generate a title for the channel it landed in.
+   * The decision is "bot just replied in a topic-session channel whose
+   * title is still null" — exactly the first-turn-done signal we want.
+   */
+  @OnEvent('message.created')
+  async onMessageCreated(payload: MessageCreatedPayload): Promise<void> {
+    try {
+      await this.maybeGenerate(payload);
+    } catch (err) {
+      this.logger.error(
+        `Title generation handler failed (channel ${payload?.message?.channelId ?? '?'}): ${err}`,
+      );
+    }
+  }
+
+  private async maybeGenerate(payload: MessageCreatedPayload): Promise<void> {
+    const channelId = payload?.message?.channelId;
+    const senderId = payload?.message?.senderId;
+    if (!channelId || !senderId) return;
+    if (!this.ai || !this.channels) return; // module wired without deps
+    if (this.inflight.has(channelId)) return;
+
+    // Only fire on bot-authored messages. If the sender info wasn't
+    // included in the payload, fall back to a single lookup.
+    let senderUserType = payload.sender?.userType;
+    if (!senderUserType) {
+      const [u] = await this.db
+        .select({ userType: schema.users.userType })
+        .from(schema.users)
+        .where(eq(schema.users.id, senderId))
+        .limit(1);
+      senderUserType = u?.userType;
+    }
+    if (senderUserType !== 'bot') return;
+
+    // Channel must be a topic session and its title must still be null.
+    const [channel] = await this.db
+      .select()
+      .from(schema.channels)
+      .where(eq(schema.channels.id, channelId))
+      .limit(1);
+    if (!channel || channel.type !== 'topic-session') return;
+
+    const ts =
+      (
+        channel.propertySettings as {
+          topicSession?: { title?: string | null };
+        } | null
+      )?.topicSession ?? {};
+    if (ts.title) return;
+
+    // Find the first human-authored message in the channel — that's the
+    // seed for the summary.
+    const firstUserMessage = await this.findFirstUserMessage(channelId);
+    if (!firstUserMessage) return;
+
+    this.inflight.add(channelId);
+    try {
+      const title = await this.callLlm(firstUserMessage);
+      if (!title) return;
+
+      const updated = await this.channels.updateTopicSessionTitle(
+        channelId,
+        title,
+        { expectCurrentTitleNull: true },
+      );
+      if (!updated) return;
+
+      // Let the search indexer re-index under the new `channel.name`,
+      // and notify sidebar listeners so the title slides in live.
+      this.eventEmitter?.emit('channel.updated', { channel: updated });
+
+      const creatorId = updated.createdBy;
+      if (creatorId && this.ws) {
+        await this.ws.sendToUser(creatorId, WS_EVENTS.TOPIC_SESSION.UPDATED, {
+          channelId,
+          title,
+        });
+      }
+
+      this.logger.log(
+        `Generated title for topic session ${channelId}: "${title}"`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `LLM title generation failed for channel ${channelId}: ${err}`,
+      );
+    } finally {
+      this.inflight.delete(channelId);
+    }
+  }
+
+  private async findFirstUserMessage(
+    channelId: string,
+  ): Promise<string | null> {
+    const rows = await this.db
+      .select({
+        content: schema.messages.content,
+        senderId: schema.messages.senderId,
+      })
+      .from(schema.messages)
+      .innerJoin(schema.users, eq(schema.users.id, schema.messages.senderId))
+      .where(
+        and(
+          eq(schema.messages.channelId, channelId),
+          eq(schema.messages.isDeleted, false),
+          eq(schema.users.userType, 'human'),
+        ),
+      )
+      .orderBy(asc(schema.messages.createdAt))
+      .limit(1);
+
+    const content = rows[0]?.content;
+    if (!content) return null;
+    // Clip egregiously long seeds so we don't burn context on a wall of
+    // text — the first couple hundred chars are plenty to summarise from.
+    return content.slice(0, 800);
+  }
+
+  private async callLlm(seed: string): Promise<string | null> {
+    if (!this.ai) return null;
+
+    let response: AICompletionResponse;
+    try {
+      response = await this.ai.chat({
+        provider: AIProvider.CLAUDE,
+        model: 'claude-3-5-haiku-20241022',
+        temperature: 0.3,
+        maxTokens: 40,
+        messages: [
+          { role: 'system', content: TITLE_PROMPT },
+          { role: 'user', content: seed },
+        ],
+      });
+    } catch (err) {
+      this.logger.warn(`AiClientService.chat threw: ${err}`);
+      return null;
+    }
+
+    const raw = (response?.content ?? '').trim();
+    if (!raw) return null;
+
+    // Defensive post-processing: strip surrounding quotes / backticks,
+    // collapse whitespace, and cap at a hard character ceiling in case
+    // the model ignores the length guidance.
+    const cleaned = raw
+      .replace(/^[`'"“”‘’「『《]+|[`'"“”‘’」』》]+$/g, '')
+      .replace(/\s+/g, ' ')
+      .replace(/[。！？!?.]+$/u, '')
+      .trim();
+
+    if (!cleaned) return null;
+    // Rough upper bound: 40 chars works for both CJK (≈20 chars visible)
+    // and Latin (≈8 words). Anything longer gets truncated.
+    return cleaned.length > 40 ? cleaned.slice(0, 40) : cleaned;
+  }
+}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
@@ -14,14 +14,10 @@ import {
   type PostgresJsDatabase,
 } from '@team9/database';
 import * as schema from '@team9/database/schemas';
-import {
-  AiClientService,
-  AIProvider,
-  type AICompletionResponse,
-} from '@team9/ai-client';
 import { ChannelsService } from '../channels/channels.service.js';
 import { WebsocketGateway } from '../websocket/websocket.gateway.js';
 import { WS_EVENTS } from '../websocket/events/events.constants.js';
+import { CapabilityHubClient } from '../../deep-research/capability-hub.client.js';
 
 interface MessageCreatedPayload {
   message: {
@@ -63,7 +59,7 @@ export class TopicTitleGeneratorService {
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
-    @Optional() private readonly ai?: AiClientService,
+    @Optional() private readonly hub?: CapabilityHubClient,
     @Inject(forwardRef(() => ChannelsService))
     private readonly channels?: ChannelsService,
     @Inject(forwardRef(() => WebsocketGateway))
@@ -92,7 +88,7 @@ export class TopicTitleGeneratorService {
     const channelId = payload?.message?.channelId;
     const senderId = payload?.message?.senderId;
     if (!channelId || !senderId) return;
-    if (!this.ai || !this.channels) return; // module wired without deps
+    if (!this.hub || !this.channels) return; // module wired without deps
     if (this.inflight.has(channelId)) return;
 
     // Only fire on bot-authored messages. If the sender info wasn't
@@ -124,6 +120,20 @@ export class TopicTitleGeneratorService {
       )?.topicSession ?? {};
     if (ts.title) return;
 
+    // capability-hub needs a billable identity (userId + tenantId) on
+    // every LLM call so it can pre-authorize and then record usage
+    // against the right workspace ledger. Skip generation cleanly when
+    // the channel is missing either — no title is better than an
+    // orphaned LLM charge or a blown-up fetch call.
+    const creatorId = channel.createdBy;
+    const tenantId = channel.tenantId;
+    if (!creatorId || !tenantId) {
+      this.logger.warn(
+        `Skipping title gen for channel ${channelId}: missing createdBy or tenantId`,
+      );
+      return;
+    }
+
     // Find the first human-authored message in the channel — that's the
     // seed for the summary.
     const firstUserMessage = await this.findFirstUserMessage(channelId);
@@ -131,7 +141,10 @@ export class TopicTitleGeneratorService {
 
     this.inflight.add(channelId);
     try {
-      const title = await this.callLlm(firstUserMessage);
+      const title = await this.callLlm(firstUserMessage, {
+        userId: creatorId,
+        tenantId,
+      });
       if (!title) return;
 
       const updated = await this.channels.updateTopicSessionTitle(
@@ -145,8 +158,7 @@ export class TopicTitleGeneratorService {
       // and notify sidebar listeners so the title slides in live.
       this.eventEmitter?.emit('channel.updated', { channel: updated });
 
-      const creatorId = updated.createdBy;
-      if (creatorId && this.ws) {
+      if (this.ws) {
         await this.ws.sendToUser(creatorId, WS_EVENTS.TOPIC_SESSION.UPDATED, {
           channelId,
           title,
@@ -157,7 +169,7 @@ export class TopicTitleGeneratorService {
         `Generated title for topic session ${channelId}: "${title}"`,
       );
     } catch (err) {
-      this.logger.warn(
+      this.logger.error(
         `LLM title generation failed for channel ${channelId}: ${err}`,
       );
     } finally {
@@ -192,27 +204,63 @@ export class TopicTitleGeneratorService {
     return content.slice(0, 800);
   }
 
-  private async callLlm(seed: string): Promise<string | null> {
-    if (!this.ai) return null;
+  private async callLlm(
+    seed: string,
+    identity: { userId: string; tenantId: string },
+  ): Promise<string | null> {
+    if (!this.hub) return null;
 
-    let response: AICompletionResponse;
+    // Route through capability-hub's llm-proxy, not the platform's
+    // Anthropic SDK. That's the path agent-pi already uses and the
+    // only one wired into pre-authorize / record / billing-hub —
+    // calling Anthropic directly would bypass usage accounting.
+    // OpenRouter-compatible OpenAI chat/completions body works
+    // because capability-hub forwards unchanged.
+    let response: Response;
     try {
-      response = await this.ai.chat({
-        provider: AIProvider.CLAUDE,
-        model: 'claude-3-5-haiku-20241022',
-        temperature: 0.3,
-        maxTokens: 40,
-        messages: [
-          { role: 'system', content: TITLE_PROMPT },
-          { role: 'user', content: seed },
-        ],
-      });
+      response = await this.hub.request(
+        'POST',
+        '/proxy/openrouter/chat/completions',
+        {
+          headers: {
+            ...this.hub.serviceHeaders(identity),
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: 'openai/gpt-4o-mini',
+            max_tokens: 40,
+            temperature: 0.3,
+            messages: [
+              { role: 'system', content: TITLE_PROMPT },
+              { role: 'user', content: seed },
+            ],
+          }),
+        },
+      );
     } catch (err) {
-      this.logger.warn(`AiClientService.chat threw: ${err}`);
+      this.logger.warn(`capability-hub fetch failed: ${err}`);
       return null;
     }
 
-    const raw = (response?.content ?? '').trim();
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      this.logger.warn(
+        `capability-hub llm-proxy returned ${response.status}: ${body.slice(0, 200)}`,
+      );
+      return null;
+    }
+
+    let data: {
+      choices?: Array<{ message?: { content?: string | null } }>;
+    };
+    try {
+      data = (await response.json()) as typeof data;
+    } catch (err) {
+      this.logger.warn(`capability-hub response not JSON: ${err}`);
+      return null;
+    }
+
+    const raw = (data.choices?.[0]?.message?.content ?? '').trim();
     if (!raw) return null;
 
     // Defensive post-processing: strip surrounding quotes / backticks,

--- a/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.spec.ts
+++ b/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.spec.ts
@@ -1153,6 +1153,59 @@ describe('PostBroadcastService — pushToHiveBots', () => {
     expect(createTrackingSpy).not.toHaveBeenCalled();
   });
 
+  it('routes topic-session channel message to topic/ scope with channel id', async () => {
+    const bot = makeHiveBot('claude');
+    setupDbForHivePush({
+      bots: [bot],
+      channel: makeChannel('topic-session'),
+    });
+
+    await (service as any).pushToHiveBots(MSG_ID, SENDER_ID, [bot.userId]);
+
+    expect(clawHiveService.sendInput).toHaveBeenCalledTimes(1);
+    const [sessionId, event] = clawHiveService.sendInput.mock.calls[0] as [
+      string,
+      any,
+      string,
+    ];
+    expect(sessionId).toBe(
+      `team9/${TENANT_ID}/${bot.managedMeta.agentId}/topic/${CHANNEL_ID}`,
+    );
+    expect(event.payload.location.type).toBe('topic');
+    expect(event.payload.team9Context.scopeType).toBe('topic');
+    expect(event.payload.team9Context.scopeId).toBe(CHANNEL_ID);
+    // No tracking channel spawned for topic sessions — same as DM.
+    expect(event.payload.trackingChannelId).toBeUndefined();
+  });
+
+  it('forwards topic-session message even without @mention (alwaysForward)', async () => {
+    const bot = makeHiveBot('claude');
+    setupDbForHivePush({
+      bots: [bot],
+      channel: makeChannel('topic-session'),
+    });
+
+    await (service as any).pushToHiveBots(MSG_ID, SENDER_ID, [bot.userId]);
+
+    expect(clawHiveService.sendInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create a tracking channel for topic-session', async () => {
+    const bot = makeHiveBot('claude');
+    const createTrackingSpy = jest.spyOn(
+      service as any,
+      'createTrackingChannel',
+    );
+    setupDbForHivePush({
+      bots: [bot],
+      channel: makeChannel('topic-session'),
+    });
+
+    await (service as any).pushToHiveBots(MSG_ID, SENDER_ID, [bot.userId]);
+
+    expect(createTrackingSpy).not.toHaveBeenCalled();
+  });
+
   it('routes tracking channel message to same session without creating new channel', async () => {
     const bot = makeHiveBot('claude');
     setupDbForHivePush({ bots: [bot], channel: makeChannel('tracking') });

--- a/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.spec.ts
+++ b/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.spec.ts
@@ -1153,7 +1153,7 @@ describe('PostBroadcastService — pushToHiveBots', () => {
     expect(createTrackingSpy).not.toHaveBeenCalled();
   });
 
-  it('routes topic-session channel message to topic/ scope with channel id', async () => {
+  it('routes topic-session channel message to dm/ scope (shared with routine-session and direct)', async () => {
     const bot = makeHiveBot('claude');
     setupDbForHivePush({
       bots: [bot],
@@ -1168,11 +1168,16 @@ describe('PostBroadcastService — pushToHiveBots', () => {
       any,
       string,
     ];
+    // topic sessions collapse into agent-pi's 'dm' bucket: runtime
+    // behaviour is identical to DM (plain-text stream, no Reply tool),
+    // and agent-pi's EventChannelType is a closed 4-value enum. team9
+    // distinguishes them via `channels.type='topic-session'`, not on
+    // the wire. Channel id disambiguates from legacy direct channels.
     expect(sessionId).toBe(
-      `team9/${TENANT_ID}/${bot.managedMeta.agentId}/topic/${CHANNEL_ID}`,
+      `team9/${TENANT_ID}/${bot.managedMeta.agentId}/dm/${CHANNEL_ID}`,
     );
-    expect(event.payload.location.type).toBe('topic');
-    expect(event.payload.team9Context.scopeType).toBe('topic');
+    expect(event.payload.location.type).toBe('dm');
+    expect(event.payload.team9Context.scopeType).toBe('dm');
     expect(event.payload.team9Context.scopeId).toBe(CHANNEL_ID);
     // No tracking channel spawned for topic sessions — same as DM.
     expect(event.payload.trackingChannelId).toBeUndefined();

--- a/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.ts
+++ b/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.ts
@@ -659,7 +659,13 @@ export class PostBroadcastService {
       // them as 'channel' (the default) would fork a new tracking session
       // per reply and break the creation conversation entirely.
       const isRoutineSession = channel.type === 'routine-session';
-      const alwaysForward = isDm || isTracking || isRoutineSession;
+      // topic-session channels: one ephemeral conversation per user×agent×
+      // topic. Every message in the channel maps 1:1 to a single agent-pi
+      // session keyed by the channel id (scope='topic'). They are always
+      // forwarded and never spawn a tracking channel, same as DM.
+      const isTopicSession = channel.type === 'topic-session';
+      const alwaysForward =
+        isDm || isTracking || isRoutineSession || isTopicSession;
       const mentionedUserIds = alwaysForward
         ? null
         : extractMentionedUserIds(mentions);
@@ -700,9 +706,17 @@ export class PostBroadcastService {
       // Build the recursive MessageLocation for the event payload.
       // routine-session channels report as 'dm' so bot context mirrors
       // the kickoff-event location (which uses the `dm/` session scope).
+      // topic-session channels report as 'topic' — same shape as 'dm' from
+      // the bot's perspective (one-on-one conversation), but distinct so
+      // components can disambiguate if they need to.
       const channelLocation: Record<string, unknown> = {
-        type:
-          isDm || isRoutineSession ? 'dm' : isTracking ? 'tracking' : 'channel',
+        type: isTopicSession
+          ? 'topic'
+          : isDm || isRoutineSession
+            ? 'dm'
+            : isTracking
+              ? 'tracking'
+              : 'channel',
         id: channel.id,
         ...(channel.name ? { name: channel.name } : {}),
       };
@@ -736,12 +750,12 @@ export class PostBroadcastService {
         }
 
         // Create new tracking channel for each group interaction
-        // (fresh @mention or follow-up thread reply). routine-session
-        // channels are DM-like and must NOT create a tracking channel —
-        // the bot already has an active session keyed off the original
-        // channel id from the kickoff event.
+        // (fresh @mention or follow-up thread reply). routine-session and
+        // topic-session channels are DM-like and must NOT create a
+        // tracking channel — the bot already has an active session keyed
+        // off the original channel id from the kickoff event.
         let trackingChannelId: string | undefined;
-        if (!isDm && !isTracking && !isRoutineSession) {
+        if (!isDm && !isTracking && !isRoutineSession && !isTopicSession) {
           trackingChannelId = await this.createTrackingChannel(
             tenantId || null,
             bot.userId,
@@ -753,12 +767,17 @@ export class PostBroadcastService {
         }
 
         // Session ID:
+        //   topic-session:        team9/{tenant}/{agent}/topic/{channelId}
         //   DM / routine-session: team9/{tenant}/{agent}/dm/{channelId}
-        //   Group @mention: team9/{tenant}/{agent}/tracking/{newTrackingChannelId}
-        //   Tracking guidance: team9/{tenant}/{agent}/tracking/{existingChannelId}
-        const scope = isDm || isRoutineSession ? 'dm' : 'tracking';
+        //   Group @mention:       team9/{tenant}/{agent}/tracking/{newTrackingChannelId}
+        //   Tracking guidance:    team9/{tenant}/{agent}/tracking/{existingChannelId}
+        const scope: 'topic' | 'dm' | 'tracking' = isTopicSession
+          ? 'topic'
+          : isDm || isRoutineSession
+            ? 'dm'
+            : 'tracking';
         const scopeId =
-          isDm || isRoutineSession
+          isTopicSession || isDm || isRoutineSession
             ? channel.id
             : (trackingChannelId ?? channel.id);
         const sessionId = `team9/${tenantId}/${agentId}/${scope}/${scopeId}`;
@@ -911,23 +930,30 @@ export class PostBroadcastService {
     sender: Pick<schema.User, 'id'>;
   }): {
     source: 'team9';
-    scopeType: 'dm' | 'channel' | 'task';
+    scopeType: 'dm' | 'channel' | 'task' | 'topic';
     scopeId: string;
     peerUserId: string;
     isMentorDm: boolean;
   } {
     const { channel, bot, sender } = params;
     // routine-session channels report as 'dm' for bot context because
-    // their session id uses the dm/ scope. isMentorDm only fires for
-    // real direct channels — creation sessions are not mentor-directed.
+    // their session id uses the dm/ scope. topic-session channels get
+    // their own 'topic' scope to mirror the session id path. isMentorDm
+    // only fires for real direct channels — creation/topic sessions are
+    // not mentor-directed.
     const isDirect = channel.type === 'direct';
     const isRoutineSession = channel.type === 'routine-session';
-    const isDmLike = isDirect || isRoutineSession;
+    const isTopicSession = channel.type === 'topic-session';
+    const scopeType: 'dm' | 'channel' | 'task' | 'topic' = isTopicSession
+      ? 'topic'
+      : isDirect || isRoutineSession
+        ? 'dm'
+        : 'channel';
     const isMentorDm =
       isDirect && bot.mentorId !== null && sender.id === bot.mentorId;
     return {
       source: 'team9',
-      scopeType: isDmLike ? 'dm' : 'channel',
+      scopeType,
       scopeId: channel.id,
       peerUserId: sender.id,
       isMentorDm,

--- a/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.ts
+++ b/apps/server/apps/im-worker/src/post-broadcast/post-broadcast.service.ts
@@ -661,7 +661,10 @@ export class PostBroadcastService {
       const isRoutineSession = channel.type === 'routine-session';
       // topic-session channels: one ephemeral conversation per user×agent×
       // topic. Every message in the channel maps 1:1 to a single agent-pi
-      // session keyed by the channel id (scope='topic'). They are always
+      // session keyed by the channel id. They share the 'dm' wire scope
+      // with routine-session because the agent behaviour is identical;
+      // team9 still keeps them as a distinct `channels.type` for IM
+      // layer concerns (sidebar, search, title generation). Always
       // forwarded and never spawn a tracking channel, same as DM.
       const isTopicSession = channel.type === 'topic-session';
       const alwaysForward =
@@ -704,15 +707,23 @@ export class PostBroadcastService {
       }
 
       // Build the recursive MessageLocation for the event payload.
-      // routine-session channels report as 'dm' so bot context mirrors
-      // the kickoff-event location (which uses the `dm/` session scope).
-      // topic-session channels report as 'topic' — same shape as 'dm' from
-      // the bot's perspective (one-on-one conversation), but distinct so
-      // components can disambiguate if they need to.
+      //
+      // Three team9 channel types collapse into agent-pi's 'dm' bucket:
+      //   - direct:          one-on-one with a human
+      //   - routine-session: one-on-one creation/reflection meta-chat
+      //   - topic-session:   one-on-one scoped to a single topic
+      // They all have the same agent runtime behaviour (plain text
+      // streams back to the user, no Reply tool, no tracking mirror),
+      // and agent-pi's EventChannelType is a closed 4-value enum
+      // ('channel' | 'dm' | 'task' | 'tracking'); anything else lands
+      // in the `else → channelType = undefined` branch of
+      // Team9Component.updateEventLocationFromLocation and the agent's
+      // reply gets swallowed. team9 keeps `channels.type='topic-session'`
+      // as the IM abstraction (sidebar grouping, search, title gen);
+      // the mapping to 'dm' only happens at the wire.
       const channelLocation: Record<string, unknown> = {
-        type: isTopicSession
-          ? 'topic'
-          : isDm || isRoutineSession
+        type:
+          isDm || isRoutineSession || isTopicSession
             ? 'dm'
             : isTracking
               ? 'tracking'
@@ -767,17 +778,19 @@ export class PostBroadcastService {
         }
 
         // Session ID:
-        //   topic-session:        team9/{tenant}/{agent}/topic/{channelId}
-        //   DM / routine-session: team9/{tenant}/{agent}/dm/{channelId}
-        //   Group @mention:       team9/{tenant}/{agent}/tracking/{newTrackingChannelId}
-        //   Tracking guidance:    team9/{tenant}/{agent}/tracking/{existingChannelId}
-        const scope: 'topic' | 'dm' | 'tracking' = isTopicSession
-          ? 'topic'
-          : isDm || isRoutineSession
-            ? 'dm'
-            : 'tracking';
+        //   DM / routine-session / topic-session:
+        //     team9/{tenant}/{agent}/dm/{channelId}
+        //   Group @mention: team9/{tenant}/{agent}/tracking/{newTrackingChannelId}
+        //   Tracking guidance: team9/{tenant}/{agent}/tracking/{existingChannelId}
+        //
+        // All three DM-like team9 channel types share the 'dm' scope —
+        // channelId is UUIDv7-unique so there is no id collision across
+        // direct / routine-session / topic-session sessions for the
+        // same (tenant, agent) pair.
+        const scope: 'dm' | 'tracking' =
+          isDm || isRoutineSession || isTopicSession ? 'dm' : 'tracking';
         const scopeId =
-          isTopicSession || isDm || isRoutineSession
+          isDm || isRoutineSession || isTopicSession
             ? channel.id
             : (trackingChannelId ?? channel.id);
         const sessionId = `team9/${tenantId}/${agentId}/${scope}/${scopeId}`;
@@ -930,25 +943,23 @@ export class PostBroadcastService {
     sender: Pick<schema.User, 'id'>;
   }): {
     source: 'team9';
-    scopeType: 'dm' | 'channel' | 'task' | 'topic';
+    scopeType: 'dm' | 'channel' | 'task';
     scopeId: string;
     peerUserId: string;
     isMentorDm: boolean;
   } {
     const { channel, bot, sender } = params;
-    // routine-session channels report as 'dm' for bot context because
-    // their session id uses the dm/ scope. topic-session channels get
-    // their own 'topic' scope to mirror the session id path. isMentorDm
-    // only fires for real direct channels — creation/topic sessions are
-    // not mentor-directed.
+    // direct, routine-session, and topic-session are all one-on-one
+    // in agent-pi's eyes, so they share the 'dm' scopeType. team9
+    // channel-type distinctions live in the IM layer (sidebar / search
+    // / title gen) and intentionally don't leak into agent runtime.
+    // isMentorDm only fires for real direct channels — creation and
+    // topic sessions are not mentor-directed.
     const isDirect = channel.type === 'direct';
     const isRoutineSession = channel.type === 'routine-session';
     const isTopicSession = channel.type === 'topic-session';
-    const scopeType: 'dm' | 'channel' | 'task' | 'topic' = isTopicSession
-      ? 'topic'
-      : isDirect || isRoutineSession
-        ? 'dm'
-        : 'channel';
+    const scopeType: 'dm' | 'channel' | 'task' =
+      isDirect || isRoutineSession || isTopicSession ? 'dm' : 'channel';
     const isMentorDm =
       isDirect && bot.mentorId !== null && sender.id === bot.mentorId;
     return {

--- a/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
@@ -464,6 +464,59 @@ describe('ClawHiveService', () => {
     });
   });
 
+  // ── updateSessionTitle ────────────────────────────────────────────────────
+
+  describe('updateSessionTitle', () => {
+    it('sends PATCH with the title to /api/sessions/{id}', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ sessionId: 'sess-1', title: 'Topic A' }),
+      );
+
+      await service.updateSessionTitle('sess-1', 'Topic A', 'tenant-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-hive:9999/api/sessions/sess-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-Hive-Tenant': 'tenant-1',
+          }),
+          body: JSON.stringify({ title: 'Topic A' }),
+        }),
+      );
+    });
+
+    it('supports clearing the title with null', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ sessionId: 'sess-1', title: null }),
+      );
+
+      await service.updateSessionTitle('sess-1', null);
+
+      const body = (mockFetch.mock.calls[0] as any[])[1]?.body;
+      expect(body).toBe(JSON.stringify({ title: null }));
+    });
+
+    it('tolerates 404 silently (session already deleted)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('Not Found', { status: 404 }),
+      );
+
+      await expect(
+        service.updateSessionTitle('gone-session', 'Late title'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws on non-404 error responses', async () => {
+      mockFetch.mockResolvedValueOnce(textResponse('Server error', 500));
+
+      await expect(service.updateSessionTitle('sess-1', 'T')).rejects.toThrow(
+        'Failed to update session title: 500',
+      );
+    });
+  });
+
   // ── headers ──────────────────────────────────────────────────────────────
 
   describe('headers', () => {

--- a/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
@@ -464,59 +464,6 @@ describe('ClawHiveService', () => {
     });
   });
 
-  // ── updateSessionTitle ────────────────────────────────────────────────────
-
-  describe('updateSessionTitle', () => {
-    it('sends PATCH with the title to /api/sessions/{id}', async () => {
-      mockFetch.mockResolvedValueOnce(
-        jsonResponse({ sessionId: 'sess-1', title: 'Topic A' }),
-      );
-
-      await service.updateSessionTitle('sess-1', 'Topic A', 'tenant-1');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://test-hive:9999/api/sessions/sess-1',
-        expect.objectContaining({
-          method: 'PATCH',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
-            'X-Hive-Tenant': 'tenant-1',
-          }),
-          body: JSON.stringify({ title: 'Topic A' }),
-        }),
-      );
-    });
-
-    it('supports clearing the title with null', async () => {
-      mockFetch.mockResolvedValueOnce(
-        jsonResponse({ sessionId: 'sess-1', title: null }),
-      );
-
-      await service.updateSessionTitle('sess-1', null);
-
-      const body = (mockFetch.mock.calls[0] as any[])[1]?.body;
-      expect(body).toBe(JSON.stringify({ title: null }));
-    });
-
-    it('tolerates 404 silently (session already deleted)', async () => {
-      mockFetch.mockResolvedValueOnce(
-        new Response('Not Found', { status: 404 }),
-      );
-
-      await expect(
-        service.updateSessionTitle('gone-session', 'Late title'),
-      ).resolves.toBeUndefined();
-    });
-
-    it('throws on non-404 error responses', async () => {
-      mockFetch.mockResolvedValueOnce(textResponse('Server error', 500));
-
-      await expect(service.updateSessionTitle('sess-1', 'T')).rejects.toThrow(
-        'Failed to update session title: 500',
-      );
-    });
-  });
-
   // ── headers ──────────────────────────────────────────────────────────────
 
   describe('headers', () => {

--- a/apps/server/libs/claw-hive/src/claw-hive.service.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.ts
@@ -285,34 +285,6 @@ export class ClawHiveService {
     }
   }
 
-  /**
-   * Set (or clear) the user-facing session title on agent-pi.
-   * The server is intentionally unrestricted — overwrite/idempotency
-   * policy is team9's job. Callers typically only write when they
-   * know the session has no title yet (first-turn title generation),
-   * but the endpoint tolerates repeat calls safely.
-   */
-  async updateSessionTitle(
-    sessionId: string,
-    title: string | null,
-    tenantId?: string,
-  ): Promise<void> {
-    const res = await fetch(
-      `${this.baseUrl}/api/sessions/${encodeURIComponent(sessionId)}`,
-      {
-        method: 'PATCH',
-        headers: this.headers(tenantId),
-        body: JSON.stringify({ title }),
-      },
-    );
-    // 404 is tolerated — session may have been deleted concurrently
-    // (e.g. user archived the topic before title generation completed).
-    if (!res.ok && res.status !== 404) {
-      const text = await res.text();
-      throw new Error(`Failed to update session title: ${res.status} ${text}`);
-    }
-  }
-
   /** Delete (terminate) a session. Swallows 404 (session already gone). */
   async deleteSession(sessionId: string, tenantId?: string): Promise<void> {
     const res = await fetch(

--- a/apps/server/libs/claw-hive/src/claw-hive.service.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.ts
@@ -285,6 +285,34 @@ export class ClawHiveService {
     }
   }
 
+  /**
+   * Set (or clear) the user-facing session title on agent-pi.
+   * The server is intentionally unrestricted — overwrite/idempotency
+   * policy is team9's job. Callers typically only write when they
+   * know the session has no title yet (first-turn title generation),
+   * but the endpoint tolerates repeat calls safely.
+   */
+  async updateSessionTitle(
+    sessionId: string,
+    title: string | null,
+    tenantId?: string,
+  ): Promise<void> {
+    const res = await fetch(
+      `${this.baseUrl}/api/sessions/${encodeURIComponent(sessionId)}`,
+      {
+        method: 'PATCH',
+        headers: this.headers(tenantId),
+        body: JSON.stringify({ title }),
+      },
+    );
+    // 404 is tolerated — session may have been deleted concurrently
+    // (e.g. user archived the topic before title generation completed).
+    if (!res.ok && res.status !== 404) {
+      const text = await res.text();
+      throw new Error(`Failed to update session title: ${res.status} ${text}`);
+    }
+  }
+
   /** Delete (terminate) a session. Swallows 404 (session already gone). */
   async deleteSession(sessionId: string, tenantId?: string): Promise<void> {
     const res = await fetch(

--- a/apps/server/libs/database/migrations/0044_topic_session_channel_type.sql
+++ b/apps/server/libs/database/migrations/0044_topic_session_channel_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."channel_type" ADD VALUE IF NOT EXISTS 'topic-session';

--- a/apps/server/libs/database/migrations/meta/_journal.json
+++ b/apps/server/libs/database/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1776762069343,
       "tag": "0043_message_relations",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1777300000000,
+      "tag": "0044_topic_session_channel_type",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/libs/database/src/schemas/im/channels.ts
+++ b/apps/server/libs/database/src/schemas/im/channels.ts
@@ -34,6 +34,7 @@ export const channelTypeEnum = pgEnum('channel_type', [
   'tracking',
   'echo',
   'routine-session',
+  'topic-session',
 ]);
 
 export const channels = pgTable(

--- a/apps/server/libs/shared/src/events/event-names.ts
+++ b/apps/server/libs/shared/src/events/event-names.ts
@@ -299,6 +299,21 @@ export const WS_EVENTS = {
     /** Tab deleted - broadcast by server */
     DELETED: 'tab_deleted',
   },
+
+  // ==================== Topic Sessions ====================
+  /**
+   * Topic session events — one ephemeral user×agent conversation per topic.
+   * Distinct from CHANNEL.* even though a topic session is a channel under
+   * the hood, because the sidebar treats the agent-group as its own entity.
+   */
+  TOPIC_SESSION: {
+    /** Topic session created - broadcast by server to creator + bot */
+    CREATED: 'topic_session_created',
+    /** Topic session metadata (title, lastMessageAt) updated - broadcast by server */
+    UPDATED: 'topic_session_updated',
+    /** Topic session deleted - broadcast by server */
+    DELETED: 'topic_session_deleted',
+  },
 } as const;
 
 /**
@@ -323,4 +338,5 @@ export type WsEventName =
   | (typeof WS_EVENTS.STREAMING)[keyof typeof WS_EVENTS.STREAMING]
   | (typeof WS_EVENTS.PROPERTY)[keyof typeof WS_EVENTS.PROPERTY]
   | (typeof WS_EVENTS.VIEW)[keyof typeof WS_EVENTS.VIEW]
-  | (typeof WS_EVENTS.TAB)[keyof typeof WS_EVENTS.TAB];
+  | (typeof WS_EVENTS.TAB)[keyof typeof WS_EVENTS.TAB]
+  | (typeof WS_EVENTS.TOPIC_SESSION)[keyof typeof WS_EVENTS.TOPIC_SESSION];


### PR DESCRIPTION
## Summary
Per-topic user × agent conversations. Dashboard input spins up a fresh session + channel + first message in one saga. Sidebar "AI Agents" lists every installed agent, expandable into recent topic sessions. LLM-generated titles via capability-hub (billed), live sidebar refresh via WS.

Companion agent-pi PRs already merged: team9ai/agent-pi#77 + #78.

## Design anchors
- \`channels.type='topic-session'\` is IM-layer; runtime wire maps to \`'dm'\` (same as \`routine-session\`) — agent-pi \`EventChannelType\` is a closed 4-value enum.
- Title stored in team9 only; agent-pi never reads it.
- Title LLM routed through \`capability-hub /api/proxy/...\` for billing.
- Sidebar merges installed-apps (directory) with \`/grouped\` (activity).

## Scope

Backend:
- Migration 0044 + channelTypeEnum addition
- post-broadcast routes topic-session as DM-like
- \`im/topic-sessions\` module: POST (saga + compensation) / GET grouped / DELETE
- TopicTitleGeneratorService via capability-hub, mirrors title to channel.name
- 3 new WS events: topic_session_created / updated / deleted

Frontend:
- topicSessionsApi + hooks
- Dashboard handleSubmit → createTopicSession
- AgentGroupList + sidebar integration
- useAgentGroupsForSidebar merges available + activity
- WS read_status_updated also patches grouped cache

## Verification
- gateway jest: 2347 passed (2 pre-existing suite-load failures reproduce on jt)
- im-worker jest: 150/150
- claw-hive jest: 31/31
- Client typecheck: 37 errors, same as jt baseline

## Not in scope
- P5 lifecycle governance (archive cron, cleanup)
- Manual title rename UI
- Non-hive agents show in directory but can't create topic-session

## Post-deploy
- \`pnpm db:migrate\` picks up 0044