### PR TITLE
feat(client): subscription UX polish + topbar back/forward arrows

### DIFF
--- a/apps/client/src/components/layout/GlobalTopBar.tsx
+++ b/apps/client/src/components/layout/GlobalTopBar.tsx
@@ -1,6 +1,19 @@
-import { useRef, useEffect, useCallback, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
-import { Search, X, PanelLeft, PanelRight } from "lucide-react";
+import {
+  useRef,
+  useEffect,
+  useCallback,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { useNavigate, useRouter } from "@tanstack/react-router";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Search,
+  X,
+  PanelLeft,
+  PanelRight,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -25,6 +38,25 @@ import { QuickSearchResults } from "@/components/search/QuickSearchResults";
 export function GlobalTopBar() {
   const { t } = useTranslation("common");
   const navigate = useNavigate();
+  const router = useRouter();
+
+  const subscribeToHistory = useCallback(
+    (callback: () => void) => router.history.subscribe(callback),
+    [router],
+  );
+  const canGoBack = useSyncExternalStore(
+    subscribeToHistory,
+    () => router.history.canGoBack(),
+    () => false,
+  );
+  const canGoForward = useSyncExternalStore(
+    subscribeToHistory,
+    () => {
+      const index = router.history.location.state?.__TSR_index ?? 0;
+      return index < router.history.length - 1;
+    },
+    () => false,
+  );
   useUser();
   const { selectedWorkspaceId } = useWorkspaceStore();
   const { data: workspaces } = useUserWorkspaces();
@@ -182,6 +214,26 @@ export function GlobalTopBar() {
             data-tauri-drag-region
             className="mx-auto flex max-w-2xl items-center justify-center gap-1"
           >
+            <Button
+              variant="ghost"
+              size="icon"
+              className={topBarButtonClassName}
+              aria-label={t("navigateBack")}
+              disabled={!canGoBack}
+              onClick={() => router.history.back()}
+            >
+              <ArrowLeft size={16} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={topBarButtonClassName}
+              aria-label={t("navigateForward")}
+              disabled={!canGoForward}
+              onClick={() => router.history.forward()}
+            >
+              <ArrowRight size={16} />
+            </Button>
             <div className="flex-1">
               <Popover open={isOpen} onOpenChange={setIsOpen}>
                 <PopoverAnchor asChild>

--- a/apps/client/src/components/layout/__tests__/GlobalTopBar.drag-region.test.tsx
+++ b/apps/client/src/components/layout/__tests__/GlobalTopBar.drag-region.test.tsx
@@ -14,6 +14,16 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
+  useRouter: () => ({
+    history: {
+      back: vi.fn(),
+      forward: vi.fn(),
+      subscribe: () => () => {},
+      canGoBack: () => false,
+      length: 1,
+      location: { state: { __TSR_index: 0 } },
+    },
+  }),
 }));
 
 vi.mock("@/stores", () => ({
@@ -60,12 +70,22 @@ vi.mock("@/components/ui/button", () => ({
     children,
     className,
     onClick,
+    disabled,
+    "aria-label": ariaLabel,
   }: {
     children: React.ReactNode;
     className?: string;
     onClick?: () => void;
+    disabled?: boolean;
+    "aria-label"?: string;
   }) => (
-    <button type="button" className={className} onClick={onClick}>
+    <button
+      type="button"
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
       {children}
     </button>
   ),
@@ -107,5 +127,14 @@ describe("GlobalTopBar drag regions", () => {
     expect(screen.getByRole("textbox")).not.toHaveAttribute(
       "data-tauri-drag-region",
     );
+  });
+
+  it("disables back and forward buttons when there is no history to traverse", () => {
+    render(<GlobalTopBar />);
+
+    expect(screen.getByRole("button", { name: "navigateBack" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "navigateForward" }),
+    ).toBeDisabled();
   });
 });

--- a/apps/client/src/components/layout/contents/SubscriptionContent.tsx
+++ b/apps/client/src/components/layout/contents/SubscriptionContent.tsx
@@ -489,6 +489,32 @@ export function SubscriptionContent({
     );
   }
 
+  const subscriptionRequiredDialog = (
+    <AlertDialog
+      open={showSubscriptionRequired}
+      onOpenChange={setShowSubscriptionRequired}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("billing.page.subscriptionRequired.title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("billing.page.subscriptionRequired.description")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>
+            {t("billing.page.subscriptionRequired.cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={() => navigateToView("plans")}>
+            {t("billing.page.subscriptionRequired.viewPlans")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
   if (currentView === "credits") {
     const currentPlanName = subscription?.product.name || "Free";
     const currentPlanCreditsLabel = subscription
@@ -509,10 +535,7 @@ export function SubscriptionContent({
 
             <div className="relative mx-auto flex w-full max-w-[960px] flex-col gap-5 px-4 pb-6 pt-7 sm:px-5 sm:pt-8 lg:px-6">
               <div className="min-w-0">
-                <div className="text-sm font-medium uppercase tracking-[0.22em] text-[#7e91b2]">
-                  {account?.ownerName || currentWorkspace.name}
-                </div>
-                <h1 className="mt-3 text-3xl font-semibold tracking-[-0.05em] text-[#111b35] sm:text-4xl">
+                <h1 className="text-3xl font-semibold tracking-[-0.05em] text-[#111b35] sm:text-4xl">
                   Workspace Credits
                 </h1>
               </div>
@@ -555,6 +578,24 @@ export function SubscriptionContent({
                         </span>
                       ) : null}
                     </div>
+
+                    {!subscription ? (
+                      <div
+                        role="status"
+                        className="flex flex-col gap-2 rounded-xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <span>
+                          {t("billing.page.subscriptionRequired.inlineHint")}
+                        </span>
+                        <Button
+                          variant="link"
+                          className="h-auto self-start p-0 text-sm font-semibold text-amber-900 underline-offset-2 hover:underline sm:self-auto"
+                          onClick={() => navigateToView("plans")}
+                        >
+                          {t("billing.page.subscriptionRequired.viewPlans")}
+                        </Button>
+                      </div>
+                    ) : null}
 
                     {customAmountConfig ? (
                       <div>
@@ -807,6 +848,8 @@ export function SubscriptionContent({
             </div>
           </div>
         </ScrollArea>
+
+        {subscriptionRequiredDialog}
       </main>
     );
   }
@@ -828,12 +871,7 @@ export function SubscriptionContent({
 
             <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
               <div className="max-w-3xl">
-                <div className="text-sm font-medium uppercase tracking-[0.22em] text-[#7e91b2]">
-                  {t("billing.page.workspaceBilling", {
-                    workspace: currentWorkspace.name,
-                  })}
-                </div>
-                <h1 className="mt-3 text-3xl font-semibold tracking-[-0.05em] text-[#111b35] sm:text-4xl">
+                <h1 className="text-3xl font-semibold tracking-[-0.05em] text-[#111b35] sm:text-4xl">
                   {t("billing.page.heading")}
                 </h1>
                 <p className="mt-2 max-w-2xl text-sm text-[#6a7d9e] sm:text-base">
@@ -996,29 +1034,7 @@ export function SubscriptionContent({
         </div>
       </ScrollArea>
 
-      <AlertDialog
-        open={showSubscriptionRequired}
-        onOpenChange={setShowSubscriptionRequired}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("billing.page.subscriptionRequired.title")}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("billing.page.subscriptionRequired.description")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {t("billing.page.subscriptionRequired.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={() => navigateToView("plans")}>
-              {t("billing.page.subscriptionRequired.viewPlans")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {subscriptionRequiredDialog}
     </main>
   );
 }

--- a/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/SubscriptionContent.test.tsx
@@ -574,6 +574,84 @@ describe("SubscriptionContent", () => {
     expect(mockCheckoutMutateAsync).not.toHaveBeenCalled();
   });
 
+  it("guides unsubscribed users to plans when clicking custom amount Add Credits", async () => {
+    mockUseWorkspaceBillingOverview.mockReturnValue({
+      data: {
+        account: {
+          id: "acct_1",
+          ownerExternalId: "tenant:ws-1",
+          ownerType: "organization",
+          ownerName: "Alpha",
+          balance: 0,
+          grantBalance: 0,
+          quota: 0,
+          quotaExpiresAt: null,
+          effectiveQuota: 0,
+          available: 0,
+          creditLimit: 0,
+          status: "active",
+          metadata: null,
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+        subscription: null,
+        subscriptionProducts: [],
+        creditProducts: [
+          {
+            stripePriceId: "price_open_topup",
+            name: "Open Top-up",
+            type: "one_time",
+            credits: 10000,
+            amountCents: 1000,
+            interval: null,
+            intervalCount: null,
+            active: true,
+            metadata: null,
+            customAmount: {
+              enabled: true,
+              minimumCents: 500,
+              maximumCents: 50000,
+              presetCents: 2500,
+            },
+            display: {
+              description: "Choose any amount.",
+              features: [],
+              sortOrder: 1,
+            },
+          },
+        ],
+        recentTransactions: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SubscriptionContent view="credits" />);
+
+    expect(
+      await screen.findByText(
+        /an active subscription is required before buying credits/i,
+      ),
+    ).toBeInTheDocument();
+
+    // Inline banner's "View Plans" link navigates to the plans view.
+    fireEvent.click(screen.getByRole("button", { name: /^view plans$/i }));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/subscription" }),
+    );
+
+    mockNavigate.mockClear();
+
+    // Clicking custom-amount Add Credits opens the subscription-required dialog
+    // instead of silently doing nothing.
+    fireEvent.click(screen.getByRole("button", { name: /^add credits$/i }));
+
+    expect(
+      await screen.findByText(/subscription required/i),
+    ).toBeInTheDocument();
+    expect(mockCheckoutMutateAsync).not.toHaveBeenCalled();
+  });
+
   it("falls back to fixed packs when custom amount is unavailable", async () => {
     mockUseWorkspaceBillingOverview.mockReturnValue({
       data: {

--- a/apps/client/src/i18n/locales/en/common.json
+++ b/apps/client/src/i18n/locales/en/common.json
@@ -21,6 +21,8 @@
   "noData": "No data",
   "retry": "Retry",
   "back": "Back",
+  "navigateBack": "Go back",
+  "navigateForward": "Go forward",
   "next": "Next",
   "previous": "Previous",
   "close": "Close",

--- a/apps/client/src/i18n/locales/en/workspace.json
+++ b/apps/client/src/i18n/locales/en/workspace.json
@@ -109,7 +109,6 @@
       }
     },
     "page": {
-      "workspaceBilling": "{{workspace}} workspace billing",
       "heading": "Choose your plan",
       "subheading": "Select the plan that fits your workload.",
       "exchangeRate": "1 USD = 1,000 credits across all plans.",
@@ -127,6 +126,7 @@
       "subscriptionRequired": {
         "title": "Subscription Required",
         "description": "You need an active subscription before purchasing credits. Please subscribe to a plan first.",
+        "inlineHint": "An active subscription is required before buying credits.",
         "cancel": "Cancel",
         "viewPlans": "View Plans"
       }

--- a/apps/client/src/i18n/locales/zh-CN/common.json
+++ b/apps/client/src/i18n/locales/zh-CN/common.json
@@ -21,6 +21,8 @@
   "noData": "暂无数据",
   "retry": "重试",
   "back": "返回",
+  "navigateBack": "后退",
+  "navigateForward": "前进",
   "next": "下一步",
   "previous": "上一步",
   "close": "关闭",

--- a/apps/client/src/i18n/locales/zh-CN/workspace.json
+++ b/apps/client/src/i18n/locales/zh-CN/workspace.json
@@ -109,7 +109,6 @@
       }
     },
     "page": {
-      "workspaceBilling": "{{workspace}} 工作空间计费",
       "heading": "选择你的方案",
       "subheading": "选择最适合你当前工作负载的套餐。",
       "exchangeRate": "所有套餐均为 1 美元 = 1,000 点数。",
@@ -127,6 +126,7 @@
       "subscriptionRequired": {
         "title": "需要订阅",
         "description": "购买点数前需要先开通一个有效订阅，请先选择并订阅套餐。",
+        "inlineHint": "购买点数前需要先开通订阅。",
         "cancel": "取消",
         "viewPlans": "查看方案"
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,6 +1183,73 @@ importers:
         specifier: ^5.7.3
         version: 5.8.3
 
+  enterprise/libs/analytics:
+    dependencies:
+      "@nestjs/common":
+        specifier: ^11.0.0
+        version: 11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      "@nestjs/core":
+        specifier: ^11.0.0
+        version: 11.1.10(@nestjs/common@11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.11)(@nestjs/platform-express@11.1.10)(@nestjs/websockets@11.1.10)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+    devDependencies:
+      "@types/node":
+        specifier: ^22.0.0
+        version: 22.19.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+
+  enterprise/libs/audit:
+    dependencies:
+      "@nestjs/common":
+        specifier: ^11.0.0
+        version: 11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      "@nestjs/core":
+        specifier: ^11.0.0
+        version: 11.1.10(@nestjs/common@11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.11)(@nestjs/platform-express@11.1.10)(@nestjs/websockets@11.1.10)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      uuid:
+        specifier: ^11.0.0
+        version: 11.1.0
+    devDependencies:
+      "@types/node":
+        specifier: ^22.0.0
+        version: 22.19.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+
+  enterprise/libs/license:
+    dependencies:
+      "@nestjs/common":
+        specifier: ^11.0.0
+        version: 11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      "@nestjs/core":
+        specifier: ^11.0.0
+        version: 11.1.10(@nestjs/common@11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.11)(@nestjs/platform-express@11.1.10)(@nestjs/websockets@11.1.10)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+    devDependencies:
+      "@types/node":
+        specifier: ^22.0.0
+        version: 22.19.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+
+  enterprise/libs/sso:
+    dependencies:
+      "@nestjs/common":
+        specifier: ^11.0.0
+        version: 11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      "@nestjs/core":
+        specifier: ^11.0.0
+        version: 11.1.10(@nestjs/common@11.1.10(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.11)(@nestjs/platform-express@11.1.10)(@nestjs/websockets@11.1.10)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+    devDependencies:
+      "@types/node":
+        specifier: ^22.0.0
+        version: 22.19.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+
 packages:
   "@adobe/css-tools@4.4.4":
     resolution:
@@ -16844,6 +16911,13 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
+  uuid@11.1.0:
+    resolution:
+      {
+        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
+      }
+    hasBin: true
+
   uuid@13.0.0:
     resolution:
       {
@@ -28761,6 +28835,8 @@ snapshots:
   utility-types@3.11.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@13.0.0: {}
 


### PR DESCRIPTION
## Summary

- **Subscription page (Workspace Credits / Choose your plan)**
  - Fix dead-click bug where the "Subscription Required" `AlertDialog` was only rendered in the plans view, so unsubscribed users clicking *Add Credits* / fixed packs in the credits view saw no feedback at all.
  - Add an inline amber hint above *Buy Credits* when no active subscription, with a *View Plans* shortcut so the requirement is visible **before** clicking — the dialog now degrades to a backstop.
  - Drop the redundant uppercase workspace-name eyebrow above page headings (e.g. the "TEST" label some workspaces produced) — the workspace name is already visible elsewhere.

- **GlobalTopBar**
  - Add browser-style back/forward arrows immediately to the left of the search box, matching the existing icon-button vocabulary (`h-7 w-7` ghost, same as the panel toggle).
  - Subscribe to `router.history` via `useSyncExternalStore` so the buttons re-render on every navigation; derive `canGoBack` from TanStack's API and `canGoForward` from `__TSR_index < length - 1`, then pass `disabled` so arrows visually grey out when there is nothing to traverse in that direction.

- **i18n**: add `common.navigateBack` / `navigateForward` (en + zh-CN), drop the orphaned `billing.page.workspaceBilling`, add `billing.page.subscriptionRequired.inlineHint`.

- **Tests**: regression for the subscription-required guidance flow in the credits view; topbar test asserting both arrows start disabled when there is no history. Mocks updated to forward `disabled` / `aria-label` and to expose `router.history.subscribe` + `canGoBack` + `length` + `__TSR_index`.

> Note: `pnpm-lock.yaml` diff is quote-style reformatting from a different pnpm runtime — no actual dependency version changed.

## Test plan

- [x] `pnpm typecheck` (client) — clean
- [x] `pnpm test` for `src/components/layout` — 108 / 108 pass, including new regression tests
- [ ] Manually verify in the desktop app: arrows greyed on first load, lighten after first navigation, subscription page shows the amber hint when a workspace has no plan, and the "Subscription Required" dialog opens when clicking Add Credits without a plan.