### PR TITLE
fix(gateway/ahand): bind raw body middleware to versioned webhook path

### DIFF
--- a/apps/server/apps/gateway/src/main.ts
+++ b/apps/server/apps/gateway/src/main.ts
@@ -41,9 +41,11 @@ export async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);
 
   // Raw body for ahand webhook signature verification — must come BEFORE json().
-  // Path matches the NestJS route after setGlobalPrefix('api').
+  // Path matches the NestJS route after setGlobalPrefix('api') and URI
+  // versioning (defaultVersion: '1') prepends `/v1/` between the global
+  // prefix and the controller path.
   app.use(
-    '/api/ahand/hub-webhook',
+    '/api/v1/ahand/hub-webhook',
     raw({ type: 'application/json', limit: '1mb' }),
   );
 


### PR DESCRIPTION
Raw body middleware was bound to `/api/ahand/hub-webhook` but URI versioning makes the real path `/api/v1/ahand/hub-webhook`. Webhook requests fell through to json() so HMAC verifier got parsed JSON instead of raw buffer → rejected with "Raw body unavailable".

Discovered during Phase-9 dev smoke: ahand hub webhook PUT returned 400 "Raw body unavailable" even with valid signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)