### PR TITLE
feat(folder9): workspace folder mounts (table + folder-map endpoint + token authz expansion)

### DIFF
--- a/apps/server/apps/gateway/src/folder9/bot-agent-ownership.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/bot-agent-ownership.service.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+const dbModule = {
+  DATABASE_CONNECTION: Symbol('DATABASE_CONNECTION'),
+  eq: jest.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  and: jest.fn((...clauses: unknown[]) => ({ op: 'and', clauses })),
+};
+
+const schemaModule = {
+  bots: {
+    userId: 'bots.user_id',
+    isActive: 'bots.is_active',
+    managedMeta: 'bots.managed_meta',
+  },
+};
+
+jest.unstable_mockModule('@team9/database', () => dbModule);
+jest.unstable_mockModule('@team9/database/schemas', () => schemaModule);
+
+const { BotAgentOwnership } = await import('./bot-agent-ownership.service.js');
+
+import { ForbiddenException } from '@nestjs/common';
+
+// ── Drizzle-chain test double ────────────────────────────────────────────────
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+function createQuery(resolve: () => unknown) {
+  const query: Record<string, MockFn> & {
+    then: (
+      onfulfilled: (value: unknown) => unknown,
+      onrejected?: (reason: unknown) => unknown,
+    ) => Promise<unknown>;
+  } = {
+    from: jest.fn<any>(),
+    where: jest.fn<any>(),
+    limit: jest.fn<any>(),
+    then(onfulfilled, onrejected) {
+      return Promise.resolve(resolve()).then(onfulfilled, onrejected);
+    },
+  };
+  for (const key of ['from', 'where', 'limit'] as const) {
+    query[key].mockReturnValue(query as never);
+  }
+  return query;
+}
+
+function mockDb() {
+  const state = {
+    selectResults: [] as unknown[][],
+  };
+  const db = {
+    __state: state,
+    select: jest.fn(() => {
+      const q = createQuery(() =>
+        state.selectResults.length > 0 ? state.selectResults.shift() : [],
+      );
+      return q as never;
+    }),
+  };
+  return db;
+}
+
+// ── Fixtures + harness ──────────────────────────────────────────────────────
+
+const BOT_USER_ID = 'bot-user-1';
+const AGENT_ID = 'agent-1';
+
+describe('BotAgentOwnership', () => {
+  let service: InstanceType<typeof BotAgentOwnership>;
+  let db: ReturnType<typeof mockDb>;
+
+  beforeEach(() => {
+    db = mockDb();
+    service = new BotAgentOwnership(db as never);
+  });
+
+  describe('assertAgentBelongsToBot', () => {
+    it('resolves when active bot has matching managedMeta.agentId', async () => {
+      db.__state.selectResults.push([
+        { userId: BOT_USER_ID, managedMeta: { agentId: AGENT_ID } },
+      ]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws ForbiddenException when no bot row exists', async () => {
+      db.__state.selectResults.push([]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when managedMeta is null', async () => {
+      db.__state.selectResults.push([
+        { userId: BOT_USER_ID, managedMeta: null },
+      ]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when managedMeta has no agentId', async () => {
+      db.__state.selectResults.push([{ userId: BOT_USER_ID, managedMeta: {} }]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when managedMeta.agentId is non-string', async () => {
+      db.__state.selectResults.push([
+        { userId: BOT_USER_ID, managedMeta: { agentId: 12345 } },
+      ]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when managedMeta.agentId mismatches', async () => {
+      db.__state.selectResults.push([
+        {
+          userId: BOT_USER_ID,
+          managedMeta: { agentId: 'different-agent' },
+        },
+      ]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('uses the same generic message for all mismatch flavors', async () => {
+      db.__state.selectResults.push([]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toMatchObject({
+        message: 'agentId does not belong to caller bot',
+      });
+
+      db.__state.selectResults.push([
+        { userId: BOT_USER_ID, managedMeta: { agentId: 'other' } },
+      ]);
+      await expect(
+        service.assertAgentBelongsToBot(BOT_USER_ID, AGENT_ID),
+      ).rejects.toMatchObject({
+        message: 'agentId does not belong to caller bot',
+      });
+    });
+  });
+});

--- a/apps/server/apps/gateway/src/folder9/bot-agent-ownership.service.ts
+++ b/apps/server/apps/gateway/src/folder9/bot-agent-ownership.service.ts
@@ -1,0 +1,91 @@
+import { ForbiddenException, Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  DATABASE_CONNECTION,
+  and,
+  eq,
+  type PostgresJsDatabase,
+} from '@team9/database';
+import * as schema from '@team9/database/schemas';
+
+/**
+ * Verifies that a bot (identified by its shadow-user `userId`) manages a
+ * specific claw-hive `agentId`.
+ *
+ * Used by the workspace-mount integration endpoints
+ * (`POST /api/v1/bot/folder-map` and the `agent.*` / `session.*` paths
+ * in `POST /api/v1/bot/folder-token`) to reject calls where the bot
+ * tries to operate on an agent it doesn't actually own.
+ *
+ * ## Linking model
+ *
+ * For managed AI Staff bots (`hive`, `openclaw` providers), the link is
+ * `bots.managedMeta.agentId` — set at staff-creation time
+ * (`StaffService.createBotWithAgent` / openclaw bootstrap) and read back
+ * in {@link routines.service.ts} and {@link personal-staff.service.ts}.
+ * The `ManagedMeta` interface in {@link bots.ts} types this field as
+ * an optional string.
+ *
+ * ## Rejected cases
+ *
+ * - Bot row not found OR `is_active=false` → `ForbiddenException`
+ * - Bot row found but `managedMeta.agentId` missing/null/non-string →
+ *   `ForbiddenException` (we cannot bind the bot to any agent)
+ * - Bot row found but `managedMeta.agentId !== requested agentId` →
+ *   `ForbiddenException`
+ *
+ * The exception messages avoid leaking which of the above conditions
+ * tripped — every mismatch surfaces as the same generic 403 to keep
+ * the bot↔agent topology unobservable to a caller wielding only its
+ * own bot token.
+ */
+@Injectable()
+export class BotAgentOwnership {
+  private readonly logger = new Logger(BotAgentOwnership.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Throws `ForbiddenException` unless `botUserId` resolves to an active
+   * bot whose `managedMeta.agentId` exactly equals `agentId`.
+   */
+  async assertAgentBelongsToBot(
+    botUserId: string,
+    agentId: string,
+  ): Promise<void> {
+    const rows = await this.db
+      .select({
+        userId: schema.bots.userId,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.bots)
+      .where(
+        and(eq(schema.bots.userId, botUserId), eq(schema.bots.isActive, true)),
+      )
+      .limit(1);
+
+    const bot = rows[0];
+    if (!bot) {
+      this.logger.warn(
+        `assertAgentBelongsToBot: no active bot for userId=${botUserId}`,
+      );
+      throw new ForbiddenException('agentId does not belong to caller bot');
+    }
+
+    const managedAgentId =
+      bot.managedMeta &&
+      typeof bot.managedMeta === 'object' &&
+      typeof (bot.managedMeta as { agentId?: unknown }).agentId === 'string'
+        ? (bot.managedMeta as { agentId: string }).agentId
+        : null;
+
+    if (!managedAgentId || managedAgentId !== agentId) {
+      this.logger.warn(
+        `assertAgentBelongsToBot: mismatch botUserId=${botUserId} requestedAgentId=${agentId} managedAgentId=${managedAgentId ?? '<none>'}`,
+      );
+      throw new ForbiddenException('agentId does not belong to caller bot');
+    }
+  }
+}

--- a/apps/server/apps/gateway/src/folder9/dto/folder-map-request.dto.ts
+++ b/apps/server/apps/gateway/src/folder9/dto/folder-map-request.dto.ts
@@ -1,0 +1,36 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Request body for `POST /api/v1/bot/folder-map`.
+ *
+ * Server-side mirror of `Team9FolderMapRequest` in
+ * `team9-agent-pi/packages/claw-hive-types/src/team9-folder-map.ts`.
+ * team9 deliberately does NOT depend on `@team9claw/claw-hive-types`
+ * (independent release cycles), so this DTO is a local redeclaration
+ * that MUST be updated in lockstep when the canonical agent-pi type
+ * changes.
+ *
+ * The shape lets `JustBashTeam9WorkspaceComponent` (agent-pi side)
+ * obtain a per-session folderMap at `onSessionStart`. The server
+ * lazy-provisions any missing Folder9 folders (session.* / agent.* /
+ * user.* / routine.{tmp,home}) via `FolderMapBuilder`.
+ */
+export class FolderMapRequestDto {
+  @IsString()
+  @MaxLength(512)
+  sessionId!: string;
+
+  @IsString()
+  @MaxLength(128)
+  agentId!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  routineId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  userId?: string;
+}

--- a/apps/server/apps/gateway/src/folder9/folder-map-builder.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-map-builder.service.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { BadRequestException } from '@nestjs/common';
+
+// `FolderMapBuilder` only depends on `FolderMountResolver` (and the
+// pure `parseSessionShape` helper). The resolver is a class instance
+// in production, but here we wire a minimal jest.fn-backed double so
+// every test can drive return values + assert call payloads without
+// touching Drizzle/Folder9 fakes.
+
+import { FolderMapBuilder } from './folder-map-builder.service.js';
+import type { FolderMountResolver } from './folder-mount-resolver.service.js';
+
+type ProvisionFn = FolderMountResolver['provisionFolderForMount'];
+
+function buildHarness() {
+  const provisionFolderForMount = jest.fn<ProvisionFn>();
+  // Default: every call resolves to a deterministic id derived from
+  // the args, so tests that don't override can still assert on
+  // result shape. Individual tests override per-case via
+  // `mockResolvedValueOnce` / `mockImplementation`.
+  provisionFolderForMount.mockImplementation(async (args) => {
+    return {
+      folder9FolderId: `folder-${args.scope}-${args.scopeId}-${args.mountKey}`,
+    };
+  });
+  const resolver = {
+    provisionFolderForMount,
+  } as unknown as FolderMountResolver;
+  const builder = new FolderMapBuilder(resolver);
+  return { builder, provisionFolderForMount };
+}
+
+const DM_SESSION = 'team9/ten-1/agent-x/dm/C_dm';
+const CHANNEL_SESSION = 'team9/ten-1/agent-x/channel/C_pub';
+const ROUTINE_SESSION = 'team9/ten-1/agent-x/routine/r-7';
+const TOPIC_SESSION = 'team9/ten-1/agent-x/topic/t-42';
+
+describe('FolderMapBuilder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('emits session.* + agent.* + user.* for a DM session with userId', async () => {
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: DM_SESSION,
+      agentId: 'agent-x',
+      userId: 'user-7',
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'session.home',
+      'session.tmp',
+      'user.home',
+      'user.tmp',
+    ]);
+
+    // Every entry uses tenantId from the parsed sessionId as workspaceId,
+    // is a `light` folder, and carries write permission per the v1 spec.
+    for (const entry of Object.values(folderMap)) {
+      expect(entry).toMatchObject({
+        workspaceId: 'ten-1',
+        folderType: 'light',
+        permission: 'write',
+      });
+      expect(entry.folderId).toMatch(/^folder-/);
+    }
+
+    // session.* uses the full sessionId as scopeId (NOT just the channelId).
+    expect(provisionFolderForMount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'session',
+        scopeId: DM_SESSION,
+        mountKey: 'home',
+        ownerType: 'workspace',
+        ownerId: 'ten-1',
+      }),
+    );
+
+    // user.* scopeId is the userId, with workspace ownership (DM
+    // peer's folder lives at workspace tenancy in v1).
+    expect(provisionFolderForMount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'user',
+        scopeId: 'user-7',
+        mountKey: 'tmp',
+        ownerType: 'workspace',
+        ownerId: 'ten-1',
+      }),
+    );
+  });
+
+  it('omits user.* when DM session has no userId', async () => {
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: DM_SESSION,
+      agentId: 'agent-x',
+      // userId intentionally omitted
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'session.home',
+      'session.tmp',
+    ]);
+
+    // No user-scope provisioning calls were made.
+    const userCalls = provisionFolderForMount.mock.calls.filter(
+      ([args]) => args.scope === 'user',
+    );
+    expect(userCalls).toHaveLength(0);
+  });
+
+  it('emits session.* + agent.* only for a channel session (no user.*, no routine.*)', async () => {
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: CHANNEL_SESSION,
+      agentId: 'agent-x',
+      // Channel sessions never get user.* even if userId is present —
+      // userId is meaningful only for DM. We pass it here to verify
+      // it's ignored.
+      userId: 'user-7',
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'session.home',
+      'session.tmp',
+    ]);
+
+    // No user.* or routine.* provisioning happened.
+    const nonBaseCalls = provisionFolderForMount.mock.calls.filter(
+      ([args]) => args.scope === 'user' || args.scope === 'routine',
+    );
+    expect(nonBaseCalls).toHaveLength(0);
+  });
+
+  it('emits routine.{tmp,home} for a routine session with routineId — and never routine.document', async () => {
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: ROUTINE_SESSION,
+      agentId: 'agent-x',
+      routineId: 'r-7',
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'routine.home',
+      'routine.tmp',
+      'session.home',
+      'session.tmp',
+    ]);
+
+    // routine.document is owned by the routine creation flow and must
+    // NOT appear in the folder-map response.
+    expect(folderMap).not.toHaveProperty('routine.document');
+
+    // Verify routine.* provisioning args: scope=routine, ownerType=agent,
+    // ownerId=agentId.
+    const routineCalls = provisionFolderForMount.mock.calls.filter(
+      ([args]) => args.scope === 'routine',
+    );
+    expect(routineCalls).toHaveLength(2);
+    expect(
+      routineCalls.every(
+        ([args]) =>
+          args.scopeId === 'r-7' &&
+          args.ownerType === 'agent' &&
+          args.ownerId === 'agent-x' &&
+          args.folderType === 'light',
+      ),
+    ).toBe(true);
+
+    // Mount keys for routine.* are exactly tmp + home (no document).
+    const routineMountKeys = routineCalls.map(([args]) => args.mountKey).sort();
+    expect(routineMountKeys).toEqual(['home', 'tmp']);
+  });
+
+  it('omits routine.* on a routine session when routineId is not provided', async () => {
+    // Even if the sessionId says `routine`, without an explicit
+    // routineId in the build context we can't materialise routine.*.
+    // The session+agent baseline still emits.
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: ROUTINE_SESSION,
+      agentId: 'agent-x',
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'session.home',
+      'session.tmp',
+    ]);
+    const routineCalls = provisionFolderForMount.mock.calls.filter(
+      ([args]) => args.scope === 'routine',
+    );
+    expect(routineCalls).toHaveLength(0);
+  });
+
+  it('emits session.* + agent.* only for a topic session', async () => {
+    // Topic sessions are recognized but the v1 spec doesn't define
+    // any topic-specific mounts — they fall into the same baseline
+    // emission pattern as channel sessions.
+    const { builder } = buildHarness();
+
+    const { folderMap } = await builder.buildFolderMap({
+      sessionId: TOPIC_SESSION,
+      agentId: 'agent-x',
+    });
+
+    expect(Object.keys(folderMap).sort()).toEqual([
+      'agent.home',
+      'agent.tmp',
+      'session.home',
+      'session.tmp',
+    ]);
+  });
+
+  it('throws BadRequestException when routineId is provided but sessionId scope is not routine', async () => {
+    // This is the safety net for the controller layer: callers must
+    // not silently get a routine.* mount tied to an unrelated DM session.
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    await expect(
+      builder.buildFolderMap({
+        sessionId: DM_SESSION,
+        agentId: 'agent-x',
+        routineId: 'r-7',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    // No resolver calls happened — we reject before any I/O.
+    expect(provisionFolderForMount).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException when sessionId is unparseable', async () => {
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    await expect(
+      builder.buildFolderMap({
+        sessionId: 'not-a-team9-session-id',
+        agentId: 'agent-x',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(provisionFolderForMount).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolver-level failures (e.g. Folder9 outage)', async () => {
+    // FolderMapBuilder doesn't catch resolver errors — Folder9 outages
+    // surface as the resolver's ServiceUnavailableException and bubble
+    // up to the caller / controller layer.
+    const { builder, provisionFolderForMount } = buildHarness();
+    provisionFolderForMount.mockReset();
+    provisionFolderForMount.mockRejectedValueOnce(new Error('folder9 down'));
+
+    await expect(
+      builder.buildFolderMap({
+        sessionId: DM_SESSION,
+        agentId: 'agent-x',
+      }),
+    ).rejects.toThrow('folder9 down');
+  });
+
+  it('uses sessionId tenantId as workspaceId for every mount call', async () => {
+    // Regression guard: it would be tempting to pass agentId as the
+    // workspaceId, but workspace tenancy is determined exclusively by
+    // the sessionId prefix. This ensures every resolver call (incl.
+    // user.*) carries the parsed tenantId.
+    const { builder, provisionFolderForMount } = buildHarness();
+
+    await builder.buildFolderMap({
+      sessionId: DM_SESSION,
+      agentId: 'agent-x',
+      userId: 'user-7',
+    });
+
+    for (const [args] of provisionFolderForMount.mock.calls) {
+      expect(args.workspaceId).toBe('ten-1');
+    }
+  });
+});

--- a/apps/server/apps/gateway/src/folder9/folder-map-builder.service.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-map-builder.service.ts
@@ -1,0 +1,161 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { FolderMountResolver } from './folder-mount-resolver.service.js';
+import { parseSessionShape } from './parse-session-shape.js';
+
+/**
+ * Inputs required to assemble a session's folder map.
+ *
+ * `sessionId` is the canonical team9 sessionId (`team9/{tenantId}/{agentId}/{scope}/{scopeId}`)
+ * which is parsed for tenant + scope detection. `agentId` is duplicated
+ * here because not every consumer wants to re-parse the sessionId, and
+ * the parser is a private detail of this builder.
+ *
+ * `routineId` is only meaningful when the session shape is `routine` —
+ * passing it for a dm/channel session is treated as a programmer error
+ * and surfaces as a 400.
+ *
+ * `userId` is only meaningful for dm sessions; ignored otherwise.
+ */
+export interface FolderMapBuildContext {
+  sessionId: string;
+  agentId: string;
+  routineId?: string;
+  userId?: string;
+}
+
+export interface FolderMapEntry {
+  workspaceId: string;
+  folderId: string;
+  folderType: 'light' | 'managed';
+  permission: 'read' | 'propose' | 'write' | 'admin';
+}
+
+export interface FolderMapResponse {
+  folderMap: Record<string, FolderMapEntry>;
+}
+
+/**
+ * Mount-inclusion matrix per the workspace-mount integration spec:
+ *
+ *   logicalKey          | always | dm | channel | routine | topic
+ *   --------------------|--------|----|---------|---------|------
+ *   session.{tmp,home}  |   *    | *  |    *    |    *    |   *
+ *   agent.{tmp,home}    |   *    | *  |    *    |    *    |   *
+ *   routine.{tmp,home}  |        |    |         |    *    |
+ *   user.{tmp,home}     |        | *  |         |         |
+ *
+ * `routine.document` is intentionally absent — that mount is owned by
+ * the routine creation flow (it embeds the document folder into the
+ * routine record at creation time) and is not re-issued through this
+ * builder.
+ *
+ * For v1 every entry carries `permission: 'write'` regardless of
+ * blueprint variant (Common/Personal/Base Model staff): the spec
+ * spells out that DM peers, routine collaborators, and the workspace
+ * owner all need write access at this stage. Refinement to per-actor
+ * read/propose tiers is deferred to the authz follow-up.
+ */
+@Injectable()
+export class FolderMapBuilder {
+  constructor(private readonly resolver: FolderMountResolver) {}
+
+  async buildFolderMap(ctx: FolderMapBuildContext): Promise<FolderMapResponse> {
+    const shape = parseSessionShape(ctx.sessionId);
+    if (shape.kind === 'unknown') {
+      // Unparseable sessionId is a 400, not a 500 — the caller passed
+      // us garbage. The token-issuance authz layer (Task 5) likewise
+      // rejects unparseable ids with the same exception class.
+      throw new BadRequestException(`Unparseable sessionId: ${ctx.sessionId}`);
+    }
+    if (ctx.routineId !== undefined && shape.kind !== 'routine') {
+      // Defensive cross-check: if the caller supplies a routineId, the
+      // sessionId must actually be a routine session. Mismatches
+      // (e.g. DM sessionId + routineId) would otherwise silently emit
+      // a routine.* mount tied to an unrelated session.
+      throw new BadRequestException(
+        `routineId provided but sessionId scope is "${shape.kind}", expected "routine"`,
+      );
+    }
+
+    const tenantId = shape.tenantId;
+    const result: Record<string, FolderMapEntry> = {};
+
+    /**
+     * Resolve a single (logicalKey, mount tuple) pair via the resolver
+     * and stitch the response into the result map. Hoisted into a
+     * helper so the per-mount cases below stay declarative — every
+     * mount looks identical aside from `logicalKey` + the resolver
+     * args.
+     */
+    const provisionInto = async (
+      logicalKey: string,
+      args: Parameters<FolderMountResolver['provisionFolderForMount']>[0],
+    ): Promise<void> => {
+      const r = await this.resolver.provisionFolderForMount(args);
+      result[logicalKey] = {
+        workspaceId: tenantId,
+        folderId: r.folder9FolderId,
+        folderType: args.folderType,
+        permission: 'write',
+      };
+    };
+
+    // session.* and agent.* are unconditional for every shape.
+    for (const mountKey of ['tmp', 'home'] as const) {
+      await provisionInto(`session.${mountKey}`, {
+        workspaceId: tenantId,
+        scope: 'session',
+        scopeId: ctx.sessionId,
+        mountKey,
+        folderType: 'light',
+        ownerType: 'workspace',
+        ownerId: tenantId,
+      });
+      await provisionInto(`agent.${mountKey}`, {
+        workspaceId: tenantId,
+        scope: 'agent',
+        scopeId: ctx.agentId,
+        mountKey,
+        folderType: 'light',
+        ownerType: 'agent',
+        ownerId: ctx.agentId,
+      });
+    }
+
+    // routine.{tmp,home} only when the caller asked for a routine
+    // session AND the session itself is a routine (mismatch already
+    // rejected above). routine.document is intentionally NOT emitted.
+    if (ctx.routineId !== undefined && shape.kind === 'routine') {
+      for (const mountKey of ['tmp', 'home'] as const) {
+        await provisionInto(`routine.${mountKey}`, {
+          workspaceId: tenantId,
+          scope: 'routine',
+          scopeId: ctx.routineId,
+          mountKey,
+          folderType: 'light',
+          ownerType: 'agent',
+          ownerId: ctx.agentId,
+        });
+      }
+    }
+
+    // user.{tmp,home} only for DM sessions where the caller passed a
+    // userId — the DM peer is the implicit "user" the agent is talking
+    // to, and channel/routine/topic sessions don't have a 1:1 peer.
+    if (shape.kind === 'dm' && ctx.userId !== undefined) {
+      for (const mountKey of ['tmp', 'home'] as const) {
+        await provisionInto(`user.${mountKey}`, {
+          workspaceId: tenantId,
+          scope: 'user',
+          scopeId: ctx.userId,
+          mountKey,
+          folderType: 'light',
+          ownerType: 'workspace',
+          ownerId: tenantId,
+        });
+      }
+    }
+
+    return { folderMap: result };
+  }
+}

--- a/apps/server/apps/gateway/src/folder9/folder-map.controller.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-map.controller.spec.ts
@@ -1,0 +1,170 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('@team9/auth', () => ({
+  AuthGuard: class AuthGuard {},
+  CurrentUser: () => () => undefined,
+}));
+
+jest.unstable_mockModule('./folder-map-builder.service.js', () => ({
+  FolderMapBuilder: class FolderMapBuilder {},
+}));
+
+jest.unstable_mockModule('./bot-agent-ownership.service.js', () => ({
+  BotAgentOwnership: class BotAgentOwnership {},
+}));
+
+const { FolderMapController } = await import('./folder-map.controller.js');
+const { FolderMapBuilder } = await import('./folder-map-builder.service.js');
+const { BotAgentOwnership } = await import('./bot-agent-ownership.service.js');
+
+import { ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { FolderMapResponse } from './folder-map-builder.service.js';
+import type { FolderMapRequestDto } from './dto/folder-map-request.dto.js';
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+const BOT_USER_ID = 'bot-user-uuid-1234';
+const AGENT_ID = 'agent-uuid-1';
+
+const makeDto = (
+  overrides: Partial<FolderMapRequestDto> = {},
+): FolderMapRequestDto =>
+  ({
+    sessionId: 'team9/tenant-1/agent-1/dm/channel-1',
+    agentId: AGENT_ID,
+    routineId: undefined,
+    userId: undefined,
+    ...overrides,
+  }) as FolderMapRequestDto;
+
+describe('FolderMapController', () => {
+  let controller: InstanceType<typeof FolderMapController>;
+  let builder: { buildFolderMap: MockFn };
+  let ownership: { assertAgentBelongsToBot: MockFn };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FolderMapController],
+      providers: [FolderMapBuilder, BotAgentOwnership],
+    }).compile();
+
+    controller = module.get(FolderMapController);
+    builder = module.get(FolderMapBuilder);
+    ownership = module.get(BotAgentOwnership);
+
+    builder.buildFolderMap = jest.fn<MockFn>();
+    ownership.assertAgentBelongsToBot = jest.fn<MockFn>();
+  });
+
+  describe('POST /api/v1/bot/folder-map', () => {
+    it('returns folderMap from builder when header matches and agentId is owned', async () => {
+      const response: FolderMapResponse = {
+        folderMap: {
+          'session.tmp': {
+            workspaceId: 'tenant-1',
+            folderId: 'f1',
+            folderType: 'light',
+            permission: 'write',
+          },
+        },
+      };
+      ownership.assertAgentBelongsToBot.mockResolvedValue(undefined);
+      builder.buildFolderMap.mockResolvedValue(response);
+
+      const result = await controller.build(
+        makeDto(),
+        BOT_USER_ID,
+        BOT_USER_ID,
+      );
+
+      expect(result).toEqual(response);
+    });
+
+    it('forwards dto fields (sessionId, agentId, routineId, userId) to builder', async () => {
+      ownership.assertAgentBelongsToBot.mockResolvedValue(undefined);
+      builder.buildFolderMap.mockResolvedValue({ folderMap: {} });
+      const dto = makeDto({
+        sessionId: 'team9/tenant-1/agent-1/routine/r-1',
+        routineId: 'r-1',
+        userId: 'u-1',
+      });
+
+      await controller.build(dto, BOT_USER_ID, BOT_USER_ID);
+
+      expect(builder.buildFolderMap).toHaveBeenCalledTimes(1);
+      expect(builder.buildFolderMap).toHaveBeenCalledWith({
+        sessionId: dto.sessionId,
+        agentId: dto.agentId,
+        routineId: 'r-1',
+        userId: 'u-1',
+      });
+    });
+
+    it('checks ownership with the authenticated sub (not the header)', async () => {
+      ownership.assertAgentBelongsToBot.mockResolvedValue(undefined);
+      builder.buildFolderMap.mockResolvedValue({ folderMap: {} });
+
+      await controller.build(makeDto(), BOT_USER_ID, BOT_USER_ID);
+
+      expect(ownership.assertAgentBelongsToBot).toHaveBeenCalledWith(
+        BOT_USER_ID,
+        AGENT_ID,
+      );
+    });
+
+    it('throws ForbiddenException when X-Team9-Bot-User-Id header is missing', async () => {
+      await expect(
+        controller.build(makeDto(), BOT_USER_ID, undefined),
+      ).rejects.toMatchObject({
+        name: 'ForbiddenException',
+        message: 'X-Team9-Bot-User-Id does not match authenticated bot',
+      });
+      expect(ownership.assertAgentBelongsToBot).not.toHaveBeenCalled();
+      expect(builder.buildFolderMap).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when header is empty string', async () => {
+      await expect(
+        controller.build(makeDto(), BOT_USER_ID, ''),
+      ).rejects.toMatchObject({
+        name: 'ForbiddenException',
+        message: 'X-Team9-Bot-User-Id does not match authenticated bot',
+      });
+      expect(ownership.assertAgentBelongsToBot).not.toHaveBeenCalled();
+      expect(builder.buildFolderMap).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when header does not match authenticated sub', async () => {
+      await expect(
+        controller.build(makeDto(), BOT_USER_ID, 'different-user'),
+      ).rejects.toMatchObject({
+        name: 'ForbiddenException',
+        message: 'X-Team9-Bot-User-Id does not match authenticated bot',
+      });
+      expect(ownership.assertAgentBelongsToBot).not.toHaveBeenCalled();
+      expect(builder.buildFolderMap).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when agentId does not belong to caller bot', async () => {
+      ownership.assertAgentBelongsToBot.mockRejectedValue(
+        new ForbiddenException('agentId does not belong to caller bot'),
+      );
+      const dto = makeDto({ agentId: 'foreign-agent' });
+
+      await expect(
+        controller.build(dto, BOT_USER_ID, BOT_USER_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(builder.buildFolderMap).not.toHaveBeenCalled();
+    });
+
+    it('does not call ownership or builder when header validation fails', async () => {
+      await expect(
+        controller.build(makeDto(), BOT_USER_ID, 'mismatch'),
+      ).rejects.toThrow();
+
+      expect(ownership.assertAgentBelongsToBot).not.toHaveBeenCalled();
+      expect(builder.buildFolderMap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/apps/gateway/src/folder9/folder-map.controller.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-map.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard, CurrentUser } from '@team9/auth';
+import { BotAgentOwnership } from './bot-agent-ownership.service.js';
+import { FolderMapRequestDto } from './dto/folder-map-request.dto.js';
+import {
+  FolderMapBuilder,
+  type FolderMapResponse,
+} from './folder-map-builder.service.js';
+
+/**
+ * `POST /api/v1/bot/folder-map` — per-session folderMap issuance for
+ * `JustBashTeam9WorkspaceComponent` (agent-pi side).
+ *
+ * Auth: bearer-authenticated bot user (matches the pattern in
+ * `/api/v1/bot/folder-token` and `/api/v1/bot/staff/profile`). The
+ * controller also requires the `X-Team9-Bot-User-Id` header to match
+ * the authenticated `sub` so a caller holding a legitimate bot token
+ * cannot impersonate a different bot id on the wire.
+ *
+ * On 200 the response is a freshly resolved
+ * `{ folderMap: { 'session.tmp': {...}, 'agent.home': {...}, ... } }`
+ * built by {@link FolderMapBuilder.buildFolderMap}, which lazy-
+ * provisions any missing `workspace_folder_mounts` rows + Folder9
+ * folders along the way.
+ *
+ * Authorization beyond header-match is handled by
+ * {@link BotAgentOwnership.assertAgentBelongsToBot}: the caller's bot
+ * must manage the `dto.agentId` it is asking for. Mismatch → 403.
+ */
+@Controller({
+  path: 'bot/folder-map',
+  version: '1',
+})
+@UseGuards(AuthGuard)
+export class FolderMapController {
+  constructor(
+    private readonly builder: FolderMapBuilder,
+    private readonly ownership: BotAgentOwnership,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async build(
+    @Body() dto: FolderMapRequestDto,
+    @CurrentUser('sub') authenticatedUserId: string,
+    @Headers('x-team9-bot-user-id') headerBotUserId: string | undefined,
+  ): Promise<FolderMapResponse> {
+    this.assertHeaderMatches(headerBotUserId, authenticatedUserId);
+    await this.ownership.assertAgentBelongsToBot(
+      authenticatedUserId,
+      dto.agentId,
+    );
+    return this.builder.buildFolderMap({
+      sessionId: dto.sessionId,
+      agentId: dto.agentId,
+      routineId: dto.routineId,
+      userId: dto.userId,
+    });
+  }
+
+  private assertHeaderMatches(header: string | undefined, sub: string): void {
+    if (!header || header !== sub) {
+      throw new ForbiddenException(
+        'X-Team9-Bot-User-Id does not match authenticated bot',
+      );
+    }
+  }
+}

--- a/apps/server/apps/gateway/src/folder9/folder-mount-resolver.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-mount-resolver.service.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+//
+// `FolderMountResolver` imports from `@team9/database` (DATABASE_CONNECTION,
+// `and`, `eq`, PostgresJsDatabase) and `@team9/database/schemas`
+// (workspaceFolderMounts). We replace both with lightweight test doubles so
+// the resolver is exercised in isolation against a chainable Drizzle stub.
+
+const dbModule = {
+  DATABASE_CONNECTION: Symbol('DATABASE_CONNECTION'),
+  eq: jest.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  and: jest.fn((...clauses: unknown[]) => ({ op: 'and', clauses })),
+};
+
+const schemaModule = {
+  workspaceFolderMounts: {
+    workspaceId: 'wfm.workspace_id',
+    scope: 'wfm.scope',
+    scopeId: 'wfm.scope_id',
+    mountKey: 'wfm.mount_key',
+    folderType: 'wfm.folder_type',
+    folder9FolderId: 'wfm.folder9_folder_id',
+  },
+};
+
+jest.unstable_mockModule('@team9/database', () => dbModule);
+jest.unstable_mockModule('@team9/database/schemas', () => schemaModule);
+
+const { FolderMountResolver } =
+  await import('./folder-mount-resolver.service.js');
+
+const { Folder9ApiError } = await import('../wikis/types/folder9.types.js');
+
+import { ServiceUnavailableException } from '@nestjs/common';
+
+// ── Drizzle test double ──────────────────────────────────────────────────────
+//
+// The resolver issues:
+//   - select(...).from(...).where(...).limit(1)  (SELECT)
+//   - insert(...).values(...).onConflictDoNothing() (race-safe INSERT)
+//
+// We expose two queues: `selectMock` returns successive SELECT results;
+// `insertMock` is the spy on `.values(...)` so callers can assert insert
+// payload AND drive the `.onConflictDoNothing()` continuation.
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+function buildHarness() {
+  const folder9 = {
+    createFolder: jest.fn<(...args: any[]) => any>(),
+  };
+
+  const selectMock: MockFn = jest.fn();
+  const insertMock: MockFn = jest.fn();
+
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(selectMock()),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: insertMock,
+    }),
+  };
+
+  // `as never` here mirrors how folder-token.service.spec.ts threads the
+  // mocked db/folder9Client into the constructor — Drizzle/Folder9 types
+  // are huge and irrelevant to the unit's branching logic.
+  const resolver = new FolderMountResolver(db as never, folder9 as never);
+
+  return { resolver, folder9, selectMock, insertMock };
+}
+
+const BASE_ARGS = {
+  workspaceId: 'ws-1',
+  scope: 'session' as const,
+  scopeId: 'sess-A',
+  mountKey: 'home' as const,
+  folderType: 'light' as const,
+  ownerType: 'workspace' as const,
+  ownerId: 'ws-1',
+};
+
+describe('FolderMountResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns existing folder on cache hit (no Folder9 call, no insert)', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    selectMock.mockReturnValue([{ folder9FolderId: 'cached-id' }]);
+
+    const result = await resolver.provisionFolderForMount(BASE_ARGS);
+
+    expect(result.folder9FolderId).toBe('cached-id');
+    expect(folder9.createFolder).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('lazy creates on miss: createFolder + insert + re-select', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    // First select: empty (cache miss). Second select (after INSERT): row found.
+    selectMock
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ folder9FolderId: 'new-id' }]);
+    folder9.createFolder.mockResolvedValue({ id: 'new-id' });
+    insertMock.mockReturnValue({
+      onConflictDoNothing: () => Promise.resolve(),
+    });
+
+    const result = await resolver.provisionFolderForMount({
+      ...BASE_ARGS,
+      scope: 'agent',
+      scopeId: 'bot-X',
+      ownerType: 'agent',
+      ownerId: 'bot-X',
+    });
+
+    expect(folder9.createFolder).toHaveBeenCalledTimes(1);
+    const [wsArg, inputArg] = folder9.createFolder.mock.calls[0];
+    expect(wsArg).toBe('ws-1');
+    expect(inputArg).toEqual(
+      expect.objectContaining({
+        type: 'light',
+        owner_type: 'agent',
+        owner_id: 'bot-X',
+        metadata: expect.objectContaining({
+          team9Scope: { scope: 'agent', scopeId: 'bot-X', mountKey: 'home' },
+        }),
+      }),
+    );
+
+    // Insert payload mirrors the create-folder result.
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'ws-1',
+        scope: 'agent',
+        scopeId: 'bot-X',
+        mountKey: 'home',
+        folderType: 'light',
+        folder9FolderId: 'new-id',
+      }),
+    );
+
+    expect(result.folder9FolderId).toBe('new-id');
+    // Two selects: lookup-miss + re-select-after-insert.
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles race: insert conflict returns the winner via re-select', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    // First lookup empty; after our (no-op) insert the re-select sees the
+    // winner's row, NOT our just-created Folder9 folder id.
+    selectMock
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ folder9FolderId: 'winner-id' }]);
+    folder9.createFolder.mockResolvedValue({ id: 'loser-id' });
+    insertMock.mockReturnValue({
+      onConflictDoNothing: () => Promise.resolve(),
+    });
+
+    const result = await resolver.provisionFolderForMount({
+      ...BASE_ARGS,
+      scopeId: 'sess-B',
+      mountKey: 'tmp',
+    });
+
+    // Re-select returned 'winner-id' (the row that beat us); we return that,
+    // and 'loser-id' leaks for follow-up GC.
+    expect(result.folder9FolderId).toBe('winner-id');
+    expect(folder9.createFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws ServiceUnavailableException on Folder9 createFolder failure', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    selectMock.mockReturnValue([]);
+    folder9.createFolder.mockRejectedValue(
+      new Folder9ApiError('folder9 down', 502, undefined),
+    );
+
+    await expect(
+      resolver.provisionFolderForMount({
+        ...BASE_ARGS,
+        scopeId: 'sess-C',
+      }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+    // No insert attempted when Folder9 createFolder fails.
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-Folder9 errors from createFolder unchanged', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    selectMock.mockReturnValue([]);
+    const boom = new Error('unexpected boom');
+    folder9.createFolder.mockRejectedValue(boom);
+
+    await expect(
+      resolver.provisionFolderForMount({
+        ...BASE_ARGS,
+        scopeId: 'sess-D',
+      }),
+    ).rejects.toBe(boom);
+
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('throws ServiceUnavailableException when re-select finds no row (concurrent delete)', async () => {
+    const { resolver, folder9, selectMock, insertMock } = buildHarness();
+    // First lookup miss; re-select after insert ALSO empty — should not
+    // happen in steady state but must surface as a 503-class failure rather
+    // than crash with `undefined`.
+    selectMock.mockReturnValueOnce([]).mockReturnValueOnce([]);
+    folder9.createFolder.mockResolvedValue({ id: 'orphan-id' });
+    insertMock.mockReturnValue({
+      onConflictDoNothing: () => Promise.resolve(),
+    });
+
+    await expect(
+      resolver.provisionFolderForMount({
+        ...BASE_ARGS,
+        scopeId: 'sess-E',
+      }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+});

--- a/apps/server/apps/gateway/src/folder9/folder-mount-resolver.service.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-mount-resolver.service.ts
@@ -1,0 +1,167 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import {
+  DATABASE_CONNECTION,
+  and,
+  eq,
+  type PostgresJsDatabase,
+} from '@team9/database';
+import * as schema from '@team9/database/schemas';
+import { Folder9ClientService } from '../wikis/folder9-client.service.js';
+import {
+  Folder9ApiError,
+  type Folder9FolderType,
+  type Folder9OwnerType,
+} from '../wikis/types/folder9.types.js';
+
+/**
+ * Inputs for {@link FolderMountResolver.provisionFolderForMount}.
+ *
+ * The (workspaceId, scope, scopeId, mountKey) tuple is the idempotency key —
+ * the unique index on `workspace_folder_mounts` ensures that two concurrent
+ * callers passing the same key end up sharing one folder regardless of who
+ * wins the INSERT race.
+ *
+ * `folderType` / `ownerType` / `ownerId` are forwarded to Folder9 only on
+ * cache miss; on cache hit they're ignored because the registry row already
+ * pins the folder type for that key.
+ */
+export interface ProvisionFolderForMountArgs {
+  workspaceId: string;
+  scope: 'session' | 'agent' | 'routine' | 'user';
+  scopeId: string;
+  mountKey: 'tmp' | 'home' | 'document';
+  folderType: Folder9FolderType;
+  ownerType: Folder9OwnerType;
+  ownerId: string;
+}
+
+export interface ProvisionFolderForMountResult {
+  folder9FolderId: string;
+}
+
+/**
+ * Lazy + race-safe Folder9 folder provisioning for the workspace mount layer.
+ *
+ * Flow:
+ *   1. SELECT — covers the steady-state cache hit path with no Folder9 traffic.
+ *   2. On miss: createFolder via Folder9, then INSERT ... ON CONFLICT DO NOTHING.
+ *   3. Re-SELECT — ensures concurrent callers converge on the winning row,
+ *      with the loser's just-created folder leaking (logged for follow-up GC).
+ *
+ * Used by:
+ *   - `FolderMapBuilder` (Task 3) — resolves mount → folderId during
+ *     bot reply / agent prompt assembly so each mount has a deterministic id.
+ *   - Expanded `FolderTokenService` authz (Task 5) — verifies that a token
+ *     request's `(scope, scopeId, mountKey)` resolves to the same folderId
+ *     before minting a write-scoped Folder9 token.
+ */
+@Injectable()
+export class FolderMountResolver {
+  private readonly logger = new Logger(FolderMountResolver.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly folder9: Folder9ClientService,
+  ) {}
+
+  async provisionFolderForMount(
+    args: ProvisionFolderForMountArgs,
+  ): Promise<ProvisionFolderForMountResult> {
+    // 1. SELECT first — covers the cache hit (most common steady-state path).
+    const existing = await this.lookup(args);
+    if (existing) {
+      return { folder9FolderId: existing };
+    }
+
+    // 2. Cache miss: create Folder9 folder.
+    let folder9Id: string;
+    try {
+      const created = await this.folder9.createFolder(args.workspaceId, {
+        name: `${args.scope}-${args.scopeId}-${args.mountKey}`,
+        type: args.folderType,
+        owner_type: args.ownerType,
+        owner_id: args.ownerId,
+        metadata: {
+          team9Scope: {
+            scope: args.scope,
+            scopeId: args.scopeId,
+            mountKey: args.mountKey,
+          },
+        },
+      });
+      folder9Id = created.id;
+    } catch (e) {
+      if (e instanceof Folder9ApiError) {
+        // Mirror FolderTokenService: surface upstream Folder9 outages as 503
+        // so the gateway returns a retryable status rather than a 500.
+        throw new ServiceUnavailableException(
+          `Folder9 createFolder failed: ${e.message}`,
+        );
+      }
+      throw e;
+    }
+
+    // 3. INSERT ON CONFLICT DO NOTHING — race-safe. If a concurrent caller
+    //    already inserted the same key, this is a no-op.
+    await this.db
+      .insert(schema.workspaceFolderMounts)
+      .values({
+        workspaceId: args.workspaceId,
+        scope: args.scope,
+        scopeId: args.scopeId,
+        mountKey: args.mountKey,
+        folderType: args.folderType,
+        folder9FolderId: folder9Id,
+      })
+      .onConflictDoNothing();
+
+    // 4. Re-SELECT. If our INSERT was the no-op (race loser), this returns
+    //    the winner's folderId; our just-created folder leaks for follow-up
+    //    GC. If our INSERT won, this returns our own folderId.
+    const winner = await this.lookup(args);
+    if (!winner) {
+      // Should be unreachable — we just inserted (or someone else did).
+      // Treating this as 503 lets the caller retry rather than blow up
+      // with a NPE on `winner.folder9FolderId`.
+      throw new ServiceUnavailableException(
+        'workspace_folder_mounts row missing after insert; concurrent delete?',
+      );
+    }
+    if (winner !== folder9Id) {
+      this.logger.warn(
+        `Folder9 folder leaked due to race: created=${folder9Id} winner=${winner} ` +
+          `key=(${args.workspaceId},${args.scope},${args.scopeId},${args.mountKey})`,
+      );
+    }
+    return { folder9FolderId: winner };
+  }
+
+  private async lookup(
+    args: Pick<
+      ProvisionFolderForMountArgs,
+      'workspaceId' | 'scope' | 'scopeId' | 'mountKey'
+    >,
+  ): Promise<string | undefined> {
+    const rows = await this.db
+      .select({
+        folder9FolderId: schema.workspaceFolderMounts.folder9FolderId,
+      })
+      .from(schema.workspaceFolderMounts)
+      .where(
+        and(
+          eq(schema.workspaceFolderMounts.workspaceId, args.workspaceId),
+          eq(schema.workspaceFolderMounts.scope, args.scope),
+          eq(schema.workspaceFolderMounts.scopeId, args.scopeId),
+          eq(schema.workspaceFolderMounts.mountKey, args.mountKey),
+        ),
+      )
+      .limit(1);
+    return rows[0]?.folder9FolderId;
+  }
+}

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
@@ -13,10 +13,26 @@ const schemaModule = {
     id: 'routines.id',
     tenantId: 'routines.tenant_id',
     folderId: 'routines.folder_id',
+    botId: 'routines.bot_id',
   },
   bots: {
+    id: 'bots.id',
     userId: 'bots.user_id',
+    managedMeta: 'bots.managed_meta',
     isActive: 'bots.is_active',
+  },
+  workspaceFolderMounts: {
+    workspaceId: 'wfm.workspace_id',
+    scope: 'wfm.scope',
+    scopeId: 'wfm.scope_id',
+    mountKey: 'wfm.mount_key',
+    folderType: 'wfm.folder_type',
+    folder9FolderId: 'wfm.folder9_folder_id',
+  },
+  channelMembers: {
+    id: 'cm.id',
+    channelId: 'cm.channel_id',
+    userId: 'cm.user_id',
   },
 };
 
@@ -75,19 +91,27 @@ function mockDb() {
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
+const BOT_ID = 'bot-1';
 const BOT_USER_ID = 'bot-user-1';
+const AGENT_ID = 'agent-1';
 const TENANT_ID = 'tenant-1';
 const ROUTINE_ID = 'routine-1';
 const FOLDER_ID = 'folder-1';
+const USER_ID = 'user-1';
+const CHANNEL_ID = 'channel-dm-1';
+// Canonical sessionIds matching `parseSessionShape` layout —
+// `team9/{tenantId}/{agentId}/{scope}/{scopeId}`.
+const DM_SESSION_ID = `team9/${TENANT_ID}/${AGENT_ID}/dm/${CHANNEL_ID}`;
+const ROUTINE_SESSION_ID = `team9/${TENANT_ID}/${AGENT_ID}/routine/${ROUTINE_ID}`;
 
 const makeDto = (
   overrides: Partial<FolderTokenRequestDto> = {},
 ): FolderTokenRequestDto =>
   ({
     sessionId: 'session-1',
-    agentId: 'agent-1',
+    agentId: AGENT_ID,
     routineId: ROUTINE_ID,
-    userId: 'user-1',
+    userId: USER_ID,
     logicalKey: 'routine.document',
     workspaceId: TENANT_ID,
     folderId: FOLDER_ID,
@@ -142,9 +166,60 @@ describe('FolderTokenService', () => {
     );
   }
 
-  /** Queue a bot row (or null) to be returned by the bot lookup. */
-  function queueBot(row: { userId: string } | null) {
-    db.__state.selectResults.push(row ? [row] : []);
+  /**
+   * Queue a bot row (or null) to be returned by the bot lookup.
+   * Defaults fill in the `(id, userId, managedMeta)` shape that the
+   * service actually selects.
+   */
+  function queueBot(
+    row: {
+      id?: string;
+      userId?: string;
+      managedMeta?: Record<string, unknown> | null;
+    } | null,
+  ) {
+    db.__state.selectResults.push(
+      row
+        ? [
+            {
+              id: row.id ?? BOT_ID,
+              userId: row.userId ?? BOT_USER_ID,
+              managedMeta:
+                row.managedMeta === undefined
+                  ? { agentId: AGENT_ID }
+                  : row.managedMeta,
+            },
+          ]
+        : [],
+    );
+  }
+
+  /**
+   * Queue a `workspace_folder_mounts` row (or null) for the next mount
+   * lookup.
+   */
+  function queueMount(row: { scopeId: string; folderType?: string } | null) {
+    db.__state.selectResults.push(
+      row
+        ? [{ scopeId: row.scopeId, folderType: row.folderType ?? 'light' }]
+        : [],
+    );
+  }
+
+  /**
+   * Queue the channel-members membership probe — non-empty means
+   * member, empty means not-a-member.
+   */
+  function queueChannelMember(present: boolean) {
+    db.__state.selectResults.push(present ? [{ id: 'cm-1' }] : []);
+  }
+
+  /**
+   * Queue a routine row keyed by `(id, botId)` (or null for "not
+   * found / not owned by bot").
+   */
+  function queueRoutineForBot(row: { id: string } | null) {
+    db.__state.selectResults.push(row ? [{ id: row.id }] : []);
   }
 
   // ── routine.document — happy paths ────────────────────────────────────────
@@ -377,7 +452,7 @@ describe('FolderTokenService', () => {
       expect(folder9Client.createToken).not.toHaveBeenCalled();
     });
 
-    it('rejects admin permission on stub scopes too (e.g. session.tmp)', async () => {
+    it('rejects admin permission on non-document scopes too (e.g. session.tmp)', async () => {
       const dto = makeDto({ logicalKey: 'session.tmp', permission: 'admin' });
       await expect(
         service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -414,65 +489,322 @@ describe('FolderTokenService', () => {
     });
   });
 
-  // ── Stub authz scopes ─────────────────────────────────────────────────────
+  // ── Real authz: agent.{tmp,home} ──────────────────────────────────────────
 
-  describe('stub authz — session/agent/user/routine.{tmp,home}', () => {
-    const STUB_KEYS = [
-      'session.tmp',
-      'session.home',
-      'agent.tmp',
-      'agent.home',
-      'user.tmp',
-      'user.home',
-      'routine.tmp',
-      'routine.home',
-    ] as const;
+  describe('agent.{tmp,home} authz', () => {
+    for (const mountKey of ['tmp', 'home'] as const) {
+      const logicalKey = `agent.${mountKey}` as const;
 
-    for (const key of STUB_KEYS) {
-      it(`accepts ${key} on tenant match and mints a read token`, async () => {
-        queueBot({ userId: BOT_USER_ID });
+      it(`200: ${logicalKey} mints a token when mount row matches bot's managed agent`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: AGENT_ID });
 
-        const dto = makeDto({ logicalKey: key, permission: 'read' });
+        const dto = makeDto({ logicalKey, permission: 'read' });
         const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
 
         expect(result.token).toBe('opaque-token');
         expect(folder9Client.createToken).toHaveBeenCalledTimes(1);
         const mintArg = folder9Client.createToken.mock.calls[0][0];
+        expect(mintArg.name).toBe(`${logicalKey}-${AGENT_ID}`);
         expect(mintArg.permission).toBe('read');
-        // Stub branch never queries routines.
-        // (The select call is for the bot lookup only.)
-        expect(db.select).toHaveBeenCalledTimes(1);
+      });
+
+      it(`403: ${logicalKey} rejects when no workspace_folder_mounts row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount(null);
+
+        const dto = makeDto({ logicalKey });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when mount row's scopeId belongs to a different agent`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: 'other-agent' });
+
+        const dto = makeDto({ logicalKey });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when bot has no managedMeta.agentId`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: null });
+        queueMount({ scopeId: AGENT_ID });
+
+        const dto = makeDto({ logicalKey });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
       });
     }
+  });
 
-    it('accepts write permission on a stub scope (no propose/write filter outside routine.document)', async () => {
-      queueBot({ userId: BOT_USER_ID });
-      const dto = makeDto({ logicalKey: 'session.tmp', permission: 'write' });
-      await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
-      expect(folder9Client.createToken).toHaveBeenCalled();
-    });
+  // ── Real authz: session.{tmp,home} ────────────────────────────────────────
 
-    it('accepts propose permission on a stub scope and uses the 1h TTL', async () => {
-      queueBot({ userId: BOT_USER_ID });
-      const dto = makeDto({ logicalKey: 'agent.home', permission: 'propose' });
+  describe('session.{tmp,home} authz', () => {
+    for (const mountKey of ['tmp', 'home'] as const) {
+      const logicalKey = `session.${mountKey}` as const;
+
+      it(`200: ${logicalKey} mints a token when sessionId parses + mount row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: DM_SESSION_ID });
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          permission: 'read',
+        });
+        const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
+
+        expect(result.token).toBe('opaque-token');
+        const mintArg = folder9Client.createToken.mock.calls[0][0];
+        expect(mintArg.name).toBe(`${logicalKey}-${DM_SESSION_ID}`);
+      });
+
+      it(`403: ${logicalKey} rejects when no workspace_folder_mounts row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount(null);
+
+        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when sessionId is unparseable`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: 'whatever' });
+
+        const dto = makeDto({ logicalKey, sessionId: 'garbage-session-id' });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when parsed sessionId.agentId differs from bot's managed agent`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: 'wrong-agent' } });
+        queueMount({ scopeId: DM_SESSION_ID });
+
+        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when mount row's scopeId differs from req.sessionId`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: 'team9/tenant-1/agent-1/dm/other-channel' });
+
+        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+    }
+  });
+
+  // ── Real authz: user.{tmp,home} ───────────────────────────────────────────
+
+  describe('user.{tmp,home} authz', () => {
+    for (const mountKey of ['tmp', 'home'] as const) {
+      const logicalKey = `user.${mountKey}` as const;
+
+      it(`200: ${logicalKey} mints a token for a DM session where userId is a channel member`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: USER_ID });
+        queueChannelMember(true);
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          userId: USER_ID,
+          permission: 'read',
+        });
+        const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
+
+        expect(result.token).toBe('opaque-token');
+        const mintArg = folder9Client.createToken.mock.calls[0][0];
+        expect(mintArg.name).toBe(`${logicalKey}-${USER_ID}`);
+      });
+
+      it(`403: ${logicalKey} rejects when no workspace_folder_mounts row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount(null);
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          userId: USER_ID,
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when sessionId is not a DM (e.g. routine)`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: USER_ID });
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: ROUTINE_SESSION_ID,
+          userId: USER_ID,
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when userId is undefined`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: USER_ID });
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          userId: undefined,
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when userId is not a member of the DM channel`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: USER_ID });
+        queueChannelMember(false);
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          userId: USER_ID,
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when mount row's scopeId differs from userId`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: 'other-user' });
+        queueChannelMember(true);
+
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          userId: USER_ID,
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+    }
+  });
+
+  // ── TTL on real authz path (1h propose) ───────────────────────────────────
+
+  describe('TTL on real authz path', () => {
+    it('uses 1h propose TTL on agent.home with permission=propose', async () => {
+      queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+      queueMount({ scopeId: AGENT_ID });
       const before = Date.now();
+
+      const dto = makeDto({
+        logicalKey: 'agent.home',
+        permission: 'propose',
+      });
       await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
 
       const mintArg = folder9Client.createToken.mock.calls[0][0];
       const expiresAtMs = Date.parse(mintArg.expires_at as string);
       expect(expiresAtMs).toBeGreaterThanOrEqual(before + 60 * 60_000 - 5_000);
+      expect(expiresAtMs).toBeLessThanOrEqual(Date.now() + 60 * 60_000 + 5_000);
     });
+  });
 
