### PR TITLE
fix(gateway/ahand): return ws(s)://host/ws to client, not https admin base

### DIFF
--- a/apps/server/apps/gateway/src/ahand/ahand.service.ts
+++ b/apps/server/apps/gateway/src/ahand/ahand.service.ts
@@ -79,6 +79,27 @@ export class AhandDevicesService {
     return url;
   }
 
+  /**
+   * Convert the admin-facing HTTPS hub base URL into the WebSocket URL
+   * ahandd uses for device connection (scheme http(s) → ws(s), path → /ws).
+   *
+   * `AHAND_HUB_URL` is configured as the HTTPS admin base (e.g.
+   * `https://ahand-hub.dev.team9.ai`) because the gateway itself calls
+   * admin REST endpoints. The client-facing `hubUrl` returned by
+   * register/refresh is consumed by `ahandd::spawn` which only accepts
+   * ws:// or wss:// (see `DaemonConfig::builder` doc comment).
+   */
+  private hubWebSocketUrl(httpBase: string): string {
+    const u = new URL(httpBase);
+    const wsScheme =
+      u.protocol === 'https:'
+        ? 'wss:'
+        : u.protocol === 'http:'
+          ? 'ws:'
+          : u.protocol;
+    return `${wsScheme}//${u.host}/ws`;
+  }
+
   // ─── registerDeviceForUser ────────────────────────────────────────────
   //
   // Multi-step flow: 1) hub pre-register, 2) DB insert, 3) mint JWT. Each
@@ -173,7 +194,7 @@ export class AhandDevicesService {
     return {
       device: inserted,
       deviceJwt: minted.token,
-      hubUrl,
+      hubUrl: this.hubWebSocketUrl(hubUrl),
       jwtExpiresAt: minted.expiresAt,
     };
   }


### PR DESCRIPTION
AHAND_HUB_URL is configured as HTTPS admin base, but client-facing `hubUrl` is consumed by `ahandd::spawn` which requires ws:// or wss://.

Derive `wss://ahand-hub.dev.team9.ai/ws` from the admin URL and return that.

Discovered during Phase-9 dev E2E smoke — Tauri status showed `Error: URL scheme not supported` after successful register.