### PR TITLE
ci(contracts): add freshness workflow to diff vendored schemas vs aHand@SHA

### DIFF
--- a/.github/workflows/contracts-freshness.yml
+++ b/.github/workflows/contracts-freshness.yml
@@ -1,0 +1,88 @@
+name: Contracts Freshness
+
+# Verifies that the vendored copies of the ahand wire-format schemas
+# under `contracts/` match the upstream `aHand` repo at the SHA pinned
+# in `contracts/README.md`. Catches three drift modes:
+#
+#   1. Vendored copy edited directly in team9 without bumping the SHA.
+#   2. SHA bumped in README without re-vendoring the files.
+#   3. SHA bumped, files re-vendored, but with stale content (e.g. a
+#      partial cp that missed one schema).
+#
+# Runs on every PR or push that touches `contracts/**` or this
+# workflow itself — fast (a few HTTPS GETs + diff), and noise-free
+# because most PRs don't touch contracts at all.
+
+on:
+  pull_request:
+    paths:
+      - "contracts/**"
+      - ".github/workflows/contracts-freshness.yml"
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "contracts/**"
+      - ".github/workflows/contracts-freshness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diff:
+    name: Diff vs aHand@SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract pinned aHand SHA from contracts/README.md
+        id: pin
+        run: |
+          # The README's "Last sync" line is the source of truth. Format:
+          #   ... `aHand` dev @ `<40-hex-sha>` (PR ...).
+          # If the line moves or its format changes, this regex must
+          # be kept in sync — the README explicitly documents the
+          # contract.
+          sha=$(grep -oE '`aHand` dev @ `[0-9a-f]{40}`' contracts/README.md \
+                | head -n 1 \
+                | grep -oE '[0-9a-f]{40}')
+          if [[ -z "${sha}" ]]; then
+            echo "::error file=contracts/README.md::Could not parse pinned aHand SHA from contracts/README.md. Expected a line containing: \`aHand\` dev @ \`<40-hex-sha>\`"
+            exit 1
+          fi
+          echo "Pinned aHand SHA: ${sha}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch upstream schemas
+        env:
+          SHA: ${{ steps.pin.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .freshness/upstream
+          for f in hub-webhook.json hub-control-plane.json; do
+            url="https://raw.githubusercontent.com/team9ai/aHand/${SHA}/contracts/${f}"
+            echo "Fetching ${url}"
+            if ! curl -fsSL --max-time 30 -o ".freshness/upstream/${f}" "${url}"; then
+              echo "::error file=contracts/README.md::Failed to fetch contracts/${f} from aHand@${SHA}. Either the SHA is wrong, the file moved, or the aHand repo is unreachable. URL: ${url}"
+              exit 1
+            fi
+          done
+
+      - name: Diff vendored vs upstream
+        run: |
+          set -euo pipefail
+          fail=0
+          for f in hub-webhook.json hub-control-plane.json; do
+            if ! diff -u ".freshness/upstream/${f}" "contracts/${f}"; then
+              echo "::error file=contracts/${f}::Vendored \`contracts/${f}\` differs from aHand@${{ steps.pin.outputs.sha }}. Either re-vendor (\`cp ../aHand/contracts/${f} contracts/\`) or bump the SHA in \`contracts/README.md\` to a commit that matches what's vendored here."
+              fail=1
+            fi
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            exit 1
+          fi
+          echo "All vendored contracts match aHand@${{ steps.pin.outputs.sha }}."

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -25,11 +25,15 @@ git submodule would force every clone to also pull `aHand` (a large Rust
 
 ## What pins the freshness
 
-The contract test (`apps/server/apps/gateway/test/ahand-contract.e2e-spec.ts`)
-is the freshness gate. If a hub-side schema change goes out, the test
-fails when the gateway DTO drifts from the schema. The `aHand`-side CI
-is where the schema is owned; team9-side CI just enforces alignment.
+Two gates work together:
+
+1. **Bit-for-bit freshness** — `.github/workflows/contracts-freshness.yml` parses the **Last sync** SHA below, fetches `contracts/hub-webhook.json` + `contracts/hub-control-plane.json` from `aHand` at that SHA, and `diff`s against the vendored copies. Fails the build if either file drifts. This catches: someone editing the vendored copy directly, or someone bumping the SHA without re-vendoring (or vice versa).
+2. **Behavioural freshness** — the gateway contract test (`apps/server/apps/gateway/test/contracts/hub-webhook.contract.e2e-spec.ts`) Ajv-validates canonical payloads against the vendored schema and round-trips a signed payload through the controller. Fails when the gateway DTO drifts from the schema even if the schema itself is in sync with upstream.
+
+The `aHand`-side CI owns the schemas; the team9-side gates enforce that whatever ships in this repo matches the `aHand` SHA recorded below.
 
 ## Last sync
 
-`hub-webhook.json` and `hub-control-plane.json` last synced from `aHand` dev @ `a21d9a44107d30ce6765e13f58a735759bc428ab` (with the Phase 9 / Task 9.5 schemas authored in `feat/ahand-contract-schemas` on top — see that branch for the canonical source).
+`hub-webhook.json` and `hub-control-plane.json` last synced from `aHand` dev @ `4b77c0ba1ed4249312080a5130bc8b20aba26230` (PR [team9ai/aHand#12](https://github.com/team9ai/aHand/pull/12)).
+
+> **When refreshing**: bump the SHA on the line above to the new aHand commit, then re-run the `cp` commands at the top of this file. The freshness workflow parses the SHA from this exact line — keep the format `aHand` dev @ `<40-hex>`.


### PR DESCRIPTION
## Summary

Closes the round-1 review gap from Phase 9 / Task 9.5: team9's `contracts/` README claims "the contract test is the freshness gate" but nothing in CI actually verified the vendored copies match the upstream `aHand` SHA recorded in the README. Was deferred because aHand PR #12 wasn't on dev yet — now [`4b77c0b`](https://github.com/team9ai/aHand/commit/4b77c0b) is on aHand@dev, so wire it up.

## What it does

`.github/workflows/contracts-freshness.yml`:

1. Parses the pinned SHA from `contracts/README.md`'s **Last sync** line. Format: `` `aHand` dev @ `<40-hex>` `` — README documents the contract explicitly.
2. Fetches `hub-webhook.json` + `hub-control-plane.json` from `raw.githubusercontent.com/team9ai/aHand@<SHA>`. aHand is public, no auth needed.
3. `diff -u` against the vendored copies. Any drift fails with an annotated error.

Path-filtered to `contracts/**` + the workflow itself — most PRs skip it; every contract change triggers it. Also runs on push to `dev`/`main`.

## Drift modes caught

1. Vendored copy edited directly without bumping the SHA.
2. SHA bumped without re-vendoring.
3. Both bumped but with stale content (e.g. a partial cp).

Behavioural drift (gateway DTO drifts from schema even when both files are upstream-synced) is still caught by the existing `hub-webhook.contract.e2e-spec.ts` round-trip cases. README updated to document both gates working together.

## Local verification

- [x] `grep -oE` SHA extraction returns `4b77c0ba1ed4249312080a5130bc8b20aba26230` from the updated README.
- [x] Fetch + diff against `aHand@4b77c0b` is in sync (both schemas match bit-for-bit).
- [x] Negative case: appended bytes to `contracts/hub-webhook.json` → `diff` correctly reports drift.
- [x] README "Last sync" bumped from `a21d9a44...` (which never had `contracts/` — the schemas didn't exist yet) to `4b77c0b...` (the post-merge commit on aHand@dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)