-    it('uses sessionId as scopeId when routineId is absent on stub scopes', async () => {
-      queueBot({ userId: BOT_USER_ID });
-      const dto = makeDto({
-        logicalKey: 'session.tmp',
-        routineId: undefined,
+  // ── Real authz: routine.{tmp,home} ────────────────────────────────────────
+
+  describe('routine.{tmp,home} authz', () => {
+    for (const mountKey of ['tmp', 'home'] as const) {
+      const logicalKey = `routine.${mountKey}` as const;
+
+      it(`200: ${logicalKey} mints a token when routine is owned by bot + mount row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: ROUTINE_ID });
+        queueRoutineForBot({ id: ROUTINE_ID });
+
+        const dto = makeDto({
+          logicalKey,
+          routineId: ROUTINE_ID,
+          permission: 'read',
+        });
+        const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
+
+        expect(result.token).toBe('opaque-token');
+        const mintArg = folder9Client.createToken.mock.calls[0][0];
+        expect(mintArg.name).toBe(`${logicalKey}-${ROUTINE_ID}`);
       });
-      await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
-      const mintArg = folder9Client.createToken.mock.calls[0][0];
-      expect(mintArg.name).toBe(`session.tmp-${dto.sessionId}`);
-    });
+
+      it(`403: ${logicalKey} rejects when no workspace_folder_mounts row matches`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount(null);
+
+        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when routineId is undefined`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: ROUTINE_ID });
+
+        const dto = makeDto({ logicalKey, routineId: undefined });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when routine is not owned by caller bot`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: ROUTINE_ID });
+        queueRoutineForBot(null);
+
+        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects when mount row's scopeId differs from routineId`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueMount({ scopeId: 'other-routine' });
+        queueRoutineForBot({ id: ROUTINE_ID });
+
+        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+    }
   });
 
   // ── folder9 mint failures ────────────────────────────────────────────────

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.ts
@@ -20,6 +20,7 @@ import {
   type Folder9Permission,
 } from '../wikis/types/folder9.types.js';
 import { FolderTokenRequestDto } from './dto/folder-token-request.dto.js';
+import { parseSessionShape } from './parse-session-shape.js';
 
 /**
  * Response body for `POST /api/v1/bot/folder-token`.
@@ -66,12 +67,21 @@ const KNOWN_LOGICAL_KEYS = new Set([
  *   same tenant as the routine, the routine's `folderId` matches the
  *   request's `folderId`, and the requested permission is `read` or
  *   `write` (no `propose`/`admin` for routines in v1).
- * - `session.*`, `agent.*`, `user.*`, `routine.tmp`, `routine.home`:
- *   stub — tenant alignment + bot-existence are still verified, then
- *   a token with the requested permission is minted. **TODO**: real
- *   authorization (session ownership / agent ownership / user-scoped
- *   home-dir gating) needs to land before these scopes ship to
- *   production. Tracked in the dynamic-token-issuance follow-up.
+ * - `session.{tmp,home}`, `agent.{tmp,home}`, `user.{tmp,home}`,
+ *   `routine.{tmp,home}`: real authz against `workspace_folder_mounts`
+ *   plus logicalKey-specific ownership. Every non-document logicalKey
+ *   first requires a matching `workspace_folder_mounts` row keyed by
+ *   `(workspaceId, folderId, scope, mountKey)`; the scope-specific
+ *   gates layer on top:
+ *     * `agent.*`  — `mountRow.scopeId === bot.managedMeta.agentId`.
+ *     * `session.*` — parsed sessionId is recognized AND
+ *       `parsed.agentId === bot.managedMeta.agentId` AND
+ *       `mountRow.scopeId === req.sessionId`.
+ *     * `user.*`   — parsed sessionId is a DM AND `req.userId` is a
+ *       member of the parsed channel AND `mountRow.scopeId === req.userId`.
+ *     * `routine.{tmp,home}` — `req.routineId` is provided AND a
+ *       `routines` row exists with `(id=req.routineId, botId=bot.id)`
+ *       AND `mountRow.scopeId === req.routineId`.
  * - `admin` permission: never issued from this endpoint, regardless
  *   of logical key. The bot surface is mount-time access; admin-tier
  *   lifecycle ops go through PSK paths.
@@ -174,24 +184,11 @@ export class FolderTokenService {
       const routine = await this.authorizeRoutineDocument(req);
       scopeId = routine.id;
     } else {
-      // Stub branch for session.*, agent.*, user.*, routine.tmp,
-      // routine.home. Tenant alignment is already verified above.
-      // TODO(team9-agent-pi #103): replace this stub with real authz
-      // when the corresponding agent-pi feature ships:
-      //   - session.{tmp,home}: verify session ownership (bot is the
-      //     persona attached to the session; sessionId belongs to the
-      //     same agent + tenant).
-      //   - agent.{tmp,home}: verify the bot is the agent runtime
-      //     (agentId matches the bot's managed agent).
-      //   - routine.{tmp,home}: verify the bot has access to the
-      //     routine (ownership or member-of routine.bots).
-      //   - user.{tmp,home}: verify the bot is acting on behalf of
-      //     `userId` (mentor relationship, DM channel, etc.).
-      this.logger.warn(
-        `folder-token issued via stub authz path: logicalKey=${req.logicalKey} ` +
-          `bot=${callerBotUserId} workspace=${req.workspaceId}`,
-      );
-      scopeId = req.routineId ?? req.sessionId;
+      // session.*, agent.*, user.*, routine.{tmp,home}: real authz
+      // delegated to a single helper that combines the
+      // workspace_folder_mounts row match with the logicalKey-specific
+      // ownership check.
+      scopeId = await this.authorizeNonDocumentLogicalKey(req, bot);
     }
 
     // Mint the folder9-scoped token.
@@ -354,14 +351,249 @@ export class FolderTokenService {
 
   private async loadActiveBotByUserId(
     botUserId: string,
-  ): Promise<{ userId: string } | null> {
+  ): Promise<BotIdentity | null> {
     const rows = await this.db
-      .select({ userId: schema.bots.userId })
+      .select({
+        id: schema.bots.id,
+        userId: schema.bots.userId,
+        managedMeta: schema.bots.managedMeta,
+      })
       .from(schema.bots)
       .where(
         and(eq(schema.bots.userId, botUserId), eq(schema.bots.isActive, true)),
       )
       .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    const managedAgentId =
+      row.managedMeta &&
+      typeof row.managedMeta === 'object' &&
+      typeof (row.managedMeta as { agentId?: unknown }).agentId === 'string'
+        ? (row.managedMeta as { agentId: string }).agentId
+        : null;
+    return { id: row.id, userId: row.userId, managedAgentId };
+  }
+
+  /**
+   * Real authz for `session.*`, `agent.*`, `user.*`, `routine.{tmp,home}`.
+   *
+   * Common gate: every non-document logicalKey requires a matching
+   * `workspace_folder_mounts` row (identified by workspaceId + folderId
+   * + scope + mountKey). Without one, the caller is unconditionally
+   * unauthorized — the row is what ties a Folder9 folderId to an audit
+   * scope inside team9.
+   *
+   * After the row match, scope-specific ownership tightens the gate:
+   *   - `agent.*`: the row's `scopeId` must match the bot's
+   *     `managedMeta.agentId`.
+   *   - `session.*`: the sessionId must parse, the parsed `agentId`
+   *     must match the bot's managed agent, and the row's `scopeId`
+   *     must match the request's `sessionId`.
+   *   - `user.*`: only valid for DM sessions — the parsed channel must
+   *     contain `req.userId`, and the row's `scopeId` must match
+   *     `req.userId`.
+   *   - `routine.{tmp,home}`: `req.routineId` must be present, the
+   *     `routines` row must exist + be owned by the caller bot
+   *     (`routines.botId === bot.id`), and the row's `scopeId` must
+   *     match `req.routineId`.
+   *
+   * Returns the resolved audit `scopeId` (used for folder9 token
+   * naming + logging).
+   */
+  private async authorizeNonDocumentLogicalKey(
+    req: FolderTokenRequestDto,
+    bot: BotIdentity,
+  ): Promise<string> {
+    const mountKey = req.logicalKey.split('.')[1];
+    const scope = req.logicalKey.split('.')[0];
+    const mountRow = await this.findWorkspaceFolderMount(
+      req.workspaceId,
+      req.folderId,
+      scope,
+      mountKey,
+    );
+    if (!mountRow) {
+      throw new ForbiddenException(
+        'No workspace_folder_mounts row matches (workspaceId, folderId, ' +
+          'scope, mountKey) — caller is not authorized for this folder',
+      );
+    }
+
+    switch (req.logicalKey) {
+      case 'agent.tmp':
+      case 'agent.home': {
+        if (!bot.managedAgentId) {
+          throw new ForbiddenException(
+            'Caller bot has no managed agent — agent.* not allowed',
+          );
+        }
+        if (mountRow.scopeId !== bot.managedAgentId) {
+          throw new ForbiddenException(
+            'agent.* mount row belongs to a different agent',
+          );
+        }
+        return mountRow.scopeId;
+      }
+
+      case 'session.tmp':
+      case 'session.home': {
+        const shape = parseSessionShape(req.sessionId);
+        if (shape.kind === 'unknown') {
+          throw new ForbiddenException(`Unparseable sessionId for session.*`);
+        }
+        if (!bot.managedAgentId || shape.agentId !== bot.managedAgentId) {
+          throw new ForbiddenException(
+            'sessionId does not belong to caller bot',
+          );
+        }
+        if (mountRow.scopeId !== req.sessionId) {
+          throw new ForbiddenException(
+            'session.* mount row does not match sessionId',
+          );
+        }
+        return req.sessionId;
+      }
+
+      case 'user.tmp':
+      case 'user.home': {
+        const shape = parseSessionShape(req.sessionId);
+        if (shape.kind !== 'dm') {
+          throw new ForbiddenException('user.* is only valid for DM sessions');
+        }
+        if (req.userId === undefined) {
+          throw new ForbiddenException('user.* requires userId');
+        }
+        const isMember = await this.isUserMemberOfChannel(
+          shape.channelId,
+          req.userId,
+        );
+        if (!isMember) {
+          throw new ForbiddenException(
+            'userId is not a member of the DM channel',
+          );
+        }
+        if (mountRow.scopeId !== req.userId) {
+          throw new ForbiddenException(
+            'user.* mount row does not match userId',
+          );
+        }
+        return req.userId;
+      }
+
+      case 'routine.tmp':
+      case 'routine.home': {
+        if (req.routineId === undefined) {
+          throw new ForbiddenException('routine.{tmp,home} requires routineId');
+        }
+        const routine = await this.loadRoutineByIdAndBot(req.routineId, bot.id);
+        if (!routine) {
+          throw new ForbiddenException(
+            'Routine not found or not owned by caller bot',
+          );
+        }
+        if (mountRow.scopeId !== req.routineId) {
+          throw new ForbiddenException(
+            'routine.* mount row does not match routineId',
+          );
+        }
+        return req.routineId;
+      }
+
+      default:
+        // Defense-in-depth — KNOWN_LOGICAL_KEYS already screens the
+        // request earlier, and `routine.document` is handled before
+        // this helper runs. Anything else here is a server-side bug.
+        throw new ForbiddenException(
+          `Unsupported logicalKey for non-document authz: ${req.logicalKey}`,
+        );
+    }
+  }
+
+  /**
+   * Lookup helper for the `workspace_folder_mounts` row that backs a
+   * non-document logicalKey. Lookup is keyed by
+   * (workspaceId, folder9FolderId, scope, mountKey) — the unique index
+   * on the table makes this an indexed lookup.
+   */
+  private async findWorkspaceFolderMount(
+    workspaceId: string,
+    folder9FolderId: string,
+    scope: string,
+    mountKey: string,
+  ): Promise<{ scopeId: string; folderType: string } | null> {
+    const rows = await this.db
+      .select({
+        scopeId: schema.workspaceFolderMounts.scopeId,
+        folderType: schema.workspaceFolderMounts.folderType,
+      })
+      .from(schema.workspaceFolderMounts)
+      .where(
+        and(
+          eq(schema.workspaceFolderMounts.workspaceId, workspaceId),
+          eq(schema.workspaceFolderMounts.folder9FolderId, folder9FolderId),
+          eq(schema.workspaceFolderMounts.scope, scope),
+          eq(schema.workspaceFolderMounts.mountKey, mountKey),
+        ),
+      )
+      .limit(1);
     return rows[0] ?? null;
   }
+
+  /**
+   * Direct DB membership probe — mirrors the inline pattern in
+   * `FileService.canAccessFile` so we don't drag a full `ChannelsService`
+   * dependency into this module just for one boolean check. The unique
+   * `(channel_id, user_id)` index makes this a single-row lookup.
+   */
+  private async isUserMemberOfChannel(
+    channelId: string,
+    userId: string,
+  ): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: schema.channelMembers.id })
+      .from(schema.channelMembers)
+      .where(
+        and(
+          eq(schema.channelMembers.channelId, channelId),
+          eq(schema.channelMembers.userId, userId),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /**
+   * Lookup a routine constrained by both `id` and `botId` — collapses
+   * "exists" + "owned by caller bot" into a single round-trip. Returns
+   * `null` if either condition fails.
+   */
+  private async loadRoutineByIdAndBot(
+    routineId: string,
+    botId: string,
+  ): Promise<{ id: string } | null> {
+    const rows = await this.db
+      .select({ id: schema.routines.id })
+      .from(schema.routines)
+      .where(
+        and(
+          eq(schema.routines.id, routineId),
+          eq(schema.routines.botId, botId),
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+}
+
+/**
+ * Caller-bot identity loaded once at the top of {@link FolderTokenService.issueToken}
+ * and threaded into every authz helper. `id` is the `im_bots.id` PK,
+ * `userId` is the shadow user (matches the JWT `sub`), `managedAgentId`
+ * is `managedMeta.agentId` lifted out and narrowed to `string | null`
+ * so callers don't need to re-parse the jsonb on every check.
+ */
+interface BotIdentity {
+  id: string;
+  userId: string;
+  managedAgentId: string | null;
 }

--- a/apps/server/apps/gateway/src/folder9/folder9.module.ts
+++ b/apps/server/apps/gateway/src/folder9/folder9.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@team9/database';
 import { AuthModule } from '../auth/auth.module.js';
 import { WikisModule } from '../wikis/wikis.module.js';
+import { FolderMapBuilder } from './folder-map-builder.service.js';
 import { FolderMountResolver } from './folder-mount-resolver.service.js';
 import { FolderTokenController } from './folder-token.controller.js';
 import { FolderTokenService } from './folder-token.service.js';
@@ -22,7 +23,7 @@ import { FolderTokenService } from './folder-token.service.js';
 @Module({
   imports: [DatabaseModule, AuthModule, WikisModule],
   controllers: [FolderTokenController],
-  providers: [FolderTokenService, FolderMountResolver],
-  exports: [FolderTokenService, FolderMountResolver],
+  providers: [FolderTokenService, FolderMountResolver, FolderMapBuilder],
+  exports: [FolderTokenService, FolderMountResolver, FolderMapBuilder],
 })
 export class Folder9Module {}

--- a/apps/server/apps/gateway/src/folder9/folder9.module.ts
+++ b/apps/server/apps/gateway/src/folder9/folder9.module.ts
@@ -2,7 +2,9 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@team9/database';
 import { AuthModule } from '../auth/auth.module.js';
 import { WikisModule } from '../wikis/wikis.module.js';
+import { BotAgentOwnership } from './bot-agent-ownership.service.js';
 import { FolderMapBuilder } from './folder-map-builder.service.js';
+import { FolderMapController } from './folder-map.controller.js';
 import { FolderMountResolver } from './folder-mount-resolver.service.js';
 import { FolderTokenController } from './folder-token.controller.js';
 import { FolderTokenService } from './folder-token.service.js';
@@ -12,18 +14,29 @@ import { FolderTokenService } from './folder-token.service.js';
  * the routines subsystem (skill folders) and the agent-pi runtime
  * (JustBashTeam9WorkspaceComponent mount issuance).
  *
- * Today it hosts `POST /api/v1/bot/folder-token` — the dynamic
- * Folder9 token-issuance endpoint that replaces the pre-minted
- * tokens formerly shipped in `startCreationSession`'s componentConfigs.
+ * Today it hosts:
+ * - `POST /api/v1/bot/folder-token` — dynamic Folder9 token issuance.
+ * - `POST /api/v1/bot/folder-map` — per-session folderMap with lazy
+ *   provisioning of `workspace_folder_mounts` rows.
  *
  * `WikisModule` is imported because it exports `Folder9ClientService`
  * (shared folder9 HTTP client). `AuthModule` provides the bot-auth
- * guard stack (`AuthGuard`) used by the controller.
+ * guard stack (`AuthGuard`) used by the controllers.
  */
 @Module({
   imports: [DatabaseModule, AuthModule, WikisModule],
-  controllers: [FolderTokenController],
-  providers: [FolderTokenService, FolderMountResolver, FolderMapBuilder],
-  exports: [FolderTokenService, FolderMountResolver, FolderMapBuilder],
+  controllers: [FolderTokenController, FolderMapController],
+  providers: [
+    FolderTokenService,
+    FolderMountResolver,
+    FolderMapBuilder,
+    BotAgentOwnership,
+  ],
+  exports: [
+    FolderTokenService,
+    FolderMountResolver,
+    FolderMapBuilder,
+    BotAgentOwnership,
+  ],
 })
 export class Folder9Module {}

--- a/apps/server/apps/gateway/src/folder9/folder9.module.ts
+++ b/apps/server/apps/gateway/src/folder9/folder9.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@team9/database';
 import { AuthModule } from '../auth/auth.module.js';
 import { WikisModule } from '../wikis/wikis.module.js';
+import { FolderMountResolver } from './folder-mount-resolver.service.js';
 import { FolderTokenController } from './folder-token.controller.js';
 import { FolderTokenService } from './folder-token.service.js';
 
@@ -21,7 +22,7 @@ import { FolderTokenService } from './folder-token.service.js';
 @Module({
   imports: [DatabaseModule, AuthModule, WikisModule],
   controllers: [FolderTokenController],
-  providers: [FolderTokenService],
-  exports: [FolderTokenService],
+  providers: [FolderTokenService, FolderMountResolver],
+  exports: [FolderTokenService, FolderMountResolver],
 })
 export class Folder9Module {}

--- a/apps/server/apps/gateway/src/folder9/parse-session-shape.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/parse-session-shape.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseSessionShape } from './parse-session-shape.js';
+
+// `parseSessionShape` is a pure string parser, so tests are direct
+// input/output assertions — no mocks, no Nest harness. We deliberately
+// cover every branch of the switch + every early-return path so the
+// 100% branch coverage requirement holds without relying on
+// `FolderMapBuilder` to also exercise the parser.
+
+describe('parseSessionShape', () => {
+  it('parses dm scope', () => {
+    expect(parseSessionShape('team9/ten-1/agent-x/dm/C_123')).toEqual({
+      kind: 'dm',
+      tenantId: 'ten-1',
+      agentId: 'agent-x',
+      channelId: 'C_123',
+    });
+  });
+
+  it('parses channel scope', () => {
+    expect(parseSessionShape('team9/ten-1/agent-x/channel/C_pub')).toEqual({
+      kind: 'channel',
+      tenantId: 'ten-1',
+      agentId: 'agent-x',
+      channelId: 'C_pub',
+    });
+  });
+
+  it('parses routine scope', () => {
+    expect(parseSessionShape('team9/ten-1/agent-x/routine/r-7')).toEqual({
+      kind: 'routine',
+      tenantId: 'ten-1',
+      agentId: 'agent-x',
+      routineId: 'r-7',
+    });
+  });
+
+  it('parses topic scope', () => {
+    expect(parseSessionShape('team9/ten-1/agent-x/topic/t-42')).toEqual({
+      kind: 'topic',
+      tenantId: 'ten-1',
+      agentId: 'agent-x',
+      topicId: 't-42',
+    });
+  });
+
+  it('returns unknown on missing team9 prefix', () => {
+    // First segment must literally be `team9` — anything else is
+    // treated as foreign traffic (e.g. older sessionId schemes).
+    expect(parseSessionShape('foo/ten/agent/dm/C')).toEqual({
+      kind: 'unknown',
+    });
+  });
+
+  it('returns unknown when there are too few parts', () => {
+    // Need at least 5 segments to extract scopeId; a 4-segment id
+    // (no scopeId) is malformed.
+    expect(parseSessionShape('team9/ten/agent/dm')).toEqual({
+      kind: 'unknown',
+    });
+  });
+
+  it('returns unknown on unrecognized scope', () => {
+    // Scope must be one of dm/channel/routine/topic — the default
+    // arm of the switch falls through to `unknown`.
+    expect(parseSessionShape('team9/ten/agent/weird/X')).toEqual({
+      kind: 'unknown',
+    });
+  });
+
+  it('preserves slashes inside scopeId', () => {
+    // Slashes after the 4th separator are part of the scopeId.
+    // This guards against accidentally truncating multi-segment ids.
+    expect(parseSessionShape('team9/ten/agent/channel/C/sub/path')).toEqual({
+      kind: 'channel',
+      tenantId: 'ten',
+      agentId: 'agent',
+      channelId: 'C/sub/path',
+    });
+  });
+
+  it('returns unknown when scopeId is empty', () => {
+    // Trailing slash with nothing after it produces an empty
+    // scopeId, which we treat as malformed rather than letting an
+    // empty string flow through to `channelId` / `routineId`.
+    expect(parseSessionShape('team9/ten/agent/dm/')).toEqual({
+      kind: 'unknown',
+    });
+  });
+});

--- a/apps/server/apps/gateway/src/folder9/parse-session-shape.ts
+++ b/apps/server/apps/gateway/src/folder9/parse-session-shape.ts
@@ -1,0 +1,48 @@
+/**
+ * Discriminated union describing the shape of a team9 sessionId.
+ *
+ * sessionIds follow the canonical layout:
+ *   `team9/{tenantId}/{agentId}/{scope}/{scopeId...}`
+ *
+ * Anything that doesn't match — wrong prefix, missing segments, or an
+ * unrecognized scope — collapses to `{kind: 'unknown'}` so callers can
+ * decide whether to reject (e.g. `FolderMapBuilder` throws BadRequest)
+ * or silently ignore (other consumers may treat unknown sessions as
+ * non-team9 traffic).
+ */
+export type SessionShape =
+  | { kind: 'dm'; tenantId: string; agentId: string; channelId: string }
+  | { kind: 'channel'; tenantId: string; agentId: string; channelId: string }
+  | { kind: 'routine'; tenantId: string; agentId: string; routineId: string }
+  | { kind: 'topic'; tenantId: string; agentId: string; topicId: string }
+  | { kind: 'unknown' };
+
+/**
+ * Pure parser — no side effects, no I/O. Splits a sessionId into its
+ * tenant/agent/scope tuple and returns a discriminated union the
+ * folder-map / token authz layers can switch on.
+ *
+ * Any segment after the 4th `/` is folded into `scopeId` (so paths like
+ * `team9/ten/agent/channel/C/sub/path` keep the trailing `C/sub/path`
+ * intact rather than dropping it). Empty `scopeId` is treated as
+ * malformed.
+ */
+export function parseSessionShape(sessionId: string): SessionShape {
+  const parts = sessionId.split('/');
+  if (parts.length < 5 || parts[0] !== 'team9') return { kind: 'unknown' };
+  const [, tenantId, agentId, scope, ...rest] = parts;
+  const scopeId = rest.join('/');
+  if (!scopeId) return { kind: 'unknown' };
+  switch (scope) {
+    case 'dm':
+      return { kind: 'dm', tenantId, agentId, channelId: scopeId };
+    case 'channel':
+      return { kind: 'channel', tenantId, agentId, channelId: scopeId };
+    case 'routine':
+      return { kind: 'routine', tenantId, agentId, routineId: scopeId };
+    case 'topic':
+      return { kind: 'topic', tenantId, agentId, topicId: scopeId };
+    default:
+      return { kind: 'unknown' };
+  }
+}

--- a/apps/server/libs/database/migrations/0055_workspace_folder_mounts.sql
+++ b/apps/server/libs/database/migrations/0055_workspace_folder_mounts.sql
@@ -1,0 +1,20 @@
+-- workspace_folder_mounts: idempotent registry mapping
+--   (workspace_id, scope, scope_id, mount_key) -> folder9_folder_id
+-- Backs the JustBashTeam9WorkspaceComponent virtual workspace mount layer
+-- (session.*, agent.*, user.*, routine.tmp, routine.home). Lazy-provisioned
+-- by FolderMountResolver: SELECT first; on miss, create via Folder9 and
+-- INSERT ... ON CONFLICT DO NOTHING. The unique index is the idempotency
+-- guard (race-safe).
+CREATE TABLE "workspace_folder_mounts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"scope" varchar(32) NOT NULL,
+	"scope_id" varchar(128) NOT NULL,
+	"mount_key" varchar(32) NOT NULL,
+	"folder_type" varchar(16) NOT NULL,
+	"folder9_folder_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "workspace_folder_mounts" ADD CONSTRAINT "workspace_folder_mounts_workspace_id_tenants_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "workspace_folder_mounts_unique" ON "workspace_folder_mounts" USING btree ("workspace_id","scope","scope_id","mount_key");

--- a/apps/server/libs/database/migrations/meta/0055_snapshot.json
+++ b/apps/server/libs/database/migrations/meta/0055_snapshot.json
@@ -1,0 +1,8192 @@
+{
+  "id": "afe4ccf7-4d7b-4e41-a760-e2817a2564f8",
+  "prevId": "85d56542-f18c-4938-8f8c-e403548ffa86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_suggestions": {
+      "name": "document_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "document_suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_version_id": {
+          "name": "result_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_document_suggestions_document_id": {
+          "name": "idx_document_suggestions_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_suggestions_status": {
+          "name": "idx_document_suggestions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_suggestions_document_id_documents_id_fk": {
+          "name": "document_suggestions_document_id_documents_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_suggestions_from_version_id_document_versions_id_fk": {
+          "name": "document_suggestions_from_version_id_document_versions_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["from_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_suggestions_result_version_id_document_versions_id_fk": {
+          "name": "document_suggestions_result_version_id_document_versions_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["result_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_versions": {
+      "name": "document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_index": {
+          "name": "version_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_document_versions_document_id": {
+          "name": "idx_document_versions_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_document_id_documents_id_fk": {
+          "name": "document_versions_document_id_documents_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_document_versions_doc_version": {
+          "name": "uq_document_versions_doc_version",
+          "nullsNotDistinct": false,
+          "columns": ["document_id", "version_index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privileges": {
+          "name": "privileges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_documents_tenant_id": {
+          "name": "idx_documents_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_document_type": {
+          "name": "idx_documents_document_type",
+          "columns": [
+            {
+              "expression": "document_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_tenant_id_tenants_id_fk": {
+          "name": "documents_tenant_id_tenants_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_folder_mounts": {
+      "name": "workspace_folder_mounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_key": {
+          "name": "mount_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_type": {
+          "name": "folder_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder9_folder_id": {
+          "name": "folder9_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_folder_mounts_unique": {
+          "name": "workspace_folder_mounts_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_folder_mounts_workspace_id_tenants_id_fk": {
+          "name": "workspace_folder_mounts_workspace_id_tenants_id_fk",
+          "tableFrom": "workspace_folder_mounts",
+          "tableTo": "tenants",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_ahand_devices": {
+      "name": "im_ahand_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hub_device_id": {
+          "name": "hub_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ahand_devices_owner_idx": {
+          "name": "ahand_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ahand_devices_status_idx": {
+          "name": "ahand_devices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_ahand_devices_hub_device_id_unique": {
+          "name": "im_ahand_devices_hub_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hub_device_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_audit_logs": {
+      "name": "im_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_channel_created": {
+          "name": "idx_audit_logs_channel_created",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_entity": {
+          "name": "idx_audit_logs_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_performer": {
+          "name": "idx_audit_logs_performer",
+          "columns": [
+            {
+              "expression": "performed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_audit_logs_channel_id_im_channels_id_fk": {
+          "name": "im_audit_logs_channel_id_im_channels_id_fk",
+          "tableFrom": "im_audit_logs",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_audit_logs_performed_by_im_users_id_fk": {
+          "name": "im_audit_logs_performed_by_im_users_id_fk",
+          "tableFrom": "im_audit_logs",
+          "tableTo": "im_users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_bots": {
+      "name": "im_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "bot_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_application_id": {
+          "name": "installed_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_headers": {
+          "name": "webhook_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "managed_provider": {
+          "name": "managed_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_meta": {
+          "name": "managed_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bots_user_id": {
+          "name": "idx_bots_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_type": {
+          "name": "idx_bots_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_owner_id": {
+          "name": "idx_bots_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_mentor_id": {
+          "name": "idx_bots_mentor_id",
+          "columns": [
+            {
+              "expression": "mentor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_installed_application_id": {
+          "name": "idx_bots_installed_application_id",
+          "columns": [
+            {
+              "expression": "installed_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_access_token": {
+          "name": "idx_bots_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bots_owner_app_unique": {
+          "name": "bots_owner_app_unique",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installed_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bots\".\"owner_id\" IS NOT NULL AND \"im_bots\".\"installed_application_id\" IS NOT NULL AND \"im_bots\".\"extra\"->>'personalStaff' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bots_user_id_im_users_id_fk": {
+          "name": "im_bots_user_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_bots_owner_id_im_users_id_fk": {
+          "name": "im_bots_owner_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bots_mentor_id_im_users_id_fk": {
+          "name": "im_bots_mentor_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["mentor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bots_installed_application_id_im_installed_applications_id_fk": {
+          "name": "im_bots_installed_application_id_im_installed_applications_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_installed_applications",
+          "columnsFrom": ["installed_application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_bots_user_id_unique": {
+          "name": "im_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_members": {
+      "name": "im_channel_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_dm_sidebar": {
+          "name": "show_in_dm_sidebar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_channel_members_user_id": {
+          "name": "idx_channel_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_members_channel_id_im_channels_id_fk": {
+          "name": "im_channel_members_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_members",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_members_user_id_im_users_id_fk": {
+          "name": "im_channel_members_user_id_im_users_id_fk",
+          "tableFrom": "im_channel_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_channel_user": {
+          "name": "unique_channel_user",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_property_definitions": {
+      "name": "im_channel_property_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "property_value_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_native": {
+          "name": "is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_auto_fill": {
+          "name": "ai_auto_fill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ai_auto_fill_prompt": {
+          "name": "ai_auto_fill_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_chat_policy": {
+          "name": "show_in_chat_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "allow_new_options": {
+          "name": "allow_new_options",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_property_def_order": {
+          "name": "idx_channel_property_def_order",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_property_definitions_channel_id_im_channels_id_fk": {
+          "name": "im_channel_property_definitions_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_property_definitions",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_property_definitions_created_by_im_users_id_fk": {
+          "name": "im_channel_property_definitions_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_property_definitions",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_channel_property_def_key": {
+          "name": "uq_channel_property_def_key",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_sections": {
+      "name": "im_channel_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_sections_tenant": {
+          "name": "idx_channel_sections_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_sections_tenant_id_tenants_id_fk": {
+          "name": "im_channel_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "im_channel_sections",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_sections_created_by_im_users_id_fk": {
+          "name": "im_channel_sections_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_sections",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_tabs": {
+      "name": "im_channel_tabs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_id": {
+          "name": "view_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_tabs_channel": {
+          "name": "idx_channel_tabs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_tabs_channel_id_im_channels_id_fk": {
+          "name": "im_channel_tabs_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_tabs_view_id_im_channel_views_id_fk": {
+          "name": "im_channel_tabs_view_id_im_channel_views_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_channel_views",
+          "columnsFrom": ["view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_channel_tabs_created_by_im_users_id_fk": {
+          "name": "im_channel_tabs_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_views": {
+      "name": "im_channel_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_views_channel": {
+          "name": "idx_channel_views_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_views_channel_id_im_channels_id_fk": {
+          "name": "im_channel_views_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_views",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_views_created_by_im_users_id_fk": {
+          "name": "im_channel_views_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_views",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channels": {
+      "name": "im_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_activated": {
+          "name": "is_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_settings": {
+          "name": "property_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channels_tenant": {
+          "name": "idx_channels_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channels_tenant_id_tenants_id_fk": {
+          "name": "im_channels_tenant_id_tenants_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channels_created_by_im_users_id_fk": {
+          "name": "im_channels_created_by_im_users_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_channels_section_id_im_channel_sections_id_fk": {
+          "name": "im_channels_section_id_im_channel_sections_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "im_channel_sections",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_email_verification_tokens": {
+      "name": "im_email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_verification_tokens_user_id": {
+          "name": "idx_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verification_tokens_token": {
+          "name": "idx_verification_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verification_tokens_expires_at": {
+          "name": "idx_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_email_verification_tokens_user_id_im_users_id_fk": {
+          "name": "im_email_verification_tokens_user_id_im_users_id_fk",
+          "tableFrom": "im_email_verification_tokens",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_email_verification_tokens_token_unique": {
+          "name": "im_email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_files": {
+      "name": "im_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "file_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_files_key": {
+          "name": "idx_files_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_tenant": {
+          "name": "idx_files_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_channel": {
+          "name": "idx_files_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_uploader": {
+          "name": "idx_files_uploader",
+          "columns": [
+            {
+              "expression": "uploader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_files_tenant_id_tenants_id_fk": {
+          "name": "im_files_tenant_id_tenants_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_files_channel_id_im_channels_id_fk": {
+          "name": "im_files_channel_id_im_channels_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_files_uploader_id_im_users_id_fk": {
+          "name": "im_files_uploader_id_im_users_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "im_users",
+          "columnsFrom": ["uploader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_hive_send_failures": {
+      "name": "im_hive_send_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_channel_id": {
+          "name": "tracking_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hive_send_failures_msg_bot_unique": {
+          "name": "hive_send_failures_msg_bot_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_agent_idx": {
+          "name": "hive_send_failures_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_tenant_idx": {
+          "name": "hive_send_failures_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_last_seen_idx": {
+          "name": "hive_send_failures_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_hive_send_failures_message_id_im_messages_id_fk": {
+          "name": "im_hive_send_failures_message_id_im_messages_id_fk",
+          "tableFrom": "im_hive_send_failures",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_hive_send_failures_bot_id_im_bots_id_fk": {
+          "name": "im_hive_send_failures_bot_id_im_bots_id_fk",
+          "tableFrom": "im_hive_send_failures",
+          "tableTo": "im_bots",
+          "columnsFrom": ["bot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_users": {
+      "name": "im_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'human'"
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_users_email_unique": {
+          "name": "im_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "im_users_username_unique": {
+          "name": "im_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_email_change_requests": {
+      "name": "im_user_email_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_email": {
+          "name": "current_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_email_change_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_email_change_requests_user_id": {
+          "name": "idx_user_email_change_requests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_email_change_requests_status": {
+          "name": "idx_user_email_change_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_email_change_requests_expires_at": {
+          "name": "idx_user_email_change_requests_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_user_email_change_requests_pending_user": {
+          "name": "uq_user_email_change_requests_pending_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_user_email_change_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_user_email_change_requests_pending_new_email": {
+          "name": "uq_user_email_change_requests_pending_new_email",
+          "columns": [
+            {
+              "expression": "new_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_user_email_change_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_email_change_requests_user_id_im_users_id_fk": {
+          "name": "im_user_email_change_requests_user_id_im_users_id_fk",
+          "tableFrom": "im_user_email_change_requests",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_user_email_change_requests_token_hash_unique": {
+          "name": "im_user_email_change_requests_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_id": {
+          "name": "root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_ast": {
+          "name": "content_ast",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_msg_id": {
+          "name": "client_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_messages_channel_id": {
+          "name": "idx_messages_channel_id",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_parent_id": {
+          "name": "idx_messages_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_root_id": {
+          "name": "idx_messages_root_id",
+          "columns": [
+            {
+              "expression": "root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_seq_id": {
+          "name": "idx_messages_seq_id",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_client_msg_id": {
+          "name": "idx_messages_client_msg_id",
+          "columns": [
+            {
+              "expression": "client_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_channel_id_im_channels_id_fk": {
+          "name": "im_messages_channel_id_im_channels_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_messages_sender_id_im_users_id_fk": {
+          "name": "im_messages_sender_id_im_users_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_users",
+          "columnsFrom": ["sender_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_attachments": {
+      "name": "im_message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_attachments_message_id": {
+          "name": "idx_message_attachments_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_attachments_message_id_im_messages_id_fk": {
+          "name": "im_message_attachments_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_attachments",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_reactions": {
+      "name": "im_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_message_reactions_message_id_im_messages_id_fk": {
+          "name": "im_message_reactions_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_reactions",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_reactions_user_id_im_users_id_fk": {
+          "name": "im_message_reactions_user_id_im_users_id_fk",
+          "tableFrom": "im_message_reactions",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "user_id", "emoji"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_acks": {
+      "name": "im_message_acks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ack_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_acks_message_id": {
+          "name": "idx_message_acks_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_user_id": {
+          "name": "idx_message_acks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_status": {
+          "name": "idx_message_acks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_retry": {
+          "name": "idx_message_acks_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_acks_message_id_im_messages_id_fk": {
+          "name": "im_message_acks_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_acks",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_acks_user_id_im_users_id_fk": {
+          "name": "im_message_acks_user_id_im_users_id_fk",
+          "tableFrom": "im_message_acks",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_message_user_ack": {
+          "name": "unique_message_user_ack",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_outbox": {
+      "name": "im_message_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "outbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_outbox_status": {
+          "name": "idx_outbox_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_created": {
+          "name": "idx_outbox_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_message_id": {
+          "name": "idx_outbox_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_status_created": {
+          "name": "idx_outbox_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_outbox_message_id_im_messages_id_fk": {
+          "name": "im_message_outbox_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_outbox",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_channel_read_status": {
+      "name": "im_user_channel_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_seq_id": {
+          "name": "last_sync_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_user_channel_read_status_user_id_im_users_id_fk": {
+          "name": "im_user_channel_read_status_user_id_im_users_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_user_channel_read_status_channel_id_im_channels_id_fk": {
+          "name": "im_user_channel_read_status_channel_id_im_channels_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_user_channel_read_status_last_read_message_id_im_messages_id_fk": {
+          "name": "im_user_channel_read_status_last_read_message_id_im_messages_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_messages",
+          "columnsFrom": ["last_read_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_channel_read": {
+          "name": "unique_user_channel_read",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_notifications": {
+      "name": "im_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "notification_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_category": {
+          "name": "idx_notifications_user_category",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_type": {
+          "name": "idx_notifications_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires": {
+          "name": "idx_notifications_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_reference": {
+          "name": "idx_notifications_reference",
+          "columns": [
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_message": {
+          "name": "idx_notifications_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_channel": {
+          "name": "idx_notifications_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_notifications_user_id_im_users_id_fk": {
+          "name": "im_notifications_user_id_im_users_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_actor_id_im_users_id_fk": {
+          "name": "im_notifications_actor_id_im_users_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_notifications_tenant_id_tenants_id_fk": {
+          "name": "im_notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_channel_id_im_channels_id_fk": {
+          "name": "im_notifications_channel_id_im_channels_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_message_id_im_messages_id_fk": {
+          "name": "im_notifications_message_id_im_messages_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_notification_mutes": {
+      "name": "im_channel_notification_mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_mutes_user": {
+          "name": "idx_channel_mutes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_mutes_channel": {
+          "name": "idx_channel_mutes_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_notification_mutes_user_id_im_users_id_fk": {
+          "name": "im_channel_notification_mutes_user_id_im_users_id_fk",
+          "tableFrom": "im_channel_notification_mutes",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_notification_mutes_channel_id_im_channels_id_fk": {
+          "name": "im_channel_notification_mutes_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_notification_mutes",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_channel_notification_mute": {
+          "name": "unique_channel_notification_mute",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_notification_preferences": {
+      "name": "im_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions_enabled": {
+          "name": "mentions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "replies_enabled": {
+          "name": "replies_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dms_enabled": {
+          "name": "dms_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "system_enabled": {
+          "name": "system_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "workspace_enabled": {
+          "name": "workspace_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "desktop_enabled": {
+          "name": "desktop_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sound_enabled": {
+          "name": "sound_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dnd_enabled": {
+          "name": "dnd_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dnd_start": {
+          "name": "dnd_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dnd_end": {
+          "name": "dnd_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_notification_preferences_user_id_im_users_id_fk": {
+          "name": "im_notification_preferences_user_id_im_users_id_fk",
+          "tableFrom": "im_notification_preferences",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_notification_preferences": {
+          "name": "unique_user_notification_preferences",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_search": {
+      "name": "im_channel_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_created_at": {
+          "name": "channel_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_search_vector": {
+          "name": "idx_channel_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_channel_search_tenant": {
+          "name": "idx_channel_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_search_type": {
+          "name": "idx_channel_search_type",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_search_channel_id_im_channels_id_fk": {
+          "name": "im_channel_search_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_search",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_channel_search_channel_id_unique": {
+          "name": "im_channel_search_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_file_search": {
+      "name": "im_file_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_username": {
+          "name": "uploader_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_file_search_vector": {
+          "name": "idx_file_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_file_search_channel": {
+          "name": "idx_file_search_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_file_search_tenant": {
+          "name": "idx_file_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_file_search_mime": {
+          "name": "idx_file_search_mime",
+          "columns": [
+            {
+              "expression": "mime_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_file_search_file_id_im_files_id_fk": {
+          "name": "im_file_search_file_id_im_files_id_fk",
+          "tableFrom": "im_file_search",
+          "tableTo": "im_files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_file_search_file_id_unique": {
+          "name": "im_file_search_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_search": {
+      "name": "im_message_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_username": {
+          "name": "sender_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_attachment": {
+          "name": "has_attachment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_thread_reply": {
+          "name": "is_thread_reply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_created_at": {
+          "name": "message_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_search_vector": {
+          "name": "idx_message_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_message_search_channel": {
+          "name": "idx_message_search_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_sender": {
+          "name": "idx_message_search_sender",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_tenant": {
+          "name": "idx_message_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_created": {
+          "name": "idx_message_search_created",
+          "columns": [
+            {
+              "expression": "message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_tenant_created": {
+          "name": "idx_message_search_tenant_created",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_search_message_id_im_messages_id_fk": {
+          "name": "im_message_search_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_search",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_message_search_message_id_unique": {
+          "name": "im_message_search_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["message_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_search": {
+      "name": "im_user_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_created_at": {
+          "name": "user_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_search_vector": {
+          "name": "idx_user_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_search_status": {
+          "name": "idx_user_search_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_search_user_id_im_users_id_fk": {
+          "name": "im_user_search_user_id_im_users_id_fk",
+          "tableFrom": "im_user_search",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_user_search_user_id_unique": {
+          "name": "im_user_search_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_installed_applications": {
+      "name": "im_installed_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "installed_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_installed_applications_tenant_id": {
+          "name": "idx_installed_applications_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_installed_applications_application_id": {
+          "name": "idx_installed_applications_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_installed_applications_status": {
+          "name": "idx_installed_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_installed_applications_installed_by_im_users_id_fk": {
+          "name": "im_installed_applications_installed_by_im_users_id_fk",
+          "tableFrom": "im_installed_applications",
+          "tableTo": "im_users",
+          "columnsFrom": ["installed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_push_subscriptions": {
+      "name": "im_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_push_sub_user": {
+          "name": "idx_push_sub_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_push_subscriptions_user_id_im_users_id_fk": {
+          "name": "im_push_subscriptions_user_id_im_users_id_fk",
+          "tableFrom": "im_push_subscriptions",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_push_endpoint": {
+          "name": "unique_push_endpoint",
+          "nullsNotDistinct": false,
+          "columns": ["endpoint"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_push_tokens": {
+      "name": "im_user_push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "push_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_push_tokens_user_id": {
+          "name": "idx_user_push_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_push_tokens_user_id_im_users_id_fk": {
+          "name": "im_user_push_tokens_user_id_im_users_id_fk",
+          "tableFrom": "im_user_push_tokens",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_push_token": {
+          "name": "uq_user_push_token",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_properties": {
+      "name": "im_message_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_definition_id": {
+          "name": "property_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_value": {
+          "name": "number_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean_value": {
+          "name": "boolean_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_value": {
+          "name": "date_value",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "json_value": {
+          "name": "json_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_props_message": {
+          "name": "idx_message_props_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_text": {
+          "name": "idx_message_props_def_text",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_number": {
+          "name": "idx_message_props_def_number",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_date": {
+          "name": "idx_message_props_def_date",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_boolean": {
+          "name": "idx_message_props_def_boolean",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "boolean_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_properties_message_id_im_messages_id_fk": {
+          "name": "im_message_properties_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_property_definition_id_im_channel_property_definitions_id_fk": {
+          "name": "im_message_properties_property_definition_id_im_channel_property_definitions_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_channel_property_definitions",
+          "columnsFrom": ["property_definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_created_by_im_users_id_fk": {
+          "name": "im_message_properties_created_by_im_users_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_updated_by_im_users_id_fk": {
+          "name": "im_message_properties_updated_by_im_users_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_message_property": {
+          "name": "uq_message_property",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "property_definition_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_relations": {
+      "name": "im_message_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_message_id": {
+          "name": "target_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_definition_id": {
+          "name": "property_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_kind": {
+          "name": "relation_kind",
+          "type": "relation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mr_source_kind": {
+          "name": "idx_mr_source_kind",
+          "columns": [
+            {
+              "expression": "source_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_target_kind": {
+          "name": "idx_mr_target_kind",
+          "columns": [
+            {
+              "expression": "target_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_channel_kind": {
+          "name": "idx_mr_channel_kind",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_propdef": {
+          "name": "idx_mr_propdef",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_relations_tenant_id_tenants_id_fk": {
+          "name": "im_message_relations_tenant_id_tenants_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_channel_id_im_channels_id_fk": {
+          "name": "im_message_relations_channel_id_im_channels_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_source_message_id_im_messages_id_fk": {
+          "name": "im_message_relations_source_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_messages",
+          "columnsFrom": ["source_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_target_message_id_im_messages_id_fk": {
+          "name": "im_message_relations_target_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_messages",
+          "columnsFrom": ["target_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_property_definition_id_im_channel_property_definitions_id_fk": {
+          "name": "im_message_relations_property_definition_id_im_channel_property_definitions_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_channel_property_definitions",
+          "columnsFrom": ["property_definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_created_by_im_users_id_fk": {
+          "name": "im_message_relations_created_by_im_users_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_message_relation_edge": {
+          "name": "uq_message_relation_edge",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_message_id",
+            "property_definition_id",
+            "target_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_message_relation_no_self": {
+          "name": "chk_message_relation_no_self",
+          "value": "\"im_message_relations\".\"source_message_id\" <> \"im_message_relations\".\"target_message_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "tenant_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenants_domain_unique": {
+          "name": "tenants_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_members": {
+      "name": "tenant_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_tenant_members_user_id": {
+          "name": "idx_tenant_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_members_tenant_id_tenants_id_fk": {
+          "name": "tenant_members_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_members_user_id_im_users_id_fk": {
+          "name": "tenant_members_user_id_im_users_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_members_invited_by_im_users_id_fk": {
+          "name": "tenant_members_invited_by_im_users_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_tenant_user": {
+          "name": "unique_tenant_user",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_usage": {
+      "name": "invitation_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_usage_invitation_id_workspace_invitations_id_fk": {
+          "name": "invitation_usage_invitation_id_workspace_invitations_id_fk",
+          "tableFrom": "invitation_usage",
+          "tableTo": "workspace_invitations",
+          "columnsFrom": ["invitation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_usage_user_id_im_users_id_fk": {
+          "name": "invitation_usage_user_id_im_users_id_fk",
+          "tableFrom": "invitation_usage",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_tenant_id": {
+          "name": "idx_workspace_invitations_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_tenant_id_tenants_id_fk": {
+          "name": "workspace_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_created_by_im_users_id_fk": {
+          "name": "workspace_invitations_created_by_im_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_code_unique": {
+          "name": "workspace_invitations_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_roles": {
+      "name": "onboarding_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_key": {
+          "name": "category_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_roles_category_idx": {
+          "name": "onboarding_roles_category_idx",
+          "columns": [
+            {
+              "expression": "category_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_roles_active_idx": {
+          "name": "onboarding_roles_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "onboarding_roles_slug_unique": {
+          "name": "onboarding_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_onboarding": {
+      "name": "workspace_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "step_data": {
+          "name": "step_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_onboarding_tenant_idx": {
+          "name": "workspace_onboarding_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_onboarding_user_idx": {
+          "name": "workspace_onboarding_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_onboarding_tenant_id_tenants_id_fk": {
+          "name": "workspace_onboarding_tenant_id_tenants_id_fk",
+          "tableFrom": "workspace_onboarding",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_onboarding_user_id_im_users_id_fk": {
+          "name": "workspace_onboarding_user_id_im_users_id_fk",
+          "tableFrom": "workspace_onboarding",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_onboarding_tenant_user_unique": {
+          "name": "workspace_onboarding_tenant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__routines": {
+      "name": "routine__routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "routine__schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'once'"
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_execution_id": {
+          "name": "current_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_channel_id": {
+          "name": "creation_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_session_id": {
+          "name": "creation_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__routines_tenant_id": {
+          "name": "idx_routine__routines_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_bot_id": {
+          "name": "idx_routine__routines_bot_id",
+          "columns": [
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_creator_id": {
+          "name": "idx_routine__routines_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_status": {
+          "name": "idx_routine__routines_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_next_run_at": {
+          "name": "idx_routine__routines_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_tenant_status": {
+          "name": "idx_routine__routines_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_creation_channel_id": {
+          "name": "idx_routine__routines_creation_channel_id",
+          "columns": [
+            {
+              "expression": "creation_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_source_ref": {
+          "name": "idx_routine__routines_source_ref",
+          "columns": [
+            {
+              "expression": "source_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__routines_tenant_id_tenants_id_fk": {
+          "name": "routine__routines_tenant_id_tenants_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__routines_bot_id_im_bots_id_fk": {
+          "name": "routine__routines_bot_id_im_bots_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_bots",
+          "columnsFrom": ["bot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__routines_creator_id_im_users_id_fk": {
+          "name": "routine__routines_creator_id_im_users_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__routines_document_id_documents_id_fk": {
+          "name": "routine__routines_document_id_documents_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__routines_creation_channel_id_im_channels_id_fk": {
+          "name": "routine__routines_creation_channel_id_im_channels_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_channels",
+          "columnsFrom": ["creation_channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__executions": {
+      "name": "routine__executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_version": {
+          "name": "routine_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskcast_task_id": {
+          "name": "taskcast_task_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_execution_id": {
+          "name": "source_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__executions_routine_id": {
+          "name": "idx_routine__executions_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__executions_status": {
+          "name": "idx_routine__executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__executions_routine_version": {
+          "name": "idx_routine__executions_routine_version",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "routine_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__executions_routine_id_routine__routines_id_fk": {
+          "name": "routine__executions_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__executions_channel_id_im_channels_id_fk": {
+          "name": "routine__executions_channel_id_im_channels_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__executions_trigger_id_routine__triggers_id_fk": {
+          "name": "routine__executions_trigger_id_routine__triggers_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "routine__triggers",
+          "columnsFrom": ["trigger_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__executions_document_version_id_document_versions_id_fk": {
+          "name": "routine__executions_document_version_id_document_versions_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["document_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_routine__executions_taskcast": {
+          "name": "uq_routine__executions_taskcast",
+          "nullsNotDistinct": false,
+          "columns": ["taskcast_task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__steps": {
+      "name": "routine__steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__steps_execution_id": {
+          "name": "idx_routine__steps_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__steps_routine_id": {
+          "name": "idx_routine__steps_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__steps_execution_id_routine__executions_id_fk": {
+          "name": "routine__steps_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__steps",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__steps_routine_id_routine__routines_id_fk": {
+          "name": "routine__steps_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__steps",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__deliverables": {
+      "name": "routine__deliverables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__deliverables_execution_id": {
+          "name": "idx_routine__deliverables_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__deliverables_routine_id": {
+          "name": "idx_routine__deliverables_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__deliverables_execution_id_routine__executions_id_fk": {
+          "name": "routine__deliverables_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__deliverables",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__deliverables_routine_id_routine__routines_id_fk": {
+          "name": "routine__deliverables_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__deliverables",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__interventions": {
+      "name": "routine__interventions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__intervention_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__interventions_execution_id": {
+          "name": "idx_routine__interventions_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__interventions_routine_id": {
+          "name": "idx_routine__interventions_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__interventions_status": {
+          "name": "idx_routine__interventions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__interventions_execution_id_routine__executions_id_fk": {
+          "name": "routine__interventions_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_routine_id_routine__routines_id_fk": {
+          "name": "routine__interventions_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_step_id_routine__steps_id_fk": {
+          "name": "routine__interventions_step_id_routine__steps_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_resolved_by_im_users_id_fk": {
+          "name": "routine__interventions_resolved_by_im_users_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "im_users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__triggers": {
+      "name": "routine__triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "routine__trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__triggers_routine_id": {
+          "name": "idx_routine__triggers_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__triggers_scan": {
+          "name": "idx_routine__triggers_scan",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__triggers_routine_id_routine__routines_id_fk": {
+          "name": "routine__triggers_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__triggers",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource__type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "authorizations": {
+          "name": "authorizations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_tenant_id": {
+          "name": "idx_resources_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_tenant_type": {
+          "name": "idx_resources_tenant_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_status": {
+          "name": "idx_resources_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_tenant_id_tenants_id_fk": {
+          "name": "resources_tenant_id_tenants_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_creator_id_im_users_id_fk": {
+          "name": "resources_creator_id_im_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_usage_logs": {
+      "name": "resource_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "resource__actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resource_usage_logs_resource_created": {
+          "name": "idx_resource_usage_logs_resource_created",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resource_usage_logs_actor_created": {
+          "name": "idx_resource_usage_logs_actor_created",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_usage_logs_resource_id_resources_id_fk": {
+          "name": "resource_usage_logs_resource_id_resources_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_usage_logs_routine_id_routine__routines_id_fk": {
+          "name": "resource_usage_logs_routine_id_routine__routines_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "resource_usage_logs_execution_id_routine__executions_id_fk": {
+          "name": "resource_usage_logs_execution_id_routine__executions_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "skill__type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_tenant_id": {
+          "name": "idx_skills_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_tenant_id_tenants_id_fk": {
+          "name": "skills_tenant_id_tenants_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skills_creator_id_im_users_id_fk": {
+          "name": "skills_creator_id_im_users_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_versions": {
+      "name": "skill_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "skill_version__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "file_manifest": {
+          "name": "file_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_versions_skill_version": {
+          "name": "idx_skill_versions_skill_version",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_versions_skill_id_skills_id_fk": {
+          "name": "skill_versions_skill_id_skills_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "skills",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_versions_creator_id_im_users_id_fk": {
+          "name": "skill_versions_creator_id_im_users_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_files": {
+      "name": "skill_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_files_skill_id": {
+          "name": "idx_skill_files_skill_id",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_files_skill_id_skills_id_fk": {
+          "name": "skill_files_skill_id_skills_id_fk",
+          "tableFrom": "skill_files",
+          "tableTo": "skills",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_wikis": {
+      "name": "workspace_wikis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder9_folder_id": {
+          "name": "folder9_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_mode": {
+          "name": "approval_mode",
+          "type": "wiki_approval_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "human_permission": {
+          "name": "human_permission",
+          "type": "wiki_permission_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'write'"
+        },
+        "agent_permission": {
+          "name": "agent_permission",
+          "type": "wiki_permission_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_wikis_workspace_slug_unique": {
+          "name": "workspace_wikis_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_wikis\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_wikis_folder9_unique": {
+          "name": "workspace_wikis_folder9_unique",
+          "columns": [
+            {
+              "expression": "folder9_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_wikis_workspace_idx": {
+          "name": "workspace_wikis_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_wikis_workspace_id_tenants_id_fk": {
+          "name": "workspace_wikis_workspace_id_tenants_id_fk",
+          "tableFrom": "workspace_wikis",
+          "tableTo": "tenants",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_suggestion_status": {
+      "name": "document_suggestion_status",
+      "schema": "public",
+      "values": ["pending", "approved", "rejected"]
+    },
+    "public.bot_type": {
+      "name": "bot_type",
+      "schema": "public",
+      "values": ["system", "custom", "webhook"]
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member"]
+    },
+    "public.property_value_type": {
+      "name": "property_value_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "number",
+        "boolean",
+        "single_select",
+        "multi_select",
+        "person",
+        "date",
+        "timestamp",
+        "date_range",
+        "timestamp_range",
+        "recurring",
+        "url",
+        "message_ref",
+        "file",
+        "image",
+        "tags"
+      ]
+    },
+    "public.channel_type": {
+      "name": "channel_type",
+      "schema": "public",
+      "values": [
+        "direct",
+        "public",
+        "private",
+        "task",
+        "tracking",
+        "echo",
+        "routine-session",
+        "topic-session"
+      ]
+    },
+    "public.file_visibility": {
+      "name": "file_visibility",
+      "schema": "public",
+      "values": ["private", "channel", "workspace", "public"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["online", "offline", "away", "busy"]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": ["human", "bot", "system"]
+    },
+    "public.user_email_change_request_status": {
+      "name": "user_email_change_request_status",
+      "schema": "public",
+      "values": ["pending", "confirmed", "cancelled", "expired"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["text", "file", "image", "system", "tracking", "long_text"]
+    },
+    "public.ack_status": {
+      "name": "ack_status",
+      "schema": "public",
+      "values": ["sent", "delivered", "read"]
+    },
+    "public.outbox_status": {
+      "name": "outbox_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.notification_category": {
+      "name": "notification_category",
+      "schema": "public",
+      "values": ["message", "system", "workspace"]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": ["low", "normal", "high", "urgent"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "mention",
+        "channel_mention",
+        "everyone_mention",
+        "here_mention",
+        "reply",
+        "thread_reply",
+        "dm_received",
+        "system_announcement",
+        "maintenance_notice",
+        "version_update",
+        "workspace_invitation",
+        "role_changed",
+        "member_joined",
+        "member_left",
+        "channel_invite"
+      ]
+    },
+    "public.installed_application_status": {
+      "name": "installed_application_status",
+      "schema": "public",
+      "values": ["active", "inactive", "pending", "error"]
+    },
+    "public.push_platform": {
+      "name": "push_platform",
+      "schema": "public",
+      "values": ["ios", "android"]
+    },
+    "public.relation_kind": {
+      "name": "relation_kind",
+      "schema": "public",
+      "values": ["parent", "related"]
+    },
+    "public.tenant_plan": {
+      "name": "tenant_plan",
+      "schema": "public",
+      "values": ["free", "pro", "enterprise"]
+    },
+    "public.tenant_role": {
+      "name": "tenant_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "guest"]
+    },
+    "public.routine__schedule_type": {
+      "name": "routine__schedule_type",
+      "schema": "public",
+      "values": ["once", "recurring"]
+    },
+    "public.routine__status": {
+      "name": "routine__status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "upcoming",
+        "in_progress",
+        "paused",
+        "pending_action",
+        "completed",
+        "failed",
+        "stopped",
+        "timeout"
+      ]
+    },
+    "public.routine__step_status": {
+      "name": "routine__step_status",
+      "schema": "public",
+      "values": ["pending", "in_progress", "completed", "failed"]
+    },
+    "public.routine__intervention_status": {
+      "name": "routine__intervention_status",
+      "schema": "public",
+      "values": ["pending", "resolved", "expired"]
+    },
+    "public.routine__trigger_type": {
+      "name": "routine__trigger_type",
+      "schema": "public",
+      "values": ["manual", "interval", "schedule", "channel_message"]
+    },
+    "public.resource__status": {
+      "name": "resource__status",
+      "schema": "public",
+      "values": ["online", "offline", "error", "configuring"]
+    },
+    "public.resource__type": {
+      "name": "resource__type",
+      "schema": "public",
+      "values": ["agent_computer", "api"]
+    },
+    "public.resource__actor_type": {
+      "name": "resource__actor_type",
+      "schema": "public",
+      "values": ["agent", "user"]
+    },
+    "public.skill__type": {
+      "name": "skill__type",
+      "schema": "public",
+      "values": ["claude_code_skill", "prompt_template", "general"]
+    },
+    "public.skill_version__status": {
+      "name": "skill_version__status",
+      "schema": "public",
+      "values": ["draft", "published", "suggested", "rejected"]
+    },
+    "public.wiki_approval_mode": {
+      "name": "wiki_approval_mode",
+      "schema": "public",
+      "values": ["auto", "review"]
+    },
+    "public.wiki_permission_level": {
+      "name": "wiki_permission_level",
+      "schema": "public",
+      "values": ["read", "propose", "write"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/libs/database/migrations/meta/_journal.json
+++ b/apps/server/libs/database/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1777708800000,
       "tag": "0054_routine_folder_id",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1777795200000,
+      "tag": "0055_workspace_folder_mounts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/libs/database/src/schemas/folder9/index.ts
+++ b/apps/server/libs/database/src/schemas/folder9/index.ts
@@ -1,0 +1,1 @@
+export * from './workspace-folder-mounts.js';

--- a/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.ts
+++ b/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.ts
@@ -1,0 +1,57 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { tenants } from '../tenant/tenants.js';
+
+/**
+ * Idempotent registry of Folder9 folders per (workspace, scope, scopeId,
+ * mountKey). Backs the `JustBashTeam9WorkspaceComponent` virtual workspace
+ * mount layer.
+ *
+ * Lazy-provisioned by `FolderMountResolver`: SELECT first; on miss, create
+ * via `Folder9ClientService.createFolder` and INSERT ... ON CONFLICT DO
+ * NOTHING (race-safe). The unique constraint on
+ * (workspace_id, scope, scope_id, mount_key) is the idempotency guard.
+ */
+export const workspaceFolderMounts = pgTable(
+  'workspace_folder_mounts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    workspaceId: uuid('workspace_id')
+      .references(() => tenants.id, { onDelete: 'cascade' })
+      .notNull(),
+    /** 'session' | 'agent' | 'routine' | 'user' */
+    scope: varchar('scope', { length: 32 }).notNull(),
+    /** sessionId / botId / routineId / userId */
+    scopeId: varchar('scope_id', { length: 128 }).notNull(),
+    /** 'tmp' | 'home' | 'document' (room for future) */
+    mountKey: varchar('mount_key', { length: 32 }).notNull(),
+    /** 'light' | 'managed' — denormalized so subsequent operations don't
+     * need to round-trip Folder9 to learn the type. */
+    folderType: varchar('folder_type', { length: 16 }).notNull(),
+    /** UUID returned by Folder9 createFolder. Source of truth. */
+    folder9FolderId: uuid('folder9_folder_id').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    // The unique constraint serves both the idempotency guard for
+    // INSERT ... ON CONFLICT DO NOTHING AND the lookup path for
+    // FolderMountResolver's SELECT — Postgres' planner picks this
+    // index for any prefix lookup on (workspace_id, scope, scope_id,
+    // mount_key), so a separate non-unique lookup index would be
+    // redundant write overhead.
+    uniqueIndex('workspace_folder_mounts_unique').on(
+      table.workspaceId,
+      table.scope,
+      table.scopeId,
+      table.mountKey,
+    ),
+  ],
+);
+
+export type WorkspaceFolderMount = typeof workspaceFolderMounts.$inferSelect;
+export type NewWorkspaceFolderMount = typeof workspaceFolderMounts.$inferInsert;

--- a/apps/server/libs/database/src/schemas/index.ts
+++ b/apps/server/libs/database/src/schemas/index.ts
@@ -6,3 +6,4 @@ export * from './routine/index.js';
 export * from './resource/index.js';
 export * from './skill/index.js';
 export * from './wiki/index.js';
+export * from './folder9/index.js';


### PR DESCRIPTION
## Summary

This PR is **Phase A** of the cross-repo workspace mount integration. It backs the agent-pi side ([team9-agent-pi PR coming next](../team9-agent-pi)) which exposes `JustBashTeam9WorkspaceComponent` to the 3 production staff blueprints (Common / Personal / Base Model).

**5 sequential commits, 5 backend tasks:**

1. `workspace_folder_mounts` table — idempotent `(workspaceId, scope, scopeId, mountKey)` → `folder9_folder_id` registry
2. `FolderMountResolver` — race-safe lazy Folder9 folder provisioning (SELECT → createFolder → INSERT ON CONFLICT DO NOTHING → re-SELECT)
3. `FolderMapBuilder` + `parseSessionShape` — assembles per-session folderMap dict per per-blueprint inclusion matrix (session.* / agent.* always; routine.{tmp,home} if routineId; user.{tmp,home} if DM + userId; never routine.document — that's owned by the routine-creation flow)
4. `POST /api/v1/bot/folder-map` controller + DTO — auth chain mirrors `/bot/folder-token` (Bearer + X-Team9-Bot-User-Id match + bot-agent ownership via `bots.managedMeta.agentId`)
5. `FolderTokenService` authz expansion — replaces existing TODO stub-passthrough for session.\* / agent.\* / user.\* / routine.{tmp,home} with real authz (mount-row match + per-family ownership: agentId / sessionId-parsing / DM-channel-membership / routine-ownership). routine.document path unchanged.

## Specs + plan

- Spec: [`docs/superpowers/specs/2026-04-30-team9-workspace-mount-integration-design.md`](https://github.com/team9ai/agent-pi/blob/feat/team9-workspace-mount-integration/docs/superpowers/specs/2026-04-30-team9-workspace-mount-integration-design.md) (in agent-pi repo)
- Plan: [`docs/superpowers/plans/2026-04-30-team9-workspace-mount-integration.md`](https://github.com/team9ai/agent-pi/blob/feat/team9-workspace-mount-integration/docs/superpowers/plans/2026-04-30-team9-workspace-mount-integration.md) (in agent-pi repo, Tasks 1-5)

## Test plan

- [ ] CI passes: lint (0 errors), build (17/17), gateway tests (3207 passing, 5 pre-existing skipped)
- [ ] Migration `0055_workspace_folder_mounts.sql` applies cleanly on dev DB
- [ ] No regressions in existing folder-token tests (30 → 60 tests; routine.document path unchanged)
- [ ] No regressions in routines / staff service tests

## Coverage

- `folder-token.service.ts`: 97.29% stmts / 92.85% branches / 100% functions
- `folder-mount-resolver.service.ts`: 100% stmts / 100% branches / 100% functions
- `folder-map-builder.service.ts`: 100% stmts / 94.44% branches / 100% functions
- `parse-session-shape.ts`: 100% stmts / 100% branches / 100% functions
- `folder-map.controller.ts` + `bot-agent-ownership.service.ts`: tests pass; coverage unmeasurable due to ESM unstable_mockModule (known false-negative)

## Followup (Phase B, separate PR in team9-agent-pi)

- Adds `Team9FolderMapApi` to claw-hive-types
- Wires `Team9ApiClient.getFolderMap` + `Team9Component.getDependencyApi` extension
- `JustBashTeam9WorkspaceComponent` runtime fetch
- `Folder9Component` PSK becomes optional
- `<workspace_usage>` system-prompt block
- 3 staff blueprints (Common / Personal / Base Model) get folder9 + just-bash + just-bash-team9-workspace components

🤖 Generated with [Claude Code](https://claude.com/claude-code)