### PR TITLE
fix(gateway/im): extract text from Lexical code-highlight + tab nodes

### DIFF
--- a/apps/server/apps/gateway/src/im/messages/utils/ast.spec.ts
+++ b/apps/server/apps/gateway/src/im/messages/utils/ast.spec.ts
@@ -163,6 +163,67 @@ describe('astToPlaintext', () => {
     expect(astToPlaintext(ast)).toBe('<script>alert(1)</script>');
   });
 
+  it('extracts text from Lexical code blocks (code-highlight leaves)', () => {
+    // Lexical wraps code blocks as `code` elements whose children are
+    // `code-highlight` nodes (TextNode subclasses) — they carry `text` but
+    // have no `children`. Without explicit handling the whole block is
+    // invisible to astToPlaintext, producing an empty `content` that
+    // downstream gRPC validation (im-worker) rejects with INVALID_ARGUMENT
+    // → HTTP 500. See: Lexical CodeHighlightNode / code-highlight plugin.
+    const ast = {
+      root: {
+        type: 'root',
+        children: [
+          {
+            type: 'code',
+            language: 'javascript',
+            children: [
+              {
+                type: 'code-highlight',
+                text: 'const ',
+                highlightType: 'keyword',
+              },
+              {
+                type: 'code-highlight',
+                text: 'x',
+              },
+              { type: 'linebreak' },
+              {
+                type: 'code-highlight',
+                text: '  return x;',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    // `code` is a block-level type so the whole block is followed by a
+    // trailing newline, which `trim()` strips. Inside the block, text flows
+    // line-by-line with the explicit linebreak preserved.
+    expect(astToPlaintext(ast)).toBe('const x\n  return x;');
+  });
+
+  it('extracts text from Lexical tab nodes (TextNode subclass without children)', () => {
+    // `tab` is another TextNode subclass (TabNode) with a `text` field and
+    // no children. Same failure mode as code-highlight if not handled.
+    const ast = {
+      root: {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'text', text: 'before' },
+              { type: 'tab', text: '\t' },
+              { type: 'text', text: 'after' },
+            ],
+          },
+        ],
+      },
+    };
+    expect(astToPlaintext(ast)).toBe('before\tafter');
+  });
+
   it('stops recursing at MAX_AST_DEPTH without crashing', () => {
     // Build a pathologically deep tree that would blow a naive recursive walk.
     // Even though normalizeAst would reject this at ingress, astToPlaintext

--- a/apps/server/apps/gateway/src/im/messages/utils/ast.ts
+++ b/apps/server/apps/gateway/src/im/messages/utils/ast.ts
@@ -135,7 +135,10 @@ export function astToPlaintext(input: unknown): string {
 function walk(node: AstBaseNode, out: string[], depth: number): void {
   if (depth > MAX_AST_DEPTH) return;
   const type = node.type;
-  if (type === 'text') {
+  // Lexical's `code-highlight` (CodeHighlightNode) and `tab` (TabNode) are
+  // TextNode subclasses with a `text` field and no children. Treat them
+  // like plain text so code blocks and tabs survive plaintext extraction.
+  if (type === 'text' || type === 'code-highlight' || type === 'tab') {
     const t = (node as AstTextNode).text;
     if (typeof t === 'string') out.push(t);
     return;


### PR DESCRIPTION
## Summary

`astToPlaintext.walk()` dropped `code-highlight` and `tab` nodes, producing empty `content` when clients sent a Lexical `code` block or tab character in the composer. im-worker's gRPC `CreateMessage` then rejected the empty-content text message with `INVALID_ARGUMENT`, surfacing as HTTP 500 on `POST /api/v1/im/channels/:id/messages`.

Fix: treat `code-highlight` (CodeHighlightNode) and `tab` (TabNode) as text-like leaves — both are Lexical `TextNode` subclasses with a `text` field and no children.

## Root cause

1. Client posts `contentAst` with outer `type: "code"` and inner `type: "code-highlight"` children.
2. Gateway `walk()` only branched on `text`/`mention`/`linebreak`; non-matching types fell through to the "recurse children" branch.
3. `code-highlight` has no children → walk skips silently → `plainlen=0`.
4. `determineMessageType("")` → `'text'`.
5. im-worker's gRPC createMessage: `!request.content && type === 'text'` → `RpcException INVALID_ARGUMENT` → HTTP 500.

Reproduced locally with the exact failing payload; after the fix `plainlen=37` with correct content.

## Test plan

- [x] New regression tests: code block + tab node cases
- [x] Full `im/messages` test suite passes (170 tests)
- [x] Local repro with the captured failing payload now yields non-empty plaintext
- [ ] Post-deploy: reproduce the original failing Tauri request and confirm it succeeds
