### PR TITLE
fix(gateway/ahand): use NestFactory rawBody option (webhook HMAC fix #2)

### DIFF
--- a/apps/server/apps/gateway/src/main.ts
+++ b/apps/server/apps/gateway/src/main.ts
@@ -1,7 +1,7 @@
 import './load-env.js'; // Load environment variables first
 import './instrument.js'; // Initialize Sentry before any other imports
 import './otel.js'; // Initialize OpenTelemetry
-import { json, raw } from 'express';
+import { json } from 'express';
 import { NestFactory } from '@nestjs/core';
 import { VersioningType, ValidationPipe, Logger } from '@nestjs/common';
 import {
@@ -38,16 +38,11 @@ export async function bootstrap(): Promise<void> {
     logger.log('Seed completed successfully');
   }
 
-  const app = await NestFactory.create(AppModule);
-
-  // Raw body for ahand webhook signature verification — must come BEFORE json().
-  // Path matches the NestJS route after setGlobalPrefix('api') and URI
-  // versioning (defaultVersion: '1') prepends `/v1/` between the global
-  // prefix and the controller path.
-  app.use(
-    '/api/v1/ahand/hub-webhook',
-    raw({ type: 'application/json', limit: '1mb' }),
-  );
+  // rawBody: true caches the raw request Buffer on req.rawBody while still
+  // letting the default JSON parser populate req.body. The ahand hub webhook
+  // HMAC verifier reads req.rawBody to avoid key-order / whitespace drift,
+  // but the controller still wants the parsed DTO for validation.
+  const app = await NestFactory.create(AppModule, { rawBody: true });
 
   // Raise JSON body parser limit to 1 MB to support long text messages (up to 100K chars)
   app.use(json({ limit: '1mb' }));


### PR DESCRIPTION
Path-scoped `raw()` middleware replaced req.body with a Buffer, which crashed ValidationPipe `whitelist` with TypeError on the raw bytes.

Switch to `NestFactory.create(AppModule, { rawBody: true })`: platform adapter caches the raw Buffer on req.rawBody while still parsing req.body as JSON. Webhook controller already prefers rawBody; ValidationPipe gets a proper DTO.

Follow-up to #60. Discovered in dev smoke test.