### PR TITLE
docs(ahand): pin hub-keying invariant in compensation comment

### DIFF
--- a/apps/server/apps/gateway/src/ahand/ahand.service.ts
+++ b/apps/server/apps/gateway/src/ahand/ahand.service.ts
@@ -174,7 +174,15 @@ export class AhandDevicesService {
         .returning();
       inserted = row;
     } catch (e) {
-      // Map postgres unique constraint violation to ConflictException
+      // Hub-keying invariant: ahand-hub keys devices by `id TEXT PRIMARY KEY`
+      // (no per-user partitioning — see team9ai/aHand devices migration). In a
+      // concurrent-register race the loser's hub.registerDevice() at step 1
+      // already returns HTTP 409, which AhandHubClient re-throws as
+      // ConflictException before reaching this try block, so 23505 is
+      // unreachable in that case. It can still fire on a retry where the
+      // gateway crashed after step 1 (hub OK) but before step 2 (DB OK); the
+      // hub.deleteDevice compensation below is safe because deviceId is
+      // globally unique — it can only target the caller's own hub binding.
       if ((e as { code?: string }).code === '23505') {
         // Compensate hub registration since the device is already in DB
         await this.hub.deleteDevice(input.hubDeviceId).catch((err) => {


### PR DESCRIPTION
## Summary

Closes #78.

Follow-up on the concurrent-register race question raised in #78. I cloned `team9ai/aHand` (SHA `62c2f9cabde1a953ea3f13917998f5cc6efff564`) and confirmed:

- **Schema** — [`crates/ahand-hub-store/migrations/0001_initial.sql`](https://github.com/team9ai/aHand/blob/62c2f9cabde1a953ea3f13917998f5cc6efff564/crates/ahand-hub-store/migrations/0001_initial.sql#L2): `id TEXT PRIMARY KEY`. No `externalUserId` column. The devices table is keyed globally by `deviceId` alone.
- **Handler** — [`crates/ahand-hub/src/http/devices.rs`, `create_device`, lines 60–101](https://github.com/team9ai/aHand/blob/62c2f9cabde1a953ea3f13917998f5cc6efff564/crates/ahand-hub/src/http/devices.rs#L60-L101): calls `devices.insert(NewDevice { id, ... })` which maps a unique violation to `HubError::DeviceAlreadyExists`.
- **Error mapping** — [`crates/ahand-hub/src/http/api_error.rs`, lines 112–116](https://github.com/team9ai/aHand/blob/62c2f9cabde1a953ea3f13917998f5cc6efff564/crates/ahand-hub/src/http/api_error.rs#L112-L116): `DeviceAlreadyExists` → HTTP 409.
- **Gateway client** — `AhandHubClient.registerDevice` maps HTTP 409 → `ConflictException`, thrown before the DB-insert `try` block.

**Race conclusion (Case A — moot):** In the feared race where two users try to register the same `hubDeviceId`, the loser's `hub.registerDevice()` at step 1 already returns HTTP 409. `AhandHubClient` re-throws it as `ConflictException` *before* entering the try block around the DB insert — so the 23505 catch is unreachable. The only legitimate path into that catch is a crash-retry scenario (hub succeeded, DB never got the row), and in that case the bare `hub.deleteDevice(deviceId)` compensation is safe because `deviceId` is the hub's global PK.

## Change

Adds a 9-line comment to the 23505 catch in `ahand.service.ts` documenting this invariant so future readers don't re-investigate the same question.

## Test plan

- [ ] No logic changed; existing unit + e2e tests cover the path
- [ ] Comment wording reviewed for accuracy against hub source

https://claude.ai/code/session_01LWu6p2kzp1f4JTA1Jzyb4D

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWu6p2kzp1f4JTA1Jzyb4D)_