### PR TITLE
fix(client/ahand): add /v1 prefix to ahand API paths

### DIFF
--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -539,7 +539,7 @@ export function ChannelView({
 
   if (channelLoading) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3">
+      <div className="h-full flex flex-col items-center justify-center gap-3">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
         <p className="text-sm text-muted-foreground">{t("loadingChannel")}</p>
       </div>
@@ -548,7 +548,7 @@ export function ChannelView({
 
   if (!channel) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="h-full flex items-center justify-center">
         <p className="text-sm text-muted-foreground">{t("channelNotFound")}</p>
       </div>
     );

--- a/apps/client/src/routes/_authenticated/channels/$channelId.tsx
+++ b/apps/client/src/routes/_authenticated/channels/$channelId.tsx
@@ -63,7 +63,7 @@ function ChannelPage() {
   // Loading state while checking membership
   if (isLoading) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3">
+      <div className="h-full flex flex-col items-center justify-center gap-3">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
         <p className="text-sm text-muted-foreground">{t("loadingChannel")}</p>
       </div>

--- a/apps/client/src/services/ahand-api.ts
+++ b/apps/client/src/services/ahand-api.ts
@@ -34,25 +34,25 @@ export interface TokenRefreshResponse {
 
 export const ahandApi = {
   register(input: RegisterDeviceInput): Promise<RegisterDeviceResponse> {
-    return http.post("/ahand/devices", input).then((r) => r.data);
+    return http.post("/v1/ahand/devices", input).then((r) => r.data);
   },
   list(opts: { includeOffline?: boolean } = {}): Promise<DeviceDto[]> {
     const q = opts.includeOffline === false ? "?includeOffline=false" : "";
-    return http.get(`/ahand/devices${q}`).then((r) => r.data);
+    return http.get(`/v1/ahand/devices${q}`).then((r) => r.data);
   },
   refreshToken(id: string): Promise<TokenRefreshResponse> {
     return http
-      .post(`/ahand/devices/${encodeURIComponent(id)}/token/refresh`)
+      .post(`/v1/ahand/devices/${encodeURIComponent(id)}/token/refresh`)
       .then((r) => r.data);
   },
   patch(id: string, body: { nickname?: string }): Promise<DeviceDto> {
     return http
-      .patch(`/ahand/devices/${encodeURIComponent(id)}`, body)
+      .patch(`/v1/ahand/devices/${encodeURIComponent(id)}`, body)
       .then((r) => r.data);
   },
   remove(id: string): Promise<void> {
     return http
-      .delete(`/ahand/devices/${encodeURIComponent(id)}`)
+      .delete(`/v1/ahand/devices/${encodeURIComponent(id)}`)
       .then(() => undefined);
   },
 };


### PR DESCRIPTION
Stream E shipped `/ahand/*` paths but gateway URI versioning rewrites to `/api/v1/*`. Client got 404 on every ahand call. Discovered during Phase-9 dev E2E smoke — Allow as agent target toggle silently no-op because register+list+patch+remove all 404.