### PR TITLE
feat(topic-session): treat topic-session as bot DM + session-scoped model override

### DIFF
--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -276,10 +276,18 @@ export function ChannelView({
   const dmOtherUser = (memberChannel as ChannelWithUnread | undefined)
     ?.otherUser;
 
-  // Determine if this is a bot DM channel
+  // Determine if this is a bot DM-style channel. `direct` is the classic
+  // human/bot DM; `routine-session` and `topic-session` are ephemeral
+  // one-on-one bot conversations. All three resolve to the same agent-pi
+  // session scope ('dm') on the backend, so the composer model switcher and
+  // bot-startup logic apply uniformly.
   const isBotDm = useMemo(() => {
     if (!memberChannel) return false;
-    return memberChannel.type === "direct" && dmOtherUser?.userType === "bot";
+    const isOneOnOneBotType =
+      memberChannel.type === "direct" ||
+      memberChannel.type === "routine-session" ||
+      memberChannel.type === "topic-session";
+    return isOneOnOneBotType && dmOtherUser?.userType === "bot";
   }, [dmOtherUser, memberChannel]);
 
   const botDmUserId = useMemo(() => {

--- a/apps/client/src/components/layout/contents/HomeMainContent.tsx
+++ b/apps/client/src/components/layout/contents/HomeMainContent.tsx
@@ -75,17 +75,18 @@ const FIXED_BASE_MODEL_LABELS = {
 
 function getAgentModelLabel(
   agent: DashboardAgent | null,
+  model: DashboardAgentModel | null,
   fallbackLabel: string,
 ) {
   if (!agent) return fallbackLabel;
 
-  if (agent.model) {
+  if (model) {
     const matchedModel = COMMON_STAFF_MODELS.find(
-      (model) =>
-        model.provider === agent.model?.provider && model.id === agent.model.id,
+      (candidate) =>
+        candidate.provider === model.provider && candidate.id === model.id,
     );
 
-    return matchedModel?.label ?? agent.model.id;
+    return matchedModel?.label ?? model.id;
   }
 
   if (agent.canSwitchModel) {
@@ -105,19 +106,17 @@ function getAgentModelLabel(
 
 function DashboardModelControl({
   agent,
+  model,
   fallbackLabel,
-  isUpdating,
   onSelectModel,
 }: {
   agent: DashboardAgent | null;
+  model: DashboardAgentModel | null;
   fallbackLabel: string;
-  isUpdating: boolean;
-  onSelectModel: (model: DashboardAgentModel) => Promise<void>;
+  onSelectModel: (model: DashboardAgentModel) => void;
 }) {
-  const currentLabel = getAgentModelLabel(agent, fallbackLabel);
-  const currentValue = agent?.model
-    ? `${agent.model.provider}::${agent.model.id}`
-    : undefined;
+  const currentLabel = getAgentModelLabel(agent, model, fallbackLabel);
+  const currentValue = model ? `${model.provider}::${model.id}` : undefined;
 
   if (!agent?.canSwitchModel) {
     return (
@@ -133,14 +132,9 @@ function DashboardModelControl({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          disabled={isUpdating}
-          className="dashboard-composer-model inline-flex h-[2.05rem] items-center gap-1.5 rounded-full px-3 text-[0.76rem] text-[#50627f] cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+          className="dashboard-composer-model inline-flex h-[2.05rem] items-center gap-1.5 rounded-full px-3 text-[0.76rem] text-[#50627f] cursor-pointer"
         >
-          {isUpdating ? (
-            <Loader2 size={12} className="animate-spin text-[#2c3647]" />
-          ) : (
-            <Sparkles size={12} className="text-[#2c3647]" />
-          )}
+          <Sparkles size={12} className="text-[#2c3647]" />
           <span>{currentLabel}</span>
           <ChevronDown size={11} className="text-[#93887b]" />
         </button>
@@ -155,7 +149,7 @@ function DashboardModelControl({
           onValueChange={(value) => {
             const [provider, id] = value.split("::");
             if (!provider || !id) return;
-            void onSelectModel({ provider, id });
+            onSelectModel({ provider, id });
           }}
         >
           {COMMON_STAFF_MODELS.map((model) => (
@@ -405,7 +399,9 @@ function formatDashboardCredits(value: number) {
   return new Intl.NumberFormat("en-US").format(Math.floor(value));
 }
 
-export function HomeMainContent() {
+export function HomeMainContent({
+  agentId = null,
+}: { agentId?: string | null } = {}) {
   const { t } = useTranslation(["navigation", "message"]);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -415,19 +411,24 @@ export function HomeMainContent() {
   // it's orthogonal to topic sessions and can be migrated later.
   const createDirectChannel = useCreateDirectChannel();
   const createTopicSession = useCreateTopicSession();
-  const { agents, updateAgentModel, updatingAgentUserId } =
-    useDashboardAgents(directChannels);
+  const { agents } = useDashboardAgents(directChannels);
   const billingSummary = useWorkspaceBillingSummary(workspaceId ?? undefined);
   const billingOverview = useWorkspaceBillingOverview(workspaceId ?? undefined);
   const [prompt, setPrompt] = useState("");
   const [selectedAgentUserId, setSelectedAgentUserId] = useState<string | null>(
-    null,
+    agentId,
   );
   const [isDeepResearch, setIsDeepResearch] = useState(false);
   const [isCreatingResearch, setIsCreatingResearch] = useState(false);
+  // Session-scoped model override: chosen in the dashboard dropdown, applied
+  // only to the next topic session the user creates. Never written back to
+  // the agent's persistent default. Cleared when the user switches agents.
+  const [sessionModelOverride, setSessionModelOverride] =
+    useState<DashboardAgentModel | null>(null);
   const selectedAgent =
     agents.find((agent) => agent.userId === selectedAgentUserId) ??
     pickDefaultAgent(agents);
+  const effectiveModel = sessionModelOverride ?? selectedAgent?.model ?? null;
   const isSubmitting =
     createDirectChannel.isPending ||
     createTopicSession.isPending ||
@@ -436,8 +437,6 @@ export function HomeMainContent() {
     prompt.trim().length > 0 &&
     !isSubmitting &&
     (isDeepResearch || !!selectedAgent);
-  const isUpdatingSelectedAgentModel =
-    !!selectedAgent && updatingAgentUserId === selectedAgent.userId;
   const activeSubscription = billingSummary.data?.subscription ?? null;
   const isSubscribed = !!activeSubscription;
   const currentPlanLabel =
@@ -452,6 +451,11 @@ export function HomeMainContent() {
     totalCredits !== null && totalCredits < LOW_CREDITS_THRESHOLD;
 
   useEffect(() => {
+    if (!agentId) return;
+    setSelectedAgentUserId(agentId);
+  }, [agentId]);
+
+  useEffect(() => {
     setSelectedAgentUserId((current) => {
       if (current && agents.some((agent) => agent.userId === current)) {
         return current;
@@ -460,6 +464,12 @@ export function HomeMainContent() {
       return pickDefaultAgent(agents)?.userId ?? null;
     });
   }, [agents]);
+
+  // Reset session model override when the user switches agents — each agent
+  // should present its own default model until the user picks one again.
+  useEffect(() => {
+    setSessionModelOverride(null);
+  }, [selectedAgentUserId]);
 
   const handleSubmit = async () => {
     const draft = prompt.trim();
@@ -507,10 +517,13 @@ export function HomeMainContent() {
       // Create a fresh topic session for this prompt. The server persists
       // the first user message inside the same saga, so we can navigate
       // straight to the new channel without draft/autoSend URL params.
+      // effectiveModel carries the session-scoped override (if any) or
+      // falls back to the agent's stored default — either way it stays
+      // local to this session and never mutates the agent's config.
       const result = await createTopicSession.mutateAsync({
         botUserId: selectedAgent.userId,
         initialMessage: draft,
-        ...(selectedAgent.model ? { model: selectedAgent.model } : {}),
+        ...(effectiveModel ? { model: effectiveModel } : {}),
       });
 
       setPrompt("");
@@ -539,21 +552,17 @@ export function HomeMainContent() {
     }
   };
 
-  const handleModelChange = async (model: DashboardAgentModel) => {
+  const handleModelChange = (model: DashboardAgentModel) => {
     if (!selectedAgent?.canSwitchModel) return;
 
     if (
-      selectedAgent.model?.provider === model.provider &&
-      selectedAgent.model?.id === model.id
+      effectiveModel?.provider === model.provider &&
+      effectiveModel?.id === model.id
     ) {
       return;
     }
 
-    try {
-      await updateAgentModel(selectedAgent, model);
-    } catch (error: unknown) {
-      alert(getHttpErrorMessage(error) || "Failed to update model");
-    }
+    setSessionModelOverride(model);
   };
 
   return (
@@ -626,8 +635,8 @@ export function HomeMainContent() {
                     {!isDeepResearch && SHOW_COMPOSER_MODEL_CONTROL ? (
                       <DashboardModelControl
                         agent={selectedAgent}
+                        model={effectiveModel}
                         fallbackLabel={t("dashboardModelLabel")}
-                        isUpdating={isUpdatingSelectedAgentModel}
                         onSelectModel={handleModelChange}
                       />
                     ) : null}

--- a/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
@@ -6,7 +6,6 @@ const mockNavigate = vi.hoisted(() => vi.fn());
 const mockUseChannelsByType = vi.hoisted(() => vi.fn());
 const mockUseCreateDirectChannel = vi.hoisted(() => vi.fn());
 const mockUseDashboardAgents = vi.hoisted(() => vi.fn());
-const mockUpdateAgentModel = vi.hoisted(() => vi.fn());
 const mockUseWorkspaceBillingOverview = vi.hoisted(() => vi.fn());
 const mockUseWorkspaceBillingSummary = vi.hoisted(() => vi.fn());
 const mockUseSelectedWorkspaceId = vi.hoisted(() => vi.fn());
@@ -165,8 +164,6 @@ describe("HomeMainContent", () => {
           canSwitchModel: true,
         },
       ],
-      updateAgentModel: mockUpdateAgentModel,
-      updatingAgentUserId: null,
     });
     mockUseUser.mockReturnValue({
       createdAt: "2024-01-01T00:00:00.000Z",
@@ -283,8 +280,6 @@ describe("HomeMainContent", () => {
           canSwitchModel: false,
         },
       ],
-      updateAgentModel: mockUpdateAgentModel,
-      updatingAgentUserId: null,
     });
 
     renderWithProviders(<HomeMainContent />);
@@ -332,8 +327,6 @@ describe("HomeMainContent", () => {
           canSwitchModel: true,
         },
       ],
-      updateAgentModel: mockUpdateAgentModel,
-      updatingAgentUserId: null,
     });
 
     renderWithProviders(<HomeMainContent />);

--- a/apps/client/src/components/sidebar/AgentGroupList.tsx
+++ b/apps/client/src/components/sidebar/AgentGroupList.tsx
@@ -155,10 +155,13 @@ function AgentGroup({
 
   const handleNewTopic = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    // Send the user back to the dashboard composer. The dashboard
-    // remembers the last-selected agent in its own state, so the user
-    // lands with sensible defaults and can type the new prompt.
-    void navigate({ to: "/channels" });
+    // Route back to the dashboard composer with the clicked agent pre-selected
+    // via search param, so the composer header reflects the correct agent
+    // instead of falling back to the dashboard's last-remembered selection.
+    void navigate({
+      to: "/channels",
+      search: { agentId: group.agentUserId },
+    });
   };
 
   return (
@@ -207,8 +210,10 @@ function AgentGroup({
           })}
           className={cn(
             "shrink-0 inline-flex size-5 items-center justify-center rounded",
-            "text-nav-foreground-subtle transition-colors",
+            "text-nav-foreground-subtle transition-opacity",
             "hover:text-nav-foreground-strong hover:bg-nav-hover",
+            "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+            (expanded || headerHighlighted) && "opacity-100",
           )}
         >
           <SquarePen size={12} />

--- a/apps/client/src/hooks/useDashboardAgents.ts
+++ b/apps/client/src/hooks/useDashboardAgents.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "@/services/api";
 import type {
   BaseModelStaffBotInfo,
@@ -167,7 +167,6 @@ export function useDashboardAgents(
 ) {
   const workspaceId = useSelectedWorkspaceId();
   const { data: currentUser } = useCurrentUser();
-  const queryClient = useQueryClient();
 
   const { data: installedApps, isLoading } = useQuery({
     queryKey: ["installed-applications-with-bots", workspaceId],
@@ -181,117 +180,8 @@ export function useDashboardAgents(
     [currentUser?.id, directChannels, installedApps],
   );
 
-  const updateAgentModelMutation = useMutation({
-    mutationFn: async ({
-      agent,
-      model,
-    }: {
-      agent: DashboardAgent;
-      model: DashboardAgentModel;
-    }) => {
-      if (!agent.canSwitchModel || !agent.installedApplicationId) {
-        throw new Error("This agent does not support model switching");
-      }
-
-      if (agent.applicationId === "common-staff") {
-        if (!agent.botId) {
-          throw new Error("Missing common staff bot ID");
-        }
-
-        await api.applications.updateCommonStaff(
-          agent.installedApplicationId,
-          agent.botId,
-          { model },
-        );
-        return;
-      }
-
-      if (agent.applicationId === "personal-staff") {
-        await api.applications.updatePersonalStaff(
-          agent.installedApplicationId,
-          {
-            model,
-          },
-        );
-        return;
-      }
-
-      throw new Error("Unsupported dashboard agent model update");
-    },
-    onMutate: async ({ agent, model }) => {
-      if (!workspaceId || !agent.installedApplicationId) {
-        return { previousApps: undefined };
-      }
-
-      const queryKey = [
-        "installed-applications-with-bots",
-        workspaceId,
-      ] as const;
-      await queryClient.cancelQueries({ queryKey });
-
-      const previousApps =
-        queryClient.getQueryData<InstalledApplicationWithBots[]>(queryKey);
-
-      if (previousApps) {
-        queryClient.setQueryData<InstalledApplicationWithBots[]>(
-          queryKey,
-          previousApps.map((app) => {
-            if (app.id !== agent.installedApplicationId) return app;
-
-            return {
-              ...app,
-              bots: app.bots.map((bot) => {
-                if (bot.userId !== agent.userId || !("model" in bot)) {
-                  return bot;
-                }
-
-                return {
-                  ...bot,
-                  model,
-                };
-              }),
-            };
-          }),
-        );
-      }
-
-      return { previousApps };
-    },
-    onError: (_error, _variables, context) => {
-      if (!workspaceId || !context?.previousApps) return;
-
-      queryClient.setQueryData(
-        ["installed-applications-with-bots", workspaceId],
-        context.previousApps,
-      );
-    },
-    onSettled: (_data, _error, variables) => {
-      if (workspaceId) {
-        void queryClient.invalidateQueries({
-          queryKey: ["installed-applications-with-bots", workspaceId],
-        });
-      }
-
-      if (
-        variables?.agent.applicationId === "personal-staff" &&
-        variables.agent.installedApplicationId
-      ) {
-        void queryClient.invalidateQueries({
-          queryKey: ["personal-staff", variables.agent.installedApplicationId],
-        });
-      }
-    },
-  });
-
   return {
     agents,
     isLoading,
-    updateAgentModel: async (
-      agent: DashboardAgent,
-      model: DashboardAgentModel,
-    ) => updateAgentModelMutation.mutateAsync({ agent, model }),
-    updatingAgentUserId: updateAgentModelMutation.isPending
-      ? (updateAgentModelMutation.variables?.agent.userId ?? null)
-      : null,
   };
 }

--- a/apps/client/src/routes/_authenticated/channels/index.tsx
+++ b/apps/client/src/routes/_authenticated/channels/index.tsx
@@ -1,14 +1,25 @@
 import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
 import { HomeMainContent } from "@/components/layout/contents/HomeMainContent";
 
+type ChannelsIndexSearch = {
+  agentId?: string;
+};
+
 export const Route = createFileRoute("/_authenticated/channels/")({
   component: ChannelsLayout,
+  validateSearch: (search: Record<string, unknown>): ChannelsIndexSearch => ({
+    agentId:
+      typeof search.agentId === "string" && search.agentId.length > 0
+        ? search.agentId
+        : undefined,
+  }),
 });
 
 function ChannelsLayout() {
   // Check if we have a channelId param (child route is active)
   const params = useParams({ strict: false });
   const hasChannelId = "channelId" in params && params.channelId;
+  const { agentId } = Route.useSearch();
 
   // If child route is active, render the Outlet (child content)
   // Otherwise, show the channels overview
@@ -16,5 +27,5 @@ function ChannelsLayout() {
     return <Outlet />;
   }
 
-  return <HomeMainContent />;
+  return <HomeMainContent agentId={agentId ?? null} />;
 }

--- a/apps/client/src/services/ahand-api.test.ts
+++ b/apps/client/src/services/ahand-api.test.ts
@@ -18,24 +18,24 @@ describe("ahandApi", () => {
   it("list() omits query string by default", async () => {
     vi.mocked(http.get).mockResolvedValue({ data: [] } as any);
     await ahandApi.list();
-    expect(http.get).toHaveBeenCalledWith("/ahand/devices");
+    expect(http.get).toHaveBeenCalledWith("/v1/ahand/devices");
   });
 
   it("list() passes includeOffline=false as query string", async () => {
     vi.mocked(http.get).mockResolvedValue({ data: [] } as any);
     await ahandApi.list({ includeOffline: false });
     expect(http.get).toHaveBeenCalledWith(
-      "/ahand/devices?includeOffline=false",
+      "/v1/ahand/devices?includeOffline=false",
     );
   });
 
   it("list() omits query string when includeOffline=true", async () => {
     vi.mocked(http.get).mockResolvedValue({ data: [] } as any);
     await ahandApi.list({ includeOffline: true });
-    expect(http.get).toHaveBeenCalledWith("/ahand/devices");
+    expect(http.get).toHaveBeenCalledWith("/v1/ahand/devices");
   });
 
-  it("register POSTs to /ahand/devices with body", async () => {
+  it("register POSTs to /v1/ahand/devices with body", async () => {
     vi.mocked(http.post).mockResolvedValue({ data: {} } as any);
     await ahandApi.register({
       hubDeviceId: "d",
@@ -44,7 +44,7 @@ describe("ahandApi", () => {
       platform: "macos",
     });
     expect(http.post).toHaveBeenCalledWith(
-      "/ahand/devices",
+      "/v1/ahand/devices",
       expect.objectContaining({ hubDeviceId: "d" }),
     );
   });
@@ -53,7 +53,7 @@ describe("ahandApi", () => {
     vi.mocked(http.post).mockResolvedValue({ data: {} } as any);
     await ahandApi.refreshToken("id with space");
     expect(http.post).toHaveBeenCalledWith(
-      "/ahand/devices/id%20with%20space/token/refresh",
+      "/v1/ahand/devices/id%20with%20space/token/refresh",
     );
   });
 
@@ -61,14 +61,14 @@ describe("ahandApi", () => {
     vi.mocked(http.post).mockResolvedValue({ data: {} } as any);
     await ahandApi.refreshToken("abc123");
     expect(http.post).toHaveBeenCalledWith(
-      "/ahand/devices/abc123/token/refresh",
+      "/v1/ahand/devices/abc123/token/refresh",
     );
   });
 
   it("patch sends body", async () => {
     vi.mocked(http.patch).mockResolvedValue({ data: {} } as any);
     await ahandApi.patch("id1", { nickname: "new" });
-    expect(http.patch).toHaveBeenCalledWith("/ahand/devices/id1", {
+    expect(http.patch).toHaveBeenCalledWith("/v1/ahand/devices/id1", {
       nickname: "new",
     });
   });
@@ -76,7 +76,7 @@ describe("ahandApi", () => {
   it("remove calls DELETE", async () => {
     vi.mocked(http.delete).mockResolvedValue({ data: {} } as any);
     await ahandApi.remove("id1");
-    expect(http.delete).toHaveBeenCalledWith("/ahand/devices/id1");
+    expect(http.delete).toHaveBeenCalledWith("/v1/ahand/devices/id1");
   });
 
   it("remove resolves to undefined", async () => {

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -7,7 +7,8 @@ export type ChannelType =
   | "task"
   | "tracking"
   | "echo"
-  | "routine-session";
+  | "routine-session"
+  | "topic-session";
 export type MessageType =
   | "text"
   | "file"

--- a/apps/server/apps/gateway/src/ahand/ahand.controller.spec.ts
+++ b/apps/server/apps/gateway/src/ahand/ahand.controller.spec.ts
@@ -9,7 +9,9 @@ import { AuthGuard } from '@team9/auth';
 import { AhandController } from './ahand.controller.js';
 import { AhandDevicesService } from './ahand.service.js';
 
-const testUser = { id: 'u1', email: 'u@t.co' } as any;
+// Controller reads the user id via @CurrentUser('sub'), so in direct test
+// calls the first argument IS the user id string — not a user object.
+const testUserId = 'u1';
 
 function makeRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -60,7 +62,7 @@ describe('AhandController', () => {
         new ConflictException('Device already registered'),
       );
       await expect(
-        controller.register(testUser, {
+        controller.register(testUserId, {
           hubDeviceId: 'a'.repeat(64),
           publicKey: 'pk',
           nickname: 'A',
@@ -77,7 +79,7 @@ describe('AhandController', () => {
         hubUrl: 'https://hub',
         jwtExpiresAt: '2026-04-29T10:00:00Z',
       });
-      const res = await controller.register(testUser, {
+      const res = await controller.register(testUserId, {
         hubDeviceId: 'a'.repeat(64),
         publicKey: 'pk',
         nickname: 'MyMac',
@@ -103,7 +105,7 @@ describe('AhandController', () => {
         hubUrl: 'h',
         jwtExpiresAt: 'e',
       });
-      const res = await controller.register(testUser, {
+      const res = await controller.register(testUserId, {
         hubDeviceId: 'a'.repeat(64),
         publicKey: 'pk',
         nickname: 'A',
@@ -118,7 +120,7 @@ describe('AhandController', () => {
   describe('list', () => {
     it('defaults includeOffline=true when param omitted', async () => {
       svc.listActiveDevicesForUser.mockResolvedValue([]);
-      await controller.list(testUser, undefined);
+      await controller.list(testUserId, undefined);
       expect(svc.listActiveDevicesForUser).toHaveBeenCalledWith('u1', {
         includeOffline: true,
       });
@@ -126,7 +128,7 @@ describe('AhandController', () => {
 
     it('passes includeOffline=false when "false" string', async () => {
       svc.listActiveDevicesForUser.mockResolvedValue([]);
-      await controller.list(testUser, 'false');
+      await controller.list(testUserId, 'false');
       expect(svc.listActiveDevicesForUser).toHaveBeenCalledWith('u1', {
         includeOffline: false,
       });
@@ -134,7 +136,7 @@ describe('AhandController', () => {
 
     it('any value other than "false" → includeOffline=true', async () => {
       svc.listActiveDevicesForUser.mockResolvedValue([]);
-      await controller.list(testUser, 'true');
+      await controller.list(testUserId, 'true');
       expect(svc.listActiveDevicesForUser).toHaveBeenCalledWith('u1', {
         includeOffline: true,
       });
@@ -148,7 +150,7 @@ describe('AhandController', () => {
           hostname: 'hA',
         }),
       ]);
-      const dtos = await controller.list(testUser, 'true');
+      const dtos = await controller.list(testUserId, 'true');
       expect(dtos).toHaveLength(1);
       expect(dtos[0]).toMatchObject({
         id: 'uuid-1',
@@ -162,7 +164,7 @@ describe('AhandController', () => {
 
     it('returns empty array when service returns nothing', async () => {
       svc.listActiveDevicesForUser.mockResolvedValue([]);
-      expect(await controller.list(testUser)).toEqual([]);
+      expect(await controller.list(testUserId)).toEqual([]);
     });
   });
 
@@ -173,7 +175,7 @@ describe('AhandController', () => {
 
     it('returns JWT pair', async () => {
       svc.refreshDeviceToken.mockResolvedValue({ token: 't', expiresAt: 'e' });
-      const res = await controller.refreshToken(testUser, uuid);
+      const res = await controller.refreshToken(testUserId, uuid);
       expect(res).toEqual({ deviceJwt: 't', jwtExpiresAt: 'e' });
     });
 
@@ -181,7 +183,7 @@ describe('AhandController', () => {
       svc.refreshDeviceToken.mockRejectedValue(
         new NotFoundException('Device not found'),
       );
-      await expect(controller.refreshToken(testUser, uuid)).rejects.toThrow(
+      await expect(controller.refreshToken(testUserId, uuid)).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -192,7 +194,7 @@ describe('AhandController', () => {
       );
       await expect(
         controller.refreshToken(
-          testUser,
+          testUserId,
           '11111111-1111-1111-1111-111111111111',
         ),
       ).rejects.toThrow(ConflictException);
@@ -206,7 +208,7 @@ describe('AhandController', () => {
 
     it('returns updated DTO with isOnline=null', async () => {
       svc.patchDevice.mockResolvedValue(makeRow({ nickname: 'New' }));
-      const res = await controller.patch(testUser, uuid, { nickname: 'New' });
+      const res = await controller.patch(testUserId, uuid, { nickname: 'New' });
       expect(res.nickname).toBe('New');
       expect(res.isOnline).toBeNull();
     });
@@ -216,7 +218,11 @@ describe('AhandController', () => {
         new NotFoundException('Device not found'),
       );
       await expect(
-        controller.patch(testUser, '11111111-1111-1111-1111-111111111111', {}),
+        controller.patch(
+          testUserId,
+          '11111111-1111-1111-1111-111111111111',
+          {},
+        ),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -225,7 +231,11 @@ describe('AhandController', () => {
         new ConflictException('Device has been revoked'),
       );
       await expect(
-        controller.patch(testUser, '11111111-1111-1111-1111-111111111111', {}),
+        controller.patch(
+          testUserId,
+          '11111111-1111-1111-1111-111111111111',
+          {},
+        ),
       ).rejects.toThrow(ConflictException);
     });
   });
@@ -237,14 +247,16 @@ describe('AhandController', () => {
 
     it('resolves to undefined (204)', async () => {
       svc.revokeDevice.mockResolvedValue(undefined);
-      await expect(controller.delete(testUser, uuid)).resolves.toBeUndefined();
+      await expect(
+        controller.delete(testUserId, uuid),
+      ).resolves.toBeUndefined();
     });
 
     it('propagates ConflictException from service', async () => {
       svc.revokeDevice.mockRejectedValue(
         new ConflictException('already revoked'),
       );
-      await expect(controller.delete(testUser, uuid)).rejects.toThrow(
+      await expect(controller.delete(testUserId, uuid)).rejects.toThrow(
         ConflictException,
       );
     });

--- a/apps/server/apps/gateway/src/ahand/ahand.service.spec.ts
+++ b/apps/server/apps/gateway/src/ahand/ahand.service.spec.ts
@@ -202,7 +202,9 @@ describe('AhandDevicesService', () => {
       });
 
       expect(res.deviceJwt).toBe('jwt.xxx');
-      expect(res.hubUrl).toBe('https://hub.test');
+      // Service rewrites the admin HTTPS base to the WebSocket URL that
+      // Tauri's ahandd::spawn accepts (see hubWebSocketUrl in the service).
+      expect(res.hubUrl).toBe('wss://hub.test/ws');
       expect(res.device.hubDeviceId).toBe('hub-d1');
       expect(hub.registerDevice).toHaveBeenCalledWith({
         deviceId: 'hub-d1',

--- a/apps/server/apps/gateway/src/im/channels/channels.service.ts
+++ b/apps/server/apps/gateway/src/im/channels/channels.service.ts
@@ -1114,8 +1114,18 @@ export class ChannelsService {
       throw new NotFoundException('Channel not found');
     }
 
-    // For direct/echo channels, fetch the other user's information
-    if ((channel.type === 'direct' || channel.type === 'echo') && userId) {
+    // For direct / echo / routine-session / topic-session channels, fetch the
+    // other user's information. All four types represent a one-on-one
+    // conversation: direct is the classic human-or-bot DM, echo shows the
+    // current user's own notes, and routine-session / topic-session are
+    // ephemeral bot conversations with exactly one bot member.
+    if (
+      userId &&
+      (channel.type === 'direct' ||
+        channel.type === 'echo' ||
+        channel.type === 'routine-session' ||
+        channel.type === 'topic-session')
+    ) {
       const otherUser =
         channel.type === 'echo'
           ? await this.getUserSummary(userId)
@@ -1729,7 +1739,7 @@ export class ChannelsService {
    * Resolve the target of a channel-level model switch.
    *
    * A channel is eligible iff:
-   *   - type ∈ ('direct', 'routine-session')
+   *   - type ∈ ('direct', 'routine-session', 'topic-session')
    *   - requester has read access
    *   - contains exactly one managed-hive bot member (managedProvider='hive'
    *     with a resolvable managedMeta.agentId)
@@ -1751,9 +1761,13 @@ export class ChannelsService {
       throw new NotFoundException('Channel not found');
     }
 
-    if (channel.type !== 'direct' && channel.type !== 'routine-session') {
+    if (
+      channel.type !== 'direct' &&
+      channel.type !== 'routine-session' &&
+      channel.type !== 'topic-session'
+    ) {
       throw new ForbiddenException(
-        'Model switching is only available on DM and routine-session channels',
+        'Model switching is only available on DM, routine-session, and topic-session channels',
       );
     }
 

--- a/apps/server/libs/database/migrations/0047_fair_blink.sql
+++ b/apps/server/libs/database/migrations/0047_fair_blink.sql
@@ -1,2 +1,2 @@
-ALTER TYPE "public"."channel_type" ADD VALUE 'topic-session';--> statement-breakpoint
-ALTER TABLE "im_messages" ADD COLUMN "content_ast" jsonb;
+ALTER TYPE "public"."channel_type" ADD VALUE IF NOT EXISTS 'topic-session';--> statement-breakpoint
+ALTER TABLE "im_messages" ADD COLUMN IF NOT EXISTS "content_ast" jsonb;


### PR DESCRIPTION
## Summary
- Extend `ChannelType` with `topic-session` and fold it (alongside `routine-session`) into every existing one-on-one/bot-DM code path — `ChannelView.isBotDm`, `channels.service` other-user resolution, and the channel-level model-switch guard.
- Replace the dashboard composer's persistent agent-model mutation with a local, session-scoped override: the picker now only influences the next topic session created, resets when the user switches agents, and never writes back to the agent config.
- Sidebar "new topic" button now navigates to `/channels?agentId=...` so the dashboard composer pre-selects the clicked agent; the button is hidden until hover/focus/expand.
- Drop the now-unused `updateAgentModel` mutation + `updatingAgentUserId` state from `useDashboardAgents` and update `HomeMainContent` tests to match.

## Test plan
- [ ] Open a topic-session channel from the sidebar → composer, bot-DM UI, and model switcher all behave like a normal bot DM.
- [ ] On the dashboard, switch model in the composer → only the next created topic session uses that model; the agent's persisted model is unchanged; switching agents resets the override.
- [ ] Click a sidebar agent's "new topic" button → lands on `/channels?agentId=...` with that agent pre-selected in the composer header.
- [ ] `pnpm --filter @team9/client test HomeMainContent` passes.
- [ ] `pnpm --filter @team9/server build` (or the relevant typecheck) passes.