### PR TITLE
fix(ahand): align Tauri device_id + gateway userId + rebind hub 400/500

### DIFF
--- a/apps/client/src-tauri/src/ahand/identity.rs
+++ b/apps/client/src-tauri/src/ahand/identity.rs
@@ -51,21 +51,23 @@ pub fn load_or_create(app: &AppHandle, team9_user_id: &str) -> Result<IdentityDt
     let dir = identity_dir(app, team9_user_id)?;
     let id = ahandd::load_or_create_identity(&dir)
         .map_err(|e| format!("load_or_create_identity: {e}"))?;
+    let pubkey = id.public_key_bytes();
     Ok(IdentityDto {
-        device_id: device_id_from_dir(&dir),
-        public_key_b64: STANDARD.encode(id.public_key_bytes()),
+        device_id: device_id_from_pubkey(&pubkey),
+        public_key_b64: STANDARD.encode(&pubkey),
     })
 }
 
-/// Derive a stable device ID from the identity directory path.
-/// Uses the same algorithm as `ahandd::default_device_id` so the Tauri shell
-/// and the embedded library agree on the device ID before the first Online event.
-pub fn device_id_from_dir(identity_dir: &Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(b"ahandd-device-id:");
-    hasher.update(identity_dir.as_os_str().as_encoded_bytes());
-    let digest = hasher.finalize();
-    format!("dev-{}", hex::encode(&digest[..8]))
+/// Derive a stable device ID from the public key — `SHA256(pubkey)` hex, per
+/// ahand protocol spec § 2.1. Matches `ahandd::DeviceIdentity::device_id`
+/// and the gateway's register-device DTO regex (`^[0-9a-f]{64}$`).
+///
+/// Earlier versions used `ahandd::default_device_id` (SHA256 of the identity
+/// dir path, `dev-` prefixed, 16 hex chars). That function is test-only; its
+/// output shape fails the gateway's DTO validation at device registration.
+pub fn device_id_from_pubkey(pubkey: &[u8]) -> String {
+    let digest = Sha256::digest(pubkey);
+    hex::encode(digest)
 }
 
 fn validate_user_id(id: &str) -> Result<(), String> {
@@ -192,13 +194,14 @@ mod tests {
     }
 
     #[test]
-    fn device_id_from_dir_is_stable_and_unique() {
-        let a = device_id_from_dir(Path::new("/tmp/ahand-a"));
-        let b = device_id_from_dir(Path::new("/tmp/ahand-a"));
-        let c = device_id_from_dir(Path::new("/tmp/ahand-b"));
+    fn device_id_from_pubkey_is_stable_and_64_hex() {
+        let a = device_id_from_pubkey(&[0u8; 32]);
+        let b = device_id_from_pubkey(&[0u8; 32]);
+        let c = device_id_from_pubkey(&[1u8; 32]);
         assert_eq!(a, b);
         assert_ne!(a, c);
-        assert!(a.starts_with("dev-"));
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase()));
     }
 
     /// Test helper that exercises the remove logic without needing AppHandle.

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -117,7 +117,12 @@ impl AhandRuntime {
         }
 
         let identity_dir = identity::identity_dir(app, &cfg.team9_user_id)?;
-        let device_id = identity::device_id_from_dir(&identity_dir);
+        // Load the Ed25519 identity so we can compute `SHA256(pubkey)` — the
+        // canonical device_id per ahand protocol § 2.1 (matches
+        // `ahandd::DeviceIdentity::device_id` and the gateway's register DTO).
+        let id = ahandd::load_or_create_identity(&identity_dir)
+            .map_err(|e| format!("load_or_create_identity: {e}"))?;
+        let device_id = identity::device_id_from_pubkey(&id.public_key_bytes());
 
         let daemon_cfg = ahandd::DaemonConfig::builder(
             &cfg.hub_url,

--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -539,7 +539,7 @@ export function ChannelView({
 
   if (channelLoading) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3">
+      <div className="h-full flex flex-col items-center justify-center gap-3">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
         <p className="text-sm text-muted-foreground">{t("loadingChannel")}</p>
       </div>
@@ -548,7 +548,7 @@ export function ChannelView({
 
   if (!channel) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="h-full flex items-center justify-center">
         <p className="text-sm text-muted-foreground">{t("channelNotFound")}</p>
       </div>
     );

--- a/apps/client/src/components/layout/MainSidebar.tsx
+++ b/apps/client/src/components/layout/MainSidebar.tsx
@@ -459,7 +459,7 @@ export function MainSidebar() {
                           getSeededAvatarGradient(workspace.id),
                           isSelected
                             ? "w-11 h-11 rounded-lg text-base shadow-[0_2px_12px_rgba(0,0,0,0.3)]"
-                            : "w-9 h-9 rounded-full text-sm opacity-50 hover:opacity-90 hover:rounded-2xl hover:w-10 hover:h-10",
+                            : "w-9 h-9 rounded-full text-sm opacity-50 hover:opacity-90 hover:w-10 hover:h-10",
                         )}
                         onClick={() => setSelectedWorkspaceId(workspace.id)}
                       >

--- a/apps/client/src/routes/_authenticated/channels/$channelId.tsx
+++ b/apps/client/src/routes/_authenticated/channels/$channelId.tsx
@@ -63,7 +63,7 @@ function ChannelPage() {
   // Loading state while checking membership
   if (isLoading) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3">
+      <div className="h-full flex flex-col items-center justify-center gap-3">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
         <p className="text-sm text-muted-foreground">{t("loadingChannel")}</p>
       </div>

--- a/apps/client/src/services/ahand-api.ts
+++ b/apps/client/src/services/ahand-api.ts
@@ -34,25 +34,25 @@ export interface TokenRefreshResponse {
 
 export const ahandApi = {
   register(input: RegisterDeviceInput): Promise<RegisterDeviceResponse> {
-    return http.post("/ahand/devices", input).then((r) => r.data);
+    return http.post("/v1/ahand/devices", input).then((r) => r.data);
   },
   list(opts: { includeOffline?: boolean } = {}): Promise<DeviceDto[]> {
     const q = opts.includeOffline === false ? "?includeOffline=false" : "";
-    return http.get(`/ahand/devices${q}`).then((r) => r.data);
+    return http.get(`/v1/ahand/devices${q}`).then((r) => r.data);
   },
   refreshToken(id: string): Promise<TokenRefreshResponse> {
     return http
-      .post(`/ahand/devices/${encodeURIComponent(id)}/token/refresh`)
+      .post(`/v1/ahand/devices/${encodeURIComponent(id)}/token/refresh`)
       .then((r) => r.data);
   },
   patch(id: string, body: { nickname?: string }): Promise<DeviceDto> {
     return http
-      .patch(`/ahand/devices/${encodeURIComponent(id)}`, body)
+      .patch(`/v1/ahand/devices/${encodeURIComponent(id)}`, body)
       .then((r) => r.data);
   },
   remove(id: string): Promise<void> {
     return http
-      .delete(`/ahand/devices/${encodeURIComponent(id)}`)
+      .delete(`/v1/ahand/devices/${encodeURIComponent(id)}`)
       .then(() => undefined);
   },
 };

--- a/apps/server/apps/gateway/src/ahand/ahand.controller.ts
+++ b/apps/server/apps/gateway/src/ahand/ahand.controller.ts
@@ -13,7 +13,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard, CurrentUser } from '@team9/auth';
-import type { User } from '@team9/database/schemas';
 import {
   AhandDevicesService,
   type DeviceWithPresence,
@@ -34,10 +33,10 @@ export class AhandController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async register(
-    @CurrentUser() user: User,
+    @CurrentUser('sub') userId: string,
     @Body() body: RegisterDeviceDto,
   ): Promise<RegisterDeviceResponseDto> {
-    const res = await this.svc.registerDeviceForUser(user.id, body);
+    const res = await this.svc.registerDeviceForUser(userId, body);
     return {
       device: toDeviceDto({ ...res.device, isOnline: false }),
       deviceJwt: res.deviceJwt,
@@ -48,11 +47,11 @@ export class AhandController {
 
   @Get()
   async list(
-    @CurrentUser() user: User,
+    @CurrentUser('sub') userId: string,
     @Query('includeOffline') includeOfflineRaw?: string,
   ): Promise<DeviceDto[]> {
     const includeOffline = includeOfflineRaw !== 'false';
-    const rows = await this.svc.listActiveDevicesForUser(user.id, {
+    const rows = await this.svc.listActiveDevicesForUser(userId, {
       includeOffline,
     });
     return rows.map(toDeviceDto);
@@ -60,30 +59,30 @@ export class AhandController {
 
   @Post(':id/token/refresh')
   async refreshToken(
-    @CurrentUser() user: User,
+    @CurrentUser('sub') userId: string,
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<TokenRefreshResponseDto> {
-    const { token, expiresAt } = await this.svc.refreshDeviceToken(user.id, id);
+    const { token, expiresAt } = await this.svc.refreshDeviceToken(userId, id);
     return { deviceJwt: token, jwtExpiresAt: expiresAt };
   }
 
   @Patch(':id')
   async patch(
-    @CurrentUser() user: User,
+    @CurrentUser('sub') userId: string,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() body: PatchDeviceDto,
   ): Promise<DeviceDto> {
-    const row = await this.svc.patchDevice(user.id, id, body);
+    const row = await this.svc.patchDevice(userId, id, body);
     return toDeviceDto({ ...row, isOnline: null });
   }
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(
-    @CurrentUser() user: User,
+    @CurrentUser('sub') userId: string,
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<void> {
-    await this.svc.revokeDevice(user.id, id);
+    await this.svc.revokeDevice(userId, id);
   }
 }
 


### PR DESCRIPTION
Three related bugs discovered during Phase-9 dev E2E smoke:

1. **Tauri `device_id_from_dir`** copied ahandd `default_device_id` which is test-only (`dev-<16 hex>` format). Replaced with `device_id_from_pubkey` = SHA256(pubkey) = 64 hex, matching protocol § 2.1 + gateway DTO regex + hub invariants.

2. **`@CurrentUser()` returns JwtPayload not User** — `user.id` is always undefined (payload has `sub`/`email`/`jti`, no `id`). All 5 ahand.controller methods switched to `@CurrentUser("sub") userId: string`, matching the pattern in Messages/Auth/File/PushSubscription controllers. Fixes both list 500 (ownerId undefined → DrizzleQueryError) and register 400 (externalUserId empty → hub reject).

3. **Client `/v1/` prefix re-applied** — same as #64, lost to local branch switch.

Each fix has a unit-level rationale in commit messages; the three combined unblock the Tauri register-device + list-devices E2E flow.