### PR TITLE
feat(browser-runtime): Tauri install UI with progress, logs, agent-visible toggle (Phase C)

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "ahand-protocol"
 version = "0.1.2"
-source = "git+https://github.com/team9ai/aHand?rev=ab5290c2dd8d2d8ec18b8959af37d415dedbfc77#ab5290c2dd8d2d8ec18b8959af37d415dedbfc77"
+source = "git+https://github.com/team9ai/aHand?rev=5972ef2da404a28031e1604f3b817a4db0187c08#5972ef2da404a28031e1604f3b817a4db0187c08"
 dependencies = [
  "prost",
  "prost-build",
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "ahandd"
 version = "0.1.2"
-source = "git+https://github.com/team9ai/aHand?rev=ab5290c2dd8d2d8ec18b8959af37d415dedbfc77#ab5290c2dd8d2d8ec18b8959af37d415dedbfc77"
+source = "git+https://github.com/team9ai/aHand?rev=5972ef2da404a28031e1604f3b817a4db0187c08#5972ef2da404a28031e1604f3b817a4db0187c08"
 dependencies = [
  "ahand-protocol",
  "anyhow",
@@ -38,6 +38,7 @@ dependencies = [
  "hex",
  "image",
  "libc",
+ "nix",
  "portable-pty",
  "prost",
  "rand 0.8.5",
@@ -130,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1117,7 +1118,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1343,7 +1344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2157,7 +2158,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2882,7 +2883,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3737,7 +3738,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -4248,7 +4249,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4304,7 +4305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4791,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5490,6 +5491,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tempfile",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower-http",
@@ -5502,10 +5504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6014,7 +6016,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6488,7 +6490,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6566,20 +6568,7 @@ dependencies = [
  "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6667,7 +6656,7 @@ checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6689,30 +6678,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -5475,6 +5475,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
+ "chrono",
  "dirs 5.0.1",
  "hex",
  "objc2",

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -45,10 +45,11 @@ anyhow = "1"
 base64 = "0.22"
 sha2 = "0.10"
 hex = "0.4"
+thiserror = "2"
 
 # ahand library embedding — pinned to aHand dev HEAD with duplicate
 # embedded-daemon session guard.
-ahandd = { git = "https://github.com/team9ai/aHand", package = "ahandd", rev = "ab5290c2dd8d2d8ec18b8959af37d415dedbfc77" }
+ahandd = { git = "https://github.com/team9ai/aHand", package = "ahandd", rev = "5972ef2da404a28031e1604f3b817a4db0187c08" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ base64 = "0.22"
 sha2 = "0.10"
 hex = "0.4"
 thiserror = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 # ahand library embedding — pinned to aHand dev HEAD with duplicate
 # embedded-daemon session guard.

--- a/apps/client/src-tauri/src/ahand/browser_runtime.rs
+++ b/apps/client/src-tauri/src/ahand/browser_runtime.rs
@@ -1,0 +1,1062 @@
+//! Tauri commands that wire the renderer's "我的设备 → 浏览器控制"
+//! install/toggle UI to the embedded `ahandd::browser_setup` library.
+//!
+//! See team9/docs/superpowers/specs/2026-04-29-ahand-browser-runtime-install-design.md
+//! §5 for the full design.
+//!
+//! ## Concurrency
+//!
+//! Only one mutating browser operation (`browser_install` /
+//! `browser_set_enabled`) may run at a time. We gate via a process-wide
+//! `AtomicBool` (`INSTALL_IN_PROGRESS`) — a second invocation while one
+//! is in flight returns `Err("operation_in_progress")` synchronously and
+//! does not touch the daemon. The flag is cleared by the `InstallGuard`
+//! RAII type on every exit path (success, error, or panic-via-drop).
+//!
+//! `AhandRuntime::reload()` is independently serialised by its own internal
+//! `Mutex<Option<ActiveSession>>`, so we don't need a second outer lock.
+//!
+//! ## Logging
+//!
+//! Each `browser_install` invocation opens a fresh
+//! `~/.ahand/logs/browser-setup-{YYYYMMDD-HHMMSS}.log` and tee's every
+//! `ProgressEvent` (verbatim) to it. At the start of each install we prune
+//! files in that directory older than 7 days. Failures to write the log
+//! are swallowed — they must never fail the install path.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+use tauri::State;
+
+use ahandd::browser_setup::{
+    self, CheckReport, CheckStatus, ErrorCode, FailedStepReport, LogStream, Phase, ProgressEvent,
+};
+use ahandd::config::Config;
+
+use super::runtime::{AhandRuntime, ReloadError};
+
+// ============================================================================
+// Concurrency gate
+// ============================================================================
+
+/// Process-wide flag: only one mutating browser operation may run at once.
+/// `compare_exchange` makes the swap-and-test atomic; we never block on
+/// another caller. RAII via `InstallGuard` ensures the flag is cleared
+/// even on panic / early-return.
+static INSTALL_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+struct InstallGuard;
+
+impl InstallGuard {
+    fn try_acquire() -> Option<Self> {
+        match INSTALL_IN_PROGRESS.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => Some(Self),
+            Err(_) => None,
+        }
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        INSTALL_IN_PROGRESS.store(false, Ordering::Release);
+    }
+}
+
+// ============================================================================
+// Wire types — shape consumed by the renderer's Channel
+// ============================================================================
+
+/// Streaming progress events emitted on the `Channel<BrowserProgressEvent>`
+/// passed by the renderer. Tagged with `type` so TS can discriminate.
+#[derive(Debug, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum BrowserProgressEvent {
+    StepStarted {
+        name: String,
+        label: String,
+    },
+    StepLog {
+        name: String,
+        line: String,
+        stream: TauriLogStream,
+    },
+    StepFinished {
+        name: String,
+        status: TauriStepStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<StepError>,
+        duration_ms: u64,
+    },
+    AllFinished {
+        overall: TauriStepStatus,
+        total_duration_ms: u64,
+    },
+    ReloadStarted,
+    ReloadOnline,
+    ReloadFailed {
+        kind: ReloadFailureKind,
+        message: String,
+    },
+}
+
+/// Renderer-visible step status. A superset of ahandd's `CheckStatus` —
+/// flattens `Missing`/`Outdated`/`NoneDetected` into `NotRun`.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TauriStepStatus {
+    Ok,
+    Skipped,
+    Failed,
+    NotRun,
+}
+
+/// Origin of a streamed log line. `Info` is synthesised by the adapter
+/// (e.g. for `Phase::Starting`/`Downloading`/...); `Stdout`/`Stderr` are
+/// forwarded verbatim from child processes via `Phase::Log`.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TauriLogStream {
+    Stdout,
+    Stderr,
+    Info,
+}
+
+impl From<LogStream> for TauriLogStream {
+    fn from(s: LogStream) -> Self {
+        match s {
+            LogStream::Stdout => TauriLogStream::Stdout,
+            LogStream::Stderr => TauriLogStream::Stderr,
+            LogStream::Info => TauriLogStream::Info,
+        }
+    }
+}
+
+/// Classified failure reason for a step. `code` is the snake_case form of
+/// `ahandd::browser_setup::ErrorCode` (e.g. `"permission_denied"`); the
+/// renderer matches on it to pick a help popover.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StepError {
+    pub code: String,
+    pub message: String,
+}
+
+impl From<(ErrorCode, String)> for StepError {
+    fn from((code, message): (ErrorCode, String)) -> Self {
+        // ErrorCode serialises as a snake_case string under serde. Round-trip
+        // through serde_json so the wire shape stays consistent with the rest
+        // of ahandd's surface area instead of hand-mapping each variant.
+        let code_str = serde_json::to_value(code)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown".into());
+        Self {
+            code: code_str,
+            message,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ReloadFailureKind {
+    ShutdownTimeout,
+    SpawnFailedRolledBack,
+    SpawnFailedNoRollback,
+}
+
+// ============================================================================
+// BrowserStatus — return type of the 3 commands
+// ============================================================================
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserStatus {
+    pub overall: TauriStepStatus,
+    pub steps: Vec<BrowserStepStatus>,
+    pub enabled: bool,
+    pub agent_visible: bool,
+    pub queried_at: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserStepStatus {
+    pub name: String,
+    pub label: String,
+    pub status: TauriStepStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<StepError>,
+}
+
+fn overall_from_reports(reports: &[CheckReport]) -> TauriStepStatus {
+    if reports
+        .iter()
+        .any(|r| matches!(r.status, CheckStatus::Failed { .. }))
+    {
+        return TauriStepStatus::Failed;
+    }
+    if reports
+        .iter()
+        .all(|r| matches!(r.status, CheckStatus::Ok { .. }))
+    {
+        return TauriStepStatus::Ok;
+    }
+    TauriStepStatus::NotRun
+}
+
+fn step_status_from_check(
+    cs: &CheckStatus,
+) -> (TauriStepStatus, Option<String>, Option<StepError>) {
+    match cs {
+        CheckStatus::Ok { version, path, .. } => {
+            let detail = if version.is_empty() {
+                Some(path.display().to_string())
+            } else {
+                Some(format!("{} ({})", version, path.display()))
+            };
+            (TauriStepStatus::Ok, detail, None)
+        }
+        CheckStatus::Missing => (TauriStepStatus::NotRun, None, None),
+        CheckStatus::Outdated {
+            current, required, ..
+        } => (
+            TauriStepStatus::NotRun,
+            Some(format!("current {current}, need {required}")),
+            None,
+        ),
+        CheckStatus::NoneDetected { tried } => (
+            TauriStepStatus::NotRun,
+            Some(format!("tried: {}", tried.join(", "))),
+            None,
+        ),
+        CheckStatus::Failed { code, message } => (
+            TauriStepStatus::Failed,
+            None,
+            Some(StepError::from((*code, message.clone()))),
+        ),
+    }
+}
+
+fn to_browser_status(
+    reports: Vec<CheckReport>,
+    enabled: bool,
+    agent_visible: bool,
+) -> BrowserStatus {
+    let overall = overall_from_reports(&reports);
+    let steps = reports
+        .into_iter()
+        .map(|r| {
+            let (status, detail, error) = step_status_from_check(&r.status);
+            BrowserStepStatus {
+                name: r.name.to_string(),
+                label: r.label.to_string(),
+                status,
+                detail,
+                error,
+            }
+        })
+        .collect();
+    BrowserStatus {
+        overall,
+        steps,
+        enabled,
+        agent_visible,
+        queried_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+// ============================================================================
+// Adapter — translate ahandd ProgressEvent → Tauri BrowserProgressEvent
+// ============================================================================
+//
+// Notes on threading:
+// * The progress callback passed to `browser_setup::run_all` is a sync
+//   `Fn(ProgressEvent)`, invoked from inside the async install loop.
+// * We must NEVER call `tokio::sync::Mutex::blocking_lock()` here — it
+//   panics inside a tokio runtime.
+// * Therefore we use `std::sync::Mutex` for both the adapter state and
+//   the log writer. These mutexes are short-lived: never held across
+//   `.await`, so they don't deadlock the executor.
+
+#[derive(Default)]
+struct AdapterState {
+    steps: std::collections::HashMap<&'static str, StepTracker>,
+}
+
+#[derive(Clone)]
+struct StepTracker {
+    started_at: Instant,
+    announced: bool,
+    label: String,
+}
+
+fn step_label(name: &str) -> String {
+    match name {
+        "node" => "Node.js".into(),
+        "playwright" => "Playwright CLI".into(),
+        "browser" => "System Browser".into(),
+        other => other.into(),
+    }
+}
+
+impl AdapterState {
+    fn translate(&mut self, ev: &ProgressEvent) -> Vec<BrowserProgressEvent> {
+        let mut out = Vec::new();
+        let tracker = self.steps.entry(ev.step).or_insert_with(|| StepTracker {
+            started_at: Instant::now(),
+            announced: false,
+            label: step_label(ev.step),
+        });
+        if !tracker.announced {
+            out.push(BrowserProgressEvent::StepStarted {
+                name: ev.step.to_string(),
+                label: tracker.label.clone(),
+            });
+            tracker.announced = true;
+            tracker.started_at = Instant::now();
+        }
+        match ev.phase {
+            Phase::Log => {
+                if let Some(stream) = ev.stream {
+                    out.push(BrowserProgressEvent::StepLog {
+                        name: ev.step.to_string(),
+                        line: ev.message.clone(),
+                        stream: stream.into(),
+                    });
+                }
+            }
+            Phase::Starting
+            | Phase::Downloading
+            | Phase::Extracting
+            | Phase::Installing
+            | Phase::Verifying => {
+                out.push(BrowserProgressEvent::StepLog {
+                    name: ev.step.to_string(),
+                    line: ev.message.clone(),
+                    stream: TauriLogStream::Info,
+                });
+            }
+            Phase::Done => {
+                // Phase::Done is emitted on BOTH success and failure paths
+                // (see `wrap_failure` in ahandd). We can't tell which here,
+                // so we surface the message as an Info log line and leave
+                // StepFinished emission to the post-pass after `run_all`
+                // returns (which has the authoritative Result + reports).
+                out.push(BrowserProgressEvent::StepLog {
+                    name: ev.step.to_string(),
+                    line: ev.message.clone(),
+                    stream: TauriLogStream::Info,
+                });
+            }
+        }
+        out
+    }
+}
+
+// ============================================================================
+// Tauri commands
+// ============================================================================
+
+/// Read-only diagnostic. Never mutates anything. Returns the current
+/// install + config + daemon-online state.
+#[tauri::command]
+pub async fn browser_status(state: State<'_, AhandRuntime>) -> Result<BrowserStatus, String> {
+    let reports = browser_setup::inspect_all().await;
+    let config_path = state
+        .config_path()
+        .await
+        .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
+    let config = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let enabled = config.browser_config().enabled.unwrap_or(false);
+    let daemon_online = matches!(
+        state.status().await,
+        super::runtime::DaemonStatus::Online { .. }
+    );
+    let agent_visible = enabled && daemon_online;
+    Ok(to_browser_status(reports, enabled, agent_visible))
+}
+
+/// Run `browser_setup::run_all`, stream progress to the renderer, tee logs
+/// to disk, flip `[browser].enabled = true` on success, and reload the
+/// daemon. Returns the final `BrowserStatus` after reload.
+///
+/// Concurrency: a second invocation while one is in flight returns
+/// `Err("operation_in_progress")` synchronously.
+#[tauri::command]
+pub async fn browser_install(
+    state: State<'_, AhandRuntime>,
+    force: bool,
+    on_progress: Channel<BrowserProgressEvent>,
+) -> Result<BrowserStatus, String> {
+    let _guard = InstallGuard::try_acquire().ok_or_else(|| "operation_in_progress".to_string())?;
+
+    let config_path = state
+        .config_path()
+        .await
+        .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
+
+    // Best-effort: prune log files older than 7 days. Failures are logged
+    // to stderr but never abort the install.
+    tokio::task::spawn_blocking(|| {
+        if let Err(e) = prune_old_logs(7) {
+            eprintln!("browser_runtime: prune_old_logs failed: {e}");
+        }
+    });
+
+    // Open the per-install log file. Failures are non-fatal — we log to
+    // stderr and proceed without tee'ing.
+    let log_writer: Option<Arc<Mutex<std::fs::File>>> = match prepare_log_file() {
+        Ok(f) => Some(Arc::new(Mutex::new(f))),
+        Err(e) => {
+            eprintln!("browser_runtime: open log file failed: {e:#}");
+            None
+        }
+    };
+
+    // Wrap the channel in Arc so the sync callback can move a clone in.
+    let channel_cb = Arc::new(on_progress);
+    let adapter_state = Arc::new(Mutex::new(AdapterState::default()));
+
+    let cb_state = adapter_state.clone();
+    let cb_channel = channel_cb.clone();
+    let cb_log = log_writer.clone();
+    let cb = move |e: ProgressEvent| {
+        // 1. Translate via adapter and emit to channel. Fire-and-forget:
+        //    if the renderer dropped the channel, send returns Err and
+        //    we just silently stop forwarding to it.
+        let translated = {
+            // Poison-recovery: an `unwrap()` here would crash the daemon
+            // worker on a poisoned mutex. `lock()` only fails when a panic
+            // happened while holding the lock; in that case fall back to
+            // emitting nothing rather than aborting the install.
+            match cb_state.lock() {
+                Ok(mut st) => st.translate(&e),
+                Err(_) => Vec::new(),
+            }
+        };
+        for ev in translated {
+            let _ = cb_channel.send(ev);
+        }
+        // 2. Tee the raw event to the log file. Best-effort — never fails.
+        if let Some(ref writer) = cb_log {
+            let _ = write_log_line(writer, &e);
+        }
+    };
+
+    let overall_start = Instant::now();
+    let result = browser_setup::run_all(force, cb).await;
+
+    // ── Reconciliation pass: emit StepFinished for each known report ──
+    //
+    // `Phase::Done` is emitted by ahandd on both success and failure
+    // paths, so we cannot reliably emit StepFinished from inside the
+    // adapter. Do it here where we have the authoritative
+    // `Result<Vec<CheckReport>>`.
+    let reports_for_status: Vec<CheckReport> = match &result {
+        Ok(reports) => {
+            for r in reports {
+                emit_step_finished(&channel_cb, &adapter_state, r);
+            }
+            reports.clone()
+        }
+        Err(e) => {
+            // Recover the classified report (if any) from the FailedStepReport
+            // context attached by `wrap_failure`.
+            if let Some(failed) = e.downcast_ref::<FailedStepReport>() {
+                emit_step_finished(&channel_cb, &adapter_state, &failed.0);
+            }
+            // No partial-report set is exposed by ahandd on Err; the
+            // post-install `inspect_all` below gives the renderer a fresh
+            // snapshot.
+            Vec::new()
+        }
+    };
+
+    let overall_status = match &result {
+        Ok(reports)
+            if reports
+                .iter()
+                .any(|r| matches!(r.status, CheckStatus::Failed { .. })) =>
+        {
+            TauriStepStatus::Failed
+        }
+        Ok(reports)
+            if reports
+                .iter()
+                .all(|r| matches!(r.status, CheckStatus::Ok { .. })) =>
+        {
+            TauriStepStatus::Ok
+        }
+        Ok(_) => TauriStepStatus::Skipped,
+        Err(_) => TauriStepStatus::Failed,
+    };
+
+    let _ = channel_cb.send(BrowserProgressEvent::AllFinished {
+        overall: overall_status,
+        total_duration_ms: overall_start.elapsed().as_millis() as u64,
+    });
+
+    // On success, flip the config flag and reload the daemon so the new
+    // [browser].enabled value takes effect for the embedded ahandd.
+    if matches!(overall_status, TauriStepStatus::Ok) {
+        match Config::load(&config_path) {
+            Ok(mut cfg) => {
+                if let Err(e) = cfg.set_browser_enabled(&config_path, true) {
+                    eprintln!("browser_runtime: config write failed: {e:#}");
+                } else {
+                    let _ = channel_cb.send(BrowserProgressEvent::ReloadStarted);
+                    match state.reload().await {
+                        Ok(()) => {
+                            let _ = channel_cb.send(BrowserProgressEvent::ReloadOnline);
+                        }
+                        Err(re) => {
+                            let _ = channel_cb.send(BrowserProgressEvent::ReloadFailed {
+                                kind: reload_error_kind(&re),
+                                message: format!("{re}"),
+                            });
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("browser_runtime: config reload failed: {e:#}");
+            }
+        }
+    }
+
+    // Final status snapshot — re-inspect since reports above may be empty
+    // on the Err path, and the daemon state may have changed via reload().
+    let reports_after = if reports_for_status.is_empty() || result.is_err() {
+        browser_setup::inspect_all().await
+    } else {
+        reports_for_status
+    };
+    let config_after =
+        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
+    let agent_visible = enabled_after
+        && matches!(
+            state.status().await,
+            super::runtime::DaemonStatus::Online { .. }
+        );
+    Ok(to_browser_status(
+        reports_after,
+        enabled_after,
+        agent_visible,
+    ))
+}
+
+/// Flip `[browser].enabled` and reload the daemon. Does NOT run
+/// `run_all` — the caller is expected to have already installed via
+/// `browser_install` (or by other means). Only emits `ReloadStarted`/
+/// `ReloadOnline`/`ReloadFailed` events.
+#[tauri::command]
+pub async fn browser_set_enabled(
+    state: State<'_, AhandRuntime>,
+    enabled: bool,
+    on_progress: Channel<BrowserProgressEvent>,
+) -> Result<BrowserStatus, String> {
+    let _guard = InstallGuard::try_acquire().ok_or_else(|| "operation_in_progress".to_string())?;
+
+    let config_path = state
+        .config_path()
+        .await
+        .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
+
+    // Guard: refuse to enable when not all components are installed —
+    // otherwise the agent would advertise a capability that immediately
+    // fails to drive a browser session.
+    if enabled {
+        let reports = browser_setup::inspect_all().await;
+        let installed = reports
+            .iter()
+            .all(|r| matches!(r.status, CheckStatus::Ok { .. }));
+        if !installed {
+            return Err("browser_not_installed".into());
+        }
+    }
+
+    let mut cfg = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let old = cfg
+        .set_browser_enabled(&config_path, enabled)
+        .map_err(|e| format!("config write: {e:#}"))?;
+
+    // No-op optimisation: skip the reload if the value didn't actually
+    // change. Saves ~3-5s of daemon shutdown/respawn time.
+    if old == enabled {
+        let reports = browser_setup::inspect_all().await;
+        let agent_visible = enabled
+            && matches!(
+                state.status().await,
+                super::runtime::DaemonStatus::Online { .. }
+            );
+        return Ok(to_browser_status(reports, enabled, agent_visible));
+    }
+
+    let _ = on_progress.send(BrowserProgressEvent::ReloadStarted);
+    match state.reload().await {
+        Ok(()) => {
+            let _ = on_progress.send(BrowserProgressEvent::ReloadOnline);
+        }
+        Err(re) => {
+            let _ = on_progress.send(BrowserProgressEvent::ReloadFailed {
+                kind: reload_error_kind(&re),
+                message: format!("{re}"),
+            });
+        }
+    }
+
+    let reports = browser_setup::inspect_all().await;
+    let config_after =
+        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
+    let agent_visible = enabled_after
+        && matches!(
+            state.status().await,
+            super::runtime::DaemonStatus::Online { .. }
+        );
+    Ok(to_browser_status(reports, enabled_after, agent_visible))
+}
+
+fn reload_error_kind(re: &ReloadError) -> ReloadFailureKind {
+    match re {
+        ReloadError::ShutdownTimeout => ReloadFailureKind::ShutdownTimeout,
+        ReloadError::SpawnFailedRolledBack { .. } => ReloadFailureKind::SpawnFailedRolledBack,
+        ReloadError::SpawnFailedNoRollback { .. } => ReloadFailureKind::SpawnFailedNoRollback,
+    }
+}
+
+fn emit_step_finished(
+    channel: &Channel<BrowserProgressEvent>,
+    adapter: &Arc<Mutex<AdapterState>>,
+    report: &CheckReport,
+) {
+    let (tauri_status, _detail, error) = step_status_from_check(&report.status);
+    let duration_ms = match adapter.lock() {
+        Ok(st) => st
+            .steps
+            .get(report.name)
+            .map(|t| t.started_at.elapsed().as_millis() as u64)
+            .unwrap_or(0),
+        Err(_) => 0,
+    };
+    let _ = channel.send(BrowserProgressEvent::StepFinished {
+        name: report.name.to_string(),
+        status: tauri_status,
+        error,
+        duration_ms,
+    });
+}
+
+// ============================================================================
+// Log-file helpers
+// ============================================================================
+
+fn log_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".ahand")
+        .join("logs")
+}
+
+fn prepare_log_file() -> anyhow::Result<std::fs::File> {
+    let dir = log_dir();
+    std::fs::create_dir_all(&dir)?;
+    let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let path = dir.join(format!("browser-setup-{ts}.log"));
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    Ok(f)
+}
+
+fn write_log_line(writer: &Arc<Mutex<std::fs::File>>, ev: &ProgressEvent) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut f = match writer.lock() {
+        Ok(g) => g,
+        Err(_) => {
+            // Mutex was poisoned by a panic; the file may still be writable
+            // but we don't have a recovery path here without unwinding. Drop
+            // the line silently rather than re-panic.
+            return Ok(());
+        }
+    };
+    let ts = chrono::Local::now().format("%H:%M:%S%.3f");
+    let stream_tag = ev
+        .stream
+        .map(|s| match s {
+            LogStream::Stdout => "OUT",
+            LogStream::Stderr => "ERR",
+            LogStream::Info => "INF",
+        })
+        .unwrap_or("---");
+    writeln!(
+        f,
+        "[{ts}] [{}] [{stream_tag}] {:?} {}",
+        ev.step, ev.phase, ev.message
+    )
+}
+
+fn prune_old_logs(max_age_days: u64) -> std::io::Result<()> {
+    let dir = log_dir();
+    if !dir.exists() {
+        return Ok(());
+    }
+    let cutoff = std::time::SystemTime::now() - Duration::from_secs(max_age_days * 24 * 60 * 60);
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if !name_str.starts_with("browser-setup-") || !name_str.ends_with(".log") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapter_emits_step_started_on_first_event_for_each_step() {
+        let mut st = AdapterState::default();
+        let events = st.translate(&ProgressEvent {
+            step: "node",
+            phase: Phase::Starting,
+            message: "Starting Node install".into(),
+            percent: None,
+            stream: None,
+        });
+        assert!(events.iter().any(
+            |e| matches!(e, BrowserProgressEvent::StepStarted { name, label }
+                if name == "node" && label == "Node.js")
+        ));
+
+        // Subsequent events for the same step do NOT re-announce.
+        let events2 = st.translate(&ProgressEvent {
+            step: "node",
+            phase: Phase::Downloading,
+            message: "downloading…".into(),
+            percent: Some(50),
+            stream: None,
+        });
+        assert!(
+            !events2
+                .iter()
+                .any(|e| matches!(e, BrowserProgressEvent::StepStarted { .. })),
+            "StepStarted must be emitted at most once per step"
+        );
+
+        // A different step gets its own StepStarted.
+        let events3 = st.translate(&ProgressEvent {
+            step: "playwright",
+            phase: Phase::Starting,
+            message: "Starting Playwright install".into(),
+            percent: None,
+            stream: None,
+        });
+        assert!(events3.iter().any(
+            |e| matches!(e, BrowserProgressEvent::StepStarted { name, label }
+                if name == "playwright" && label == "Playwright CLI")
+        ));
+    }
+
+    #[test]
+    fn adapter_forwards_stdout_log_lines_with_stream_tag() {
+        let mut st = AdapterState::default();
+        // Prime the step so StepStarted fires once and doesn't pollute later events.
+        let _ = st.translate(&ProgressEvent {
+            step: "playwright",
+            phase: Phase::Starting,
+            message: "start".into(),
+            percent: None,
+            stream: None,
+        });
+        let events = st.translate(&ProgressEvent {
+            step: "playwright",
+            phase: Phase::Log,
+            message: "npm notice".into(),
+            percent: None,
+            stream: Some(LogStream::Stdout),
+        });
+        let log = events.iter().find_map(|e| match e {
+            BrowserProgressEvent::StepLog {
+                line,
+                stream: TauriLogStream::Stdout,
+                name,
+            } if name == "playwright" => Some(line.clone()),
+            _ => None,
+        });
+        assert_eq!(log, Some("npm notice".into()));
+
+        // Stderr lines are forwarded too.
+        let events_err = st.translate(&ProgressEvent {
+            step: "playwright",
+            phase: Phase::Log,
+            message: "warn deprecated".into(),
+            percent: None,
+            stream: Some(LogStream::Stderr),
+        });
+        assert!(events_err.iter().any(|e| matches!(
+            e,
+            BrowserProgressEvent::StepLog {
+                stream: TauriLogStream::Stderr,
+                ..
+            }
+        )));
+
+        // Phase::Log without a stream is dropped (defensive: spec requires
+        // stream to be set when phase==Log, but the runtime should not
+        // panic if it isn't).
+        let events_no_stream = st.translate(&ProgressEvent {
+            step: "playwright",
+            phase: Phase::Log,
+            message: "shouldn't appear".into(),
+            percent: None,
+            stream: None,
+        });
+        assert!(
+            !events_no_stream
+                .iter()
+                .any(|e| matches!(e, BrowserProgressEvent::StepLog { .. })),
+            "Log phase without stream tag should be dropped"
+        );
+    }
+
+    #[test]
+    fn overall_from_reports_prefers_failed_over_ok() {
+        let reports = vec![
+            CheckReport {
+                name: "node",
+                label: "Node.js",
+                status: CheckStatus::Ok {
+                    version: "20.10".into(),
+                    path: "/foo".into(),
+                    source: ahandd::browser_setup::CheckSource::Managed,
+                },
+                fix_hint: None,
+            },
+            CheckReport {
+                name: "playwright",
+                label: "Playwright CLI",
+                status: CheckStatus::Failed {
+                    code: ErrorCode::Network,
+                    message: "ECONNRESET".into(),
+                },
+                fix_hint: None,
+            },
+        ];
+        assert_eq!(overall_from_reports(&reports), TauriStepStatus::Failed);
+
+        // All Ok → Ok.
+        let all_ok = vec![CheckReport {
+            name: "browser",
+            label: "System Browser",
+            status: CheckStatus::Ok {
+                version: "".into(),
+                path: "/Applications/Chrome".into(),
+                source: ahandd::browser_setup::CheckSource::System,
+            },
+            fix_hint: None,
+        }];
+        assert_eq!(overall_from_reports(&all_ok), TauriStepStatus::Ok);
+
+        // Some Missing but no Failed → NotRun.
+        let mixed = vec![
+            CheckReport {
+                name: "node",
+                label: "Node.js",
+                status: CheckStatus::Missing,
+                fix_hint: None,
+            },
+            CheckReport {
+                name: "playwright",
+                label: "Playwright CLI",
+                status: CheckStatus::Ok {
+                    version: "0.1.0".into(),
+                    path: "/x".into(),
+                    source: ahandd::browser_setup::CheckSource::Managed,
+                },
+                fix_hint: None,
+            },
+        ];
+        assert_eq!(overall_from_reports(&mixed), TauriStepStatus::NotRun);
+    }
+
+    #[test]
+    fn step_error_serializes_code_as_snake_case_string() {
+        let e = StepError::from((ErrorCode::PermissionDenied, "EACCES".into()));
+        assert_eq!(e.code, "permission_denied");
+        assert_eq!(e.message, "EACCES");
+
+        let e2 = StepError::from((ErrorCode::NoSystemBrowser, "x".into()));
+        assert_eq!(e2.code, "no_system_browser");
+
+        // Round-trip through serde to verify the wire shape.
+        let json = serde_json::to_value(&e).unwrap();
+        assert_eq!(json["code"], "permission_denied");
+        assert_eq!(json["message"], "EACCES");
+    }
+
+    #[test]
+    fn reload_failure_kind_serializes_camel_case() {
+        assert_eq!(
+            serde_json::to_value(ReloadFailureKind::ShutdownTimeout).unwrap(),
+            serde_json::json!("shutdownTimeout")
+        );
+        assert_eq!(
+            serde_json::to_value(ReloadFailureKind::SpawnFailedRolledBack).unwrap(),
+            serde_json::json!("spawnFailedRolledBack")
+        );
+        assert_eq!(
+            serde_json::to_value(ReloadFailureKind::SpawnFailedNoRollback).unwrap(),
+            serde_json::json!("spawnFailedNoRollback")
+        );
+    }
+
+    #[test]
+    fn reload_error_kind_maps_all_variants() {
+        assert_eq!(
+            reload_error_kind(&ReloadError::ShutdownTimeout),
+            ReloadFailureKind::ShutdownTimeout
+        );
+        assert_eq!(
+            reload_error_kind(&ReloadError::SpawnFailedRolledBack {
+                primary: "x".into()
+            }),
+            ReloadFailureKind::SpawnFailedRolledBack
+        );
+        assert_eq!(
+            reload_error_kind(&ReloadError::SpawnFailedNoRollback {
+                primary: "p".into(),
+                rollback: "r".into(),
+            }),
+            ReloadFailureKind::SpawnFailedNoRollback
+        );
+    }
+
+    #[test]
+    fn install_guard_serializes_concurrent_acquire() {
+        // Two acquisitions back-to-back: the second must fail until the
+        // first guard is dropped.
+        let g1 = InstallGuard::try_acquire();
+        assert!(g1.is_some(), "first acquire should succeed");
+        let g2 = InstallGuard::try_acquire();
+        assert!(
+            g2.is_none(),
+            "second acquire while the first is held must fail"
+        );
+        drop(g1);
+        let g3 = InstallGuard::try_acquire();
+        assert!(g3.is_some(), "after drop, acquire should succeed again");
+    }
+
+    #[test]
+    fn browser_progress_event_step_started_serializes_with_tag() {
+        let ev = BrowserProgressEvent::StepStarted {
+            name: "node".into(),
+            label: "Node.js".into(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["type"], "stepStarted");
+        assert_eq!(v["name"], "node");
+        assert_eq!(v["label"], "Node.js");
+    }
+
+    #[test]
+    fn browser_progress_event_reload_failed_includes_kind_and_message() {
+        let ev = BrowserProgressEvent::ReloadFailed {
+            kind: ReloadFailureKind::SpawnFailedRolledBack,
+            message: "boom".into(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["type"], "reloadFailed");
+        assert_eq!(v["kind"], "spawnFailedRolledBack");
+        assert_eq!(v["message"], "boom");
+    }
+
+    #[test]
+    fn step_status_from_check_ok_with_empty_version_only_shows_path() {
+        // Browser detection returns version = "" because there's no cheap
+        // way to query Chrome's version. Verify we don't render "()".
+        let cs = CheckStatus::Ok {
+            version: "".into(),
+            path: "/Applications/Google Chrome.app".into(),
+            source: ahandd::browser_setup::CheckSource::System,
+        };
+        let (status, detail, error) = step_status_from_check(&cs);
+        assert_eq!(status, TauriStepStatus::Ok);
+        assert_eq!(detail, Some("/Applications/Google Chrome.app".into()));
+        assert!(error.is_none());
+    }
+
+    #[test]
+    fn step_status_from_check_failed_carries_error_code_and_message() {
+        let cs = CheckStatus::Failed {
+            code: ErrorCode::Network,
+            message: "ECONNRESET".into(),
+        };
+        let (status, detail, error) = step_status_from_check(&cs);
+        assert_eq!(status, TauriStepStatus::Failed);
+        assert!(detail.is_none());
+        let err = error.expect("must surface a StepError");
+        assert_eq!(err.code, "network");
+        assert_eq!(err.message, "ECONNRESET");
+    }
+
+    #[test]
+    fn to_browser_status_emits_camel_case_wire_shape() {
+        let reports = vec![CheckReport {
+            name: "node",
+            label: "Node.js",
+            status: CheckStatus::Ok {
+                version: "20.10".into(),
+                path: "/usr/bin/node".into(),
+                source: ahandd::browser_setup::CheckSource::Managed,
+            },
+            fix_hint: None,
+        }];
+        let s = to_browser_status(reports, true, true);
+        let v = serde_json::to_value(&s).unwrap();
+        assert!(
+            v.get("agentVisible").is_some(),
+            "agent_visible → agentVisible"
+        );
+        assert!(v.get("queriedAt").is_some(), "queried_at → queriedAt");
+        assert_eq!(v["overall"], "ok");
+        assert_eq!(v["enabled"], true);
+        assert_eq!(v["agentVisible"], true);
+    }
+
+    #[test]
+    fn step_label_handles_known_and_unknown_steps() {
+        assert_eq!(step_label("node"), "Node.js");
+        assert_eq!(step_label("playwright"), "Playwright CLI");
+        assert_eq!(step_label("browser"), "System Browser");
+        assert_eq!(step_label("future-step"), "future-step");
+    }
+}

--- a/apps/client/src-tauri/src/ahand/mod.rs
+++ b/apps/client/src-tauri/src/ahand/mod.rs
@@ -1,6 +1,10 @@
+pub mod browser_runtime;
 pub mod commands;
 pub mod identity;
 pub mod runtime;
 
-pub use commands::{ahand_clear_identity, ahand_get_identity, ahand_start, ahand_status, ahand_stop};
+pub use browser_runtime::{browser_install, browser_set_enabled, browser_status};
+pub use commands::{
+    ahand_clear_identity, ahand_get_identity, ahand_start, ahand_status, ahand_stop,
+};
 pub use runtime::{AhandRuntime, DaemonStatus, ErrorKind, StartConfig, StartResult};

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -292,6 +292,17 @@ impl AhandRuntime {
         guard.as_ref().map(|s| s.hub_device_id.clone())
     }
 
+    /// Resolve the on-disk `config.toml` path captured at `start()` time.
+    /// Returns `None` when no session is active or when the renderer started
+    /// the daemon without supplying a `config_path` (e.g. tests). Callers
+    /// (specifically the `browser_runtime` Tauri commands in Task 14) treat
+    /// `None` as "ahand runtime not started" and surface an error to the UI
+    /// rather than fabricating a path.
+    pub async fn config_path(&self) -> Option<PathBuf> {
+        let guard = self.inner.lock().await;
+        guard.as_ref().and_then(|s| s.config_path.clone())
+    }
+
     /// Hot-reload the embedded daemon. Reads the on-disk config fresh
     /// (when `StartConfig::config_path` was supplied), shuts the running
     /// daemon down with a 5-second timeout, and spawns a new instance
@@ -621,6 +632,12 @@ mod tests {
         let rt = AhandRuntime::new();
         assert!(rt.stop(None).await.is_ok());
         assert!(rt.stop(None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn config_path_is_none_when_no_session() {
+        let rt = AhandRuntime::new();
+        assert!(rt.config_path().await.is_none());
     }
 
     #[test]

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -7,6 +8,14 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 use super::identity;
+
+/// Default 5s budget for a graceful daemon shutdown during reload. The
+/// timeout is enforced via `tokio::time::timeout`; when it fires we drop
+/// the in-flight shutdown future and surface `ReloadError::ShutdownTimeout`
+/// to the caller. We do NOT force-kill the underlying task — the
+/// `DaemonHandle::Drop` impl cancels the inner oneshot, which in practice
+/// terminates the daemon shortly after.
+const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ── Public wire types ──────────────────────────────────────────────────────
 
@@ -76,6 +85,16 @@ pub struct StartConfig {
     pub jwt_expires_at: u64,
     #[serde(default = "default_heartbeat_interval")]
     pub heartbeat_interval_seconds: u64,
+    /// Optional path to an ahandd `config.toml` on disk.
+    ///
+    /// When supplied, `AhandRuntime::reload()` re-reads this file via
+    /// `ahandd::config::Config::load()` to pick up changes (e.g. the
+    /// `[browser].enabled` flag flipped by the install UI). When `None`,
+    /// `reload()` rebuilds the daemon config purely from the in-memory
+    /// `StartupInputs` captured at `start()` time — useful for tests and
+    /// for callers who don't expose a config-on-disk surface.
+    #[serde(default)]
+    pub config_path: Option<PathBuf>,
 }
 
 fn default_heartbeat_interval() -> u64 {
@@ -89,7 +108,52 @@ pub struct StartResult {
     pub device_id: String,
 }
 
+/// Failure modes for `AhandRuntime::reload()`. Each variant captures a
+/// distinct recovery posture so the UI can pick the right banner:
+///
+/// * `ShutdownTimeout` — the previous daemon failed to exit within
+///   [`RELOAD_SHUTDOWN_TIMEOUT`]. The reload is aborted before any
+///   respawn. The runtime is left in a session-less state (handle was
+///   dropped); a follow-up `start()` is required to recover. We do NOT
+///   force-kill — the `DaemonHandle::Drop` impl cancels the worker task.
+/// * `SpawnFailedRolledBack` — the new spawn failed but a rollback spawn
+///   with the previous `DaemonConfig` succeeded. The runtime is fully
+///   functional, just with the old config; the user's intended change
+///   didn't take effect.
+/// * `SpawnFailedNoRollback` — both spawns failed. The runtime has no
+///   active daemon; the app needs to call `start()` again (or restart).
+#[derive(Debug, Serialize, thiserror::Error)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ReloadError {
+    #[error("daemon shutdown timed out after 5s")]
+    ShutdownTimeout,
+
+    /// Wrapped as a struct variant rather than a newtype because
+    /// `#[serde(tag = "kind")]` does not support tagging a newtype variant
+    /// that contains a primitive — it would have to wrap the inner value in
+    /// an extra envelope. Using a single named field (`primary`) keeps the
+    /// TS-side shape uniform across all variants:
+    /// `{ kind, primary[, rollback] }`.
+    #[error("respawn failed, rolled back to previous config: {primary}")]
+    SpawnFailedRolledBack { primary: String },
+
+    #[error("respawn failed and rollback also failed; daemon is offline")]
+    SpawnFailedNoRollback { primary: String, rollback: String },
+}
+
 // ── Internal state ─────────────────────────────────────────────────────────
+
+/// Inputs supplied at `start()` time that aren't represented in the
+/// on-disk `config.toml`. Captured on the active session so `reload()`
+/// can rebuild a fresh `DaemonConfig` without re-asking the renderer.
+#[derive(Clone, Debug)]
+struct StartupInputs {
+    hub_url: String,
+    device_jwt: String,
+    identity_dir: PathBuf,
+    device_id: String,
+    heartbeat_interval: Duration,
+}
 
 struct ActiveSession {
     handle: ahandd::DaemonHandle,
@@ -97,6 +161,17 @@ struct ActiveSession {
     hub_url: String,
     hub_device_id: String,
     status_forwarder: JoinHandle<()>,
+    /// Captured at `start()` time. Used by `reload()` to reconstruct a
+    /// `DaemonConfig` from the current on-disk `Config` without going
+    /// back to the renderer.
+    startup_inputs: StartupInputs,
+    /// Snapshot of the most recently-applied `DaemonConfig`. Cloned for
+    /// rollback inside `reload()` before we attempt a respawn.
+    current_daemon_config: ahandd::DaemonConfig,
+    /// Optional `config.toml` path to read in `reload()`. Mirrors the
+    /// `StartConfig::config_path` field; `None` means reload reuses the
+    /// in-memory inputs only (no on-disk overlay).
+    config_path: Option<PathBuf>,
 }
 
 pub struct AhandRuntime {
@@ -127,30 +202,31 @@ impl AhandRuntime {
         let device_id = identity::device_id_from_pubkey(&id.public_key_bytes());
 
         if let Some(prev) = guard.as_ref() {
-            if should_reuse_active_session(
-                prev,
-                &cfg.team9_user_id,
-                &cfg.hub_url,
-                &device_id,
-            ) {
+            if should_reuse_active_session(prev, &cfg.team9_user_id, &cfg.hub_url, &device_id) {
                 return Ok(StartResult {
                     device_id: prev.hub_device_id.clone(),
                 });
             }
         }
 
-        let daemon_cfg = ahandd::DaemonConfig::builder(
-            &cfg.hub_url,
-            &cfg.device_jwt,
-            identity_dir,
-        )
-        .device_id(&device_id)
-        .session_mode(ahandd::SessionMode::AutoAccept)
-        .browser_enabled(false)
-        .heartbeat_interval(Duration::from_secs(cfg.heartbeat_interval_seconds))
-        .build();
+        let startup_inputs = StartupInputs {
+            hub_url: cfg.hub_url.clone(),
+            device_jwt: cfg.device_jwt.clone(),
+            identity_dir: identity_dir.clone(),
+            device_id: device_id.clone(),
+            heartbeat_interval: Duration::from_secs(cfg.heartbeat_interval_seconds),
+        };
 
-        let handle = ahandd::spawn(daemon_cfg)
+        // Optionally overlay the on-disk Config (mainly for browser.enabled).
+        // Failures to read are non-fatal during start() — we fall back to
+        // pure in-memory defaults so the daemon can still spawn.
+        let on_disk = cfg
+            .config_path
+            .as_deref()
+            .and_then(|p| ahandd::config::Config::load(p).ok());
+        let daemon_cfg = build_daemon_config(on_disk.as_ref(), &startup_inputs);
+
+        let handle = ahandd::spawn(daemon_cfg.clone())
             .await
             .map_err(|e| format!("ahandd::spawn failed: {e}"))?;
 
@@ -174,6 +250,9 @@ impl AhandRuntime {
             hub_url: cfg.hub_url,
             hub_device_id: device_id.clone(),
             status_forwarder,
+            startup_inputs,
+            current_daemon_config: daemon_cfg,
+            config_path: cfg.config_path,
         });
 
         Ok(StartResult { device_id })
@@ -212,12 +291,257 @@ impl AhandRuntime {
         guard.as_ref().map(|s| s.hub_device_id.clone())
     }
 
+    /// Hot-reload the embedded daemon. Reads the on-disk config fresh
+    /// (when `StartConfig::config_path` was supplied), shuts the running
+    /// daemon down with a 5-second timeout, and spawns a new instance
+    /// with the new config. On primary-spawn failure, attempts a rollback
+    /// spawn with the previous `DaemonConfig`.
+    ///
+    /// Serialization: this method takes `&self` and uses interior
+    /// mutability via `Arc<Mutex<Option<ActiveSession>>>`. The mutex is
+    /// held for the entire reload — including both the shutdown wait and
+    /// the spawn — so concurrent calls to `reload()` (or `start()` /
+    /// `stop()`) are serialized at the AhandRuntime level. A second
+    /// reload waits for the first one to commit (or fail) before
+    /// observing the post-reload state.
+    ///
+    /// Failure modes are described on [`ReloadError`].
+    ///
+    /// Pre-condition: a session must be active (`start()` has succeeded).
+    /// Calling `reload()` when no session is active returns
+    /// `SpawnFailedNoRollback` describing the precondition violation —
+    /// the caller is expected to call `start()` instead.
+    pub async fn reload(&self) -> Result<(), ReloadError> {
+        let mut guard = self.inner.lock().await;
+
+        // 1. Take ownership of the active session (so we can move the
+        //    handle into shutdown()). If absent, there's nothing to
+        //    reload — surface a NoRollback failure so the caller knows
+        //    to call start() instead.
+        let Some(session) = guard.take() else {
+            return Err(ReloadError::SpawnFailedNoRollback {
+                primary: "reload called with no active session".into(),
+                rollback: "not attempted — no previous config to roll back to".into(),
+            });
+        };
+
+        let ActiveSession {
+            handle: old_handle,
+            team9_user_id,
+            hub_url,
+            hub_device_id,
+            status_forwarder,
+            startup_inputs,
+            current_daemon_config: rollback_daemon_cfg,
+            config_path,
+        } = session;
+
+        // 2. Read fresh on-disk config (when applicable). Failures here
+        //    mean we can't compute a new DaemonConfig — surface
+        //    NoRollback rather than tear down the still-running daemon.
+        //    Restore the session into `*guard` so the runtime stays
+        //    healthy.
+        let new_on_disk = match config_path.clone() {
+            Some(path) => match ahandd::config::Config::load(&path) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    let path_display = path.display().to_string();
+                    *guard = Some(ActiveSession {
+                        handle: old_handle,
+                        team9_user_id,
+                        hub_url,
+                        hub_device_id,
+                        status_forwarder,
+                        startup_inputs,
+                        current_daemon_config: rollback_daemon_cfg,
+                        config_path,
+                    });
+                    return Err(ReloadError::SpawnFailedNoRollback {
+                        primary: format!("load new config from {path_display}: {e:#}"),
+                        rollback: "not attempted — old daemon left running".into(),
+                    });
+                }
+            },
+            None => None,
+        };
+
+        // 3. Build the new DaemonConfig and pre-clone for spawn (the
+        //    builder consumes by value).
+        let new_daemon_cfg = build_daemon_config(new_on_disk.as_ref(), &startup_inputs);
+
+        // 4. Stop forwarding status events from the dying handle. We
+        //    abort the forwarder before shutdown so the renderer doesn't
+        //    momentarily see Idle/Offline transitions before the new
+        //    handle's status arrives. The new spawn below will register
+        //    its own forwarder.
+        status_forwarder.abort();
+        let _ = status_forwarder.await;
+
+        // 5. Shutdown old daemon with timeout. On timeout we drop the
+        //    in-flight future; the handle's Drop will cancel the worker.
+        match tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, old_handle.shutdown()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_e)) => {
+                // shutdown returned Err but within timeout. The daemon
+                // is gone either way — proceed to spawn.
+            }
+            Err(_timeout) => {
+                // *guard is already None (we took the session out). The
+                // runtime now has no active daemon; the caller can
+                // recover by calling start() again.
+                return Err(ReloadError::ShutdownTimeout);
+            }
+        }
+
+        // 6. Spawn primary; on failure, attempt rollback.
+        match ahandd::spawn(new_daemon_cfg.clone()).await {
+            Ok(handle) => {
+                let session = build_active_session(
+                    self.app_emitter_for_session(&team9_user_id),
+                    handle,
+                    team9_user_id,
+                    hub_url,
+                    hub_device_id,
+                    startup_inputs,
+                    new_daemon_cfg,
+                    config_path,
+                );
+                *guard = Some(session);
+                Ok(())
+            }
+            Err(primary_err) => {
+                match ahandd::spawn(rollback_daemon_cfg.clone()).await {
+                    Ok(handle) => {
+                        let session = build_active_session(
+                            self.app_emitter_for_session(&team9_user_id),
+                            handle,
+                            team9_user_id,
+                            hub_url,
+                            hub_device_id,
+                            startup_inputs,
+                            rollback_daemon_cfg,
+                            config_path,
+                        );
+                        *guard = Some(session);
+                        Err(ReloadError::SpawnFailedRolledBack {
+                            primary: format!("{primary_err:#}"),
+                        })
+                    }
+                    Err(rollback_err) => {
+                        // *guard remains None — runtime is offline.
+                        Err(ReloadError::SpawnFailedNoRollback {
+                            primary: format!("{primary_err:#}"),
+                            rollback: format!("{rollback_err:#}"),
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    /// Hook that returns the `AppHandle` used to forward status events
+    /// from the new daemon spawned during `reload()`. The current
+    /// implementation has no `AppHandle` cached on `AhandRuntime` (it's
+    /// passed per-call to `start()`/`stop()`), so the reload path emits
+    /// no status events directly — the new daemon's own status watch
+    /// will be subscribed to once a Tauri command resolves the handle
+    /// again. Tests pass `None`.
+    ///
+    /// NOTE for Task 14: when wiring up the `browser_install` Tauri
+    /// command, the caller is expected to also `state.app_handle()` and
+    /// re-emit the new daemon's status. A future iteration may cache
+    /// the `AppHandle` inside `AhandRuntime` so reload() forwards
+    /// transparently.
+    fn app_emitter_for_session(&self, _team9_user_id: &str) -> Option<AppHandle> {
+        None
+    }
+
     async fn shutdown_session(session: ActiveSession) {
         let _ = session.handle.shutdown().await;
         // Abort then await so the forwarder finishes its current poll (delivering
         // the final Offline status event) before we return.
         session.status_forwarder.abort();
         let _ = session.status_forwarder.await;
+    }
+}
+
+/// Construct a fresh `ahandd::DaemonConfig` from the given startup
+/// inputs, optionally overlaying values from an on-disk
+/// `ahandd::config::Config`.
+///
+/// Today the only on-disk field that affects the embedded daemon is
+/// `[browser].enabled`. If `on_disk` is `None` (no `config_path` was
+/// supplied at start, or the file failed to load), the daemon is spawned
+/// with `browser_enabled = false` (the historical default).
+///
+/// All other fields (`hub_url`, `device_jwt`, `identity_dir`,
+/// `device_id`, `heartbeat_interval`) come from the startup inputs.
+/// Future on-disk overlays should extend this helper rather than the
+/// inline call sites.
+fn build_daemon_config(
+    on_disk: Option<&ahandd::config::Config>,
+    inputs: &StartupInputs,
+) -> ahandd::DaemonConfig {
+    let browser_enabled = on_disk
+        .and_then(|c| c.browser.as_ref())
+        .and_then(|b| b.enabled)
+        .unwrap_or(false);
+
+    ahandd::DaemonConfig::builder(
+        &inputs.hub_url,
+        &inputs.device_jwt,
+        inputs.identity_dir.clone(),
+    )
+    .device_id(&inputs.device_id)
+    .session_mode(ahandd::SessionMode::AutoAccept)
+    .browser_enabled(browser_enabled)
+    .heartbeat_interval(inputs.heartbeat_interval)
+    .build()
+}
+
+/// Stitch a freshly-spawned `DaemonHandle` plus the carried-over session
+/// metadata back into an `ActiveSession`. Used by `reload()` after both
+/// primary and rollback spawns. The optional `app` is the Tauri
+/// `AppHandle` used to forward status events; when `None` (current
+/// behavior — see `app_emitter_for_session`) no forwarder task is
+/// spawned and the renderer must consult `runtime.status()` to discover
+/// the new state.
+#[allow(clippy::too_many_arguments)]
+fn build_active_session(
+    app: Option<AppHandle>,
+    handle: ahandd::DaemonHandle,
+    team9_user_id: String,
+    hub_url: String,
+    hub_device_id: String,
+    startup_inputs: StartupInputs,
+    current_daemon_config: ahandd::DaemonConfig,
+    config_path: Option<PathBuf>,
+) -> ActiveSession {
+    let status_forwarder = match app {
+        Some(app_clone) => {
+            let mut status_rx = handle.subscribe_status();
+            let initial = DaemonStatus::from(status_rx.borrow().clone());
+            let _ = app_clone.emit("ahand-daemon-status", &initial);
+            tokio::spawn(async move {
+                while status_rx.changed().await.is_ok() {
+                    let s = DaemonStatus::from(status_rx.borrow().clone());
+                    if app_clone.emit("ahand-daemon-status", &s).is_err() {
+                        break;
+                    }
+                }
+            })
+        }
+        None => tokio::spawn(async {}),
+    };
+    ActiveSession {
+        handle,
+        team9_user_id,
+        hub_url,
+        hub_device_id,
+        status_forwarder,
+        startup_inputs,
+        current_daemon_config,
+        config_path,
     }
 }
 
@@ -299,7 +623,11 @@ mod tests {
         // Verify full deserialization round-trip
         let back: DaemonStatus = serde_json::from_str(&json).unwrap();
         match back {
-            DaemonStatus::Error { kind: ErrorKind::Auth, message, device_id: Some(d) } => {
+            DaemonStatus::Error {
+                kind: ErrorKind::Auth,
+                message,
+                device_id: Some(d),
+            } => {
                 assert_eq!(message, "jwt_expired");
                 assert_eq!(d, "abc");
             }
@@ -314,11 +642,18 @@ mod tests {
             (r#"{"state":"connecting"}"#, "connecting"),
             (r#"{"state":"online","device_id":"dev-1"}"#, "online"),
             (r#"{"state":"offline"}"#, "offline"),
-            (r#"{"state":"error","kind":"network","message":"x"}"#, "error"),
+            (
+                r#"{"state":"error","kind":"network","message":"x"}"#,
+                "error",
+            ),
         ];
         for (json, label) in &cases {
             let result: Result<DaemonStatus, _> = serde_json::from_str(json);
-            assert!(result.is_ok(), "failed to deserialize {label}: {:?}", result.err());
+            assert!(
+                result.is_ok(),
+                "failed to deserialize {label}: {:?}",
+                result.err()
+            );
         }
     }
 
@@ -445,5 +780,164 @@ mod tests {
     fn error_kind_from_ahandd_other() {
         let k: ErrorKind = ahandd::ErrorKind::Other.into();
         assert!(matches!(k, ErrorKind::Other));
+    }
+
+    #[test]
+    fn reload_error_serialize_shape() {
+        // Verify the camelCase tagged-union shape expected by the TS side.
+        let e = ReloadError::ShutdownTimeout;
+        let json = serde_json::to_string(&e).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["kind"], "shutdownTimeout");
+
+        let e = ReloadError::SpawnFailedRolledBack {
+            primary: "primary boom".into(),
+        };
+        let v: serde_json::Value =
+            serde_json::from_value(serde_json::to_value(&e).unwrap()).unwrap();
+        assert_eq!(v["kind"], "spawnFailedRolledBack");
+        assert_eq!(v["primary"], "primary boom");
+
+        let e = ReloadError::SpawnFailedNoRollback {
+            primary: "p".into(),
+            rollback: "r".into(),
+        };
+        let v: serde_json::Value =
+            serde_json::from_value(serde_json::to_value(&e).unwrap()).unwrap();
+        assert_eq!(v["kind"], "spawnFailedNoRollback");
+        assert_eq!(v["primary"], "p");
+        assert_eq!(v["rollback"], "r");
+    }
+
+    #[test]
+    fn reload_error_display_messages_match_thiserror() {
+        assert_eq!(
+            format!("{}", ReloadError::ShutdownTimeout),
+            "daemon shutdown timed out after 5s"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ReloadError::SpawnFailedRolledBack {
+                    primary: "boom".into()
+                }
+            ),
+            "respawn failed, rolled back to previous config: boom"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ReloadError::SpawnFailedNoRollback {
+                    primary: "p".into(),
+                    rollback: "r".into(),
+                }
+            ),
+            "respawn failed and rollback also failed; daemon is offline"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_with_no_active_session_returns_no_rollback_error() {
+        // Calling reload() before start() is a precondition violation.
+        // We surface SpawnFailedNoRollback rather than a panic so the
+        // command layer can render the same banner as a real failure.
+        let rt = AhandRuntime::new();
+        match rt.reload().await {
+            Err(ReloadError::SpawnFailedNoRollback { primary, .. }) => {
+                assert!(primary.contains("no active session"));
+            }
+            other => panic!("expected SpawnFailedNoRollback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn start_config_config_path_optional_and_round_trips() {
+        // Without config_path
+        let json = r#"{
+            "team9_user_id": "uuid",
+            "hub_url": "wss://x",
+            "device_jwt": "j",
+            "jwt_expires_at": 0
+        }"#;
+        let cfg: StartConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.config_path.is_none());
+
+        // With config_path
+        let json = r#"{
+            "team9_user_id": "uuid",
+            "hub_url": "wss://x",
+            "device_jwt": "j",
+            "jwt_expires_at": 0,
+            "config_path": "/tmp/ahandd/config.toml"
+        }"#;
+        let cfg: StartConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.config_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
+            Some("/tmp/ahandd/config.toml".to_string())
+        );
+    }
+
+    #[test]
+    fn build_daemon_config_browser_enabled_defaults_false_without_overlay() {
+        let inputs = StartupInputs {
+            hub_url: "wss://hub/ws".into(),
+            device_jwt: "jwt".into(),
+            identity_dir: PathBuf::from("/tmp/id"),
+            device_id: "dev1".into(),
+            heartbeat_interval: Duration::from_secs(30),
+        };
+        let cfg = build_daemon_config(None, &inputs);
+        assert!(!cfg.browser_enabled);
+        assert_eq!(cfg.hub_url, "wss://hub/ws");
+        assert_eq!(cfg.device_jwt, "jwt");
+        assert_eq!(cfg.device_id.as_deref(), Some("dev1"));
+        assert_eq!(cfg.heartbeat_interval, Duration::from_secs(30));
+    }
+
+    // ── reload() integration tests ──────────────────────────────────────
+    //
+    // These four tests cover the happy path and three failure modes for
+    // `AhandRuntime::reload()`. They require either:
+    //   (a) a real ahandd daemon (heavy, requires WebSocket hub fixture), OR
+    //   (b) injection of a mock `DaemonHandle` / `spawn` boundary.
+    //
+    // ahandd does not currently expose a mocking surface, and introducing
+    // a local `trait DaemonAdapter` wrapper would touch every call site in
+    // start()/stop()/reload() with non-trivial blast radius. Per Phase C
+    // plan §Task 13 Step 6, leaving these as `#[ignore]`'d todos is the
+    // accepted fallback — real bodies will land in a follow-up after the
+    // mock-DaemonHandle infrastructure is decided. The non-ignored tests
+    // above (`reload_with_no_active_session_returns_no_rollback_error`,
+    // `reload_error_serialize_shape`, `reload_error_display_messages_match_thiserror`,
+    // `build_daemon_config_browser_enabled_defaults_false_without_overlay`,
+    // and `start_config_config_path_optional_and_round_trips`) cover the
+    // contract surface that doesn't depend on a live daemon.
+    //
+    // TODO(task-13-followup): blocked on mock-DaemonHandle test infrastructure.
+
+    #[tokio::test]
+    #[ignore = "blocked on mock-DaemonHandle test infrastructure (Phase C plan §Task 13 Step 6)"]
+    async fn reload_happy_path_respawns_with_new_config() {
+        todo!("implement after deciding on mock strategy for ahandd::spawn / DaemonHandle");
+    }
+
+    #[tokio::test]
+    #[ignore = "blocked on mock-DaemonHandle test infrastructure (Phase C plan §Task 13 Step 6)"]
+    async fn reload_shutdown_timeout_surfaces_error() {
+        todo!("implement after deciding on mock strategy for ahandd::spawn / DaemonHandle");
+    }
+
+    #[tokio::test]
+    #[ignore = "blocked on mock-DaemonHandle test infrastructure (Phase C plan §Task 13 Step 6)"]
+    async fn reload_rollback_on_spawn_failure() {
+        todo!("implement after deciding on mock strategy for ahandd::spawn / DaemonHandle");
+    }
+
+    #[tokio::test]
+    #[ignore = "blocked on mock-DaemonHandle test infrastructure (Phase C plan §Task 13 Step 6)"]
+    async fn reload_hard_fail_when_rollback_also_fails() {
+        todo!("implement after deciding on mock strategy for ahandd::spawn / DaemonHandle");
     }
 }

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -116,10 +116,11 @@ pub struct StartResult {
 ///   respawn. The runtime is left in a session-less state (handle was
 ///   dropped); a follow-up `start()` is required to recover. We do NOT
 ///   force-kill — the `DaemonHandle::Drop` impl cancels the worker task.
-/// * `SpawnFailedRolledBack` — the new spawn failed but a rollback spawn
-///   with the previous `DaemonConfig` succeeded. The runtime is fully
-///   functional, just with the old config; the user's intended change
-///   didn't take effect.
+/// * `SpawnFailedRolledBack` — the config-rollout did not take effect
+///   (either the new config was invalid / failed to load, or the new
+///   spawn failed and a rollback spawn with the previous `DaemonConfig`
+///   succeeded). The runtime is fully functional on the previous config;
+///   the user's intended change didn't take effect.
 /// * `SpawnFailedNoRollback` — both spawns failed. The runtime has no
 ///   active daemon; the app needs to call `start()` again (or restart).
 #[derive(Debug, Serialize, thiserror::Error)]
@@ -345,6 +346,13 @@ impl AhandRuntime {
             Some(path) => match ahandd::config::Config::load(&path) {
                 Ok(c) => Some(c),
                 Err(e) => {
+                    // Config-load failure: the user's intent (apply new
+                    // config) didn't take effect; the old daemon is still
+                    // running on the previous config. Semantically this is
+                    // the same outcome as a primary-spawn failure that
+                    // succeeded its rollback — surface
+                    // `SpawnFailedRolledBack` so the UI reports an honest
+                    // "still online, on previous config" state.
                     let path_display = path.display().to_string();
                     *guard = Some(ActiveSession {
                         handle: old_handle,
@@ -356,9 +364,8 @@ impl AhandRuntime {
                         current_daemon_config: rollback_daemon_cfg,
                         config_path,
                     });
-                    return Err(ReloadError::SpawnFailedNoRollback {
-                        primary: format!("load new config from {path_display}: {e:#}"),
-                        rollback: "not attempted — old daemon left running".into(),
+                    return Err(ReloadError::SpawnFailedRolledBack {
+                        primary: format!("config load from {path_display}: {e:#}"),
                     });
                 }
             },
@@ -452,6 +459,14 @@ impl AhandRuntime {
     /// re-emit the new daemon's status. A future iteration may cache
     /// the `AppHandle` inside `AhandRuntime` so reload() forwards
     /// transparently.
+    // TODO(task-14): replace with real plumbing — pass the AppHandle through
+    // from the Tauri command site so post-reload daemon-status events reach
+    // the renderer. Today this returns None and the watch task at
+    // build_active_session is a no-op for reload-spawned daemons.
+    // The `_team9_user_id` parameter is currently unused; it exists so a
+    // single Tauri app could later scope per-user app handles when hosting
+    // multiple users. Keeping the signature stable means Task 14's wiring
+    // is a body-only change.
     fn app_emitter_for_session(&self, _team9_user_id: &str) -> Option<AppHandle> {
         None
     }
@@ -531,6 +546,8 @@ fn build_active_session(
                 }
             })
         }
+        // TODO(task-14): becomes unreachable once app_emitter_for_session returns Some.
+        // Until then, no-op so the JoinHandle field on ActiveSession is always populated.
         None => tokio::spawn(async {}),
     };
     ActiveSession {
@@ -785,28 +802,39 @@ mod tests {
     #[test]
     fn reload_error_serialize_shape() {
         // Verify the camelCase tagged-union shape expected by the TS side.
-        let e = ReloadError::ShutdownTimeout;
-        let json = serde_json::to_string(&e).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["kind"], "shutdownTimeout");
+        // Use full-JSON `assert_eq!` so any drift (e.g. a new field) breaks
+        // the test rather than silently widening the contract.
+        let timeout_json = serde_json::to_value(&ReloadError::ShutdownTimeout).unwrap();
+        assert_eq!(
+            timeout_json,
+            serde_json::json!({ "kind": "shutdownTimeout" })
+        );
 
-        let e = ReloadError::SpawnFailedRolledBack {
+        let rolled = ReloadError::SpawnFailedRolledBack {
             primary: "primary boom".into(),
         };
-        let v: serde_json::Value =
-            serde_json::from_value(serde_json::to_value(&e).unwrap()).unwrap();
-        assert_eq!(v["kind"], "spawnFailedRolledBack");
-        assert_eq!(v["primary"], "primary boom");
+        let rolled_json = serde_json::to_value(&rolled).unwrap();
+        assert_eq!(
+            rolled_json,
+            serde_json::json!({
+                "kind": "spawnFailedRolledBack",
+                "primary": "primary boom",
+            })
+        );
 
-        let e = ReloadError::SpawnFailedNoRollback {
-            primary: "p".into(),
-            rollback: "r".into(),
+        let no_rollback = ReloadError::SpawnFailedNoRollback {
+            primary: "primary boom".into(),
+            rollback: "rollback boom".into(),
         };
-        let v: serde_json::Value =
-            serde_json::from_value(serde_json::to_value(&e).unwrap()).unwrap();
-        assert_eq!(v["kind"], "spawnFailedNoRollback");
-        assert_eq!(v["primary"], "p");
-        assert_eq!(v["rollback"], "r");
+        let no_rollback_json = serde_json::to_value(&no_rollback).unwrap();
+        assert_eq!(
+            no_rollback_json,
+            serde_json::json!({
+                "kind": "spawnFailedNoRollback",
+                "primary": "primary boom",
+                "rollback": "rollback boom",
+            })
+        );
     }
 
     #[test]
@@ -894,6 +922,38 @@ mod tests {
         assert_eq!(cfg.device_jwt, "jwt");
         assert_eq!(cfg.device_id.as_deref(), Some("dev1"));
         assert_eq!(cfg.heartbeat_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn build_daemon_config_browser_enabled_overlay_propagates_true() {
+        use std::io::Write;
+        // ahandd::config::Config doesn't implement Default and we don't
+        // want to pull `toml` as a new dev-dep just to construct one.
+        // `Config::load` already deserializes from a TOML file, so write
+        // a minimal TOML literal to a tempfile and reuse it. All Config
+        // fields are Option/serde-default, so `[browser] enabled = true`
+        // alone parses cleanly.
+        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        writeln!(tmp.as_file(), "[browser]\nenabled = true").expect("write toml");
+        let cfg = ahandd::config::Config::load(tmp.path()).expect("valid TOML");
+
+        let inputs = StartupInputs {
+            hub_url: "wss://hub/ws".into(),
+            device_jwt: "jwt".into(),
+            identity_dir: PathBuf::from("/tmp/id"),
+            device_id: "dev1".into(),
+            heartbeat_interval: Duration::from_secs(30),
+        };
+
+        let daemon_cfg = build_daemon_config(Some(&cfg), &inputs);
+
+        assert!(
+            daemon_cfg.browser_enabled,
+            "overlay browser.enabled=true must propagate to DaemonConfig.browser_enabled"
+        );
+        // Other fields still come from inputs.
+        assert_eq!(daemon_cfg.hub_url, "wss://hub/ws");
+        assert_eq!(daemon_cfg.device_id.as_deref(), Some("dev1"));
     }
 
     // ── reload() integration tests ──────────────────────────────────────

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -368,6 +368,9 @@ pub fn run() {
             ahand::commands::ahand_stop,
             ahand::commands::ahand_status,
             ahand::commands::ahand_clear_identity,
+            ahand::browser_runtime::browser_status,
+            ahand::browser_runtime::browser_install,
+            ahand::browser_runtime::browser_set_enabled,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/BrowserBinaryCard.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/BrowserBinaryCard.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { Check, Chrome, Globe, Package, Puzzle } from "lucide-react";
+import { Check, Chrome, Globe, Puzzle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -10,65 +9,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-
-export function BrowserConfigTab() {
-  const { t } = useTranslation("ahand");
-
-  return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">
-        {t("devicesTabs.browserDescription")}
-      </p>
-      <RuntimeCard />
-      <BrowserBinaryCard />
-    </div>
-  );
-}
-
-function RuntimeCard() {
-  const { t } = useTranslation("ahand");
-
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-2">
-          <CardTitle className="text-base">
-            {t("browser.runtimeTitle")}
-          </CardTitle>
-          <Badge
-            variant="outline"
-            size="sm"
-            className="h-5 shrink-0 rounded-md border-border/60 bg-background/80 px-1.5 text-[10px] font-medium text-muted-foreground"
-          >
-            {t("comingSoon")}
-          </Badge>
-        </div>
-        <CardDescription>{t("browser.runtimeDescription")}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center gap-3">
-          <Package className="h-5 w-5 text-muted-foreground shrink-0" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">Playwright</p>
-            <p className="text-xs text-muted-foreground">
-              {t("browser.runtimeSubtitle")}
-            </p>
-          </div>
-          <Badge
-            variant="outline"
-            size="sm"
-            className="h-5 shrink-0 rounded-md border-muted bg-background/80 px-1.5 text-[10px] font-medium text-muted-foreground"
-          >
-            {t("browser.statusNotInstalled")}
-          </Badge>
-          <Button variant="outline" size="sm" disabled>
-            {t("browser.install")}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
 
 type BrowserOption = {
   key: "bundled" | "chrome" | "edge" | "firefox";
@@ -84,7 +24,7 @@ const BROWSERS: BrowserOption[] = [
   { key: "firefox", icon: Globe, detected: false },
 ];
 
-function BrowserBinaryCard() {
+export function BrowserBinaryCard() {
   const { t } = useTranslation("ahand");
   const selected: BrowserOption["key"] = "bundled";
 

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/LogDrawer.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/LogDrawer.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TauriLogStream } from "@/hooks/useBrowserRuntime";
+
+export interface LogDrawerStep {
+  name: string;
+  logs: { line: string; stream: TauriLogStream }[];
+}
+
+interface LogDrawerProps {
+  steps: LogDrawerStep[];
+  expandedByDefault?: boolean;
+}
+
+function streamColor(stream: TauriLogStream): string {
+  if (stream === "stderr") return "text-amber-600";
+  if (stream === "info") return "text-muted-foreground italic";
+  return "";
+}
+
+export function LogDrawer({ steps, expandedByDefault }: LogDrawerProps) {
+  const { t } = useTranslation("ahand");
+  const [expanded, setExpanded] = useState(!!expandedByDefault);
+  const wasExpandedDefault = useRef(!!expandedByDefault);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  // Auto-expand when caller flips expandedByDefault to true (e.g. install
+  // starts). Don't auto-collapse on the way back — let users keep logs open
+  // if they manually expanded them.
+  useEffect(() => {
+    if (expandedByDefault && !wasExpandedDefault.current) {
+      setExpanded(true);
+    }
+    wasExpandedDefault.current = !!expandedByDefault;
+  }, [expandedByDefault]);
+
+  const totalLines = steps.reduce((sum, s) => sum + s.logs.length, 0);
+
+  useEffect(() => {
+    if (expanded && logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [steps, expanded]);
+
+  if (totalLines === 0) return null;
+
+  return (
+    <div className="border-t pt-3">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded((x) => !x)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        {expanded
+          ? t("browser.logDrawer.collapse")
+          : t("browser.logDrawer.expand", { count: totalLines })}
+      </button>
+      {expanded && (
+        <div
+          ref={logRef}
+          className="mt-2 max-h-60 overflow-y-auto font-mono text-xs bg-muted/40 p-2 rounded"
+        >
+          {steps.flatMap((s) =>
+            s.logs.map((l, i) => (
+              <div
+                key={`${s.name}-${i}`}
+                className={cn("whitespace-pre-wrap", streamColor(l.stream))}
+              >
+                <span className="text-muted-foreground">[{s.name}]</span>{" "}
+                {l.line}
+              </div>
+            )),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Package } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import {
+  type BrowserStepStatus,
+  type RuntimeUiState,
+  type StepError,
+  type TauriLogStream,
+  type TauriStepStatus,
+  useBrowserRuntime,
+} from "@/hooks/useBrowserRuntime";
+import { LogDrawer, type LogDrawerStep } from "./LogDrawer";
+import { StepRow } from "./StepRow";
+
+// The 3 canonical step names. Matches src-tauri/src/ahand/browser_runtime.rs::step_label.
+const STEP_ORDER = ["node", "playwright", "browser"] as const;
+
+interface DerivedStep {
+  name: string;
+  label: string;
+  status: TauriStepStatus;
+  detail?: string;
+  error?: StepError;
+  logs: { line: string; stream: TauriLogStream }[];
+}
+
+// Static lookup. Avoid templated `t()` calls — the i18next typed `t` overload
+// resolution combined with a template literal key has triggered a tsc 5.8
+// internal compiler crash in this repo ("Debug Failure. No error for last
+// overload signature").
+function fallbackStepLabel(name: string): string {
+  switch (name) {
+    case "node":
+      return "Node.js";
+    case "playwright":
+      return "Playwright CLI";
+    case "browser":
+      return "System browser";
+    default:
+      return name;
+  }
+}
+
+function deriveSteps(state: RuntimeUiState): DerivedStep[] {
+  // Build a lookup of any persisted/static step info first.
+  const fromStatus: Record<string, BrowserStepStatus> = {};
+  const snapshotStatus =
+    state.kind === "idle"
+      ? state.status
+      : state.kind === "error"
+        ? state.status
+        : null;
+  if (snapshotStatus) {
+    for (const s of snapshotStatus.steps) {
+      fromStatus[s.name] = s;
+    }
+  }
+  // Per-step live feed (during install/reload, or preserved on error).
+  const feed =
+    state.kind === "installing" ||
+    state.kind === "reloading" ||
+    state.kind === "error"
+      ? state.steps
+      : {};
+
+  // Union of step names from the static order, the status snapshot, and
+  // anything streamed in via the channel — preserves ordering for the
+  // canonical 3, then appends unknown step names at the end.
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const n of STEP_ORDER) {
+    seen.add(n);
+    ordered.push(n);
+  }
+  for (const k of [...Object.keys(fromStatus), ...Object.keys(feed)]) {
+    if (!seen.has(k)) {
+      seen.add(k);
+      ordered.push(k);
+    }
+  }
+
+  return ordered.map((name) => {
+    const snapshot = fromStatus[name];
+    const live = feed[name];
+    const label = snapshot?.label ?? live?.label ?? fallbackStepLabel(name);
+    const status: TauriStepStatus =
+      live?.status && live.status !== "notRun"
+        ? live.status
+        : (snapshot?.status ?? "notRun");
+    const error = live?.error ?? snapshot?.error;
+    const detail = snapshot?.detail;
+    const logs = live?.logs ?? [];
+    return { name, label, status, detail, error, logs };
+  });
+}
+
+function overallFor(state: RuntimeUiState): TauriStepStatus {
+  if (state.kind === "idle") return state.status.overall;
+  if (state.kind === "error") return state.status?.overall ?? "failed";
+  // installing / reloading / loading
+  return "notRun";
+}
+
+export function RuntimeCard() {
+  const { t } = useTranslation("ahand");
+  const { state, install, setEnabled } = useBrowserRuntime();
+  const [logDrawerOpenSignal, setLogDrawerOpenSignal] = useState(0);
+
+  // Surface terminal errors via toast. Only fire once per transition into
+  // the "error" kind — guarded by a ref so re-renders don't spam.
+  const lastErrorMessage = useRef<string | null>(null);
+  useEffect(() => {
+    if (state.kind === "error") {
+      if (lastErrorMessage.current !== state.message) {
+        lastErrorMessage.current = state.message;
+        const raw = state.message;
+        // Stable identifiers returned synchronously from the Tauri commands.
+        let translated = raw;
+        if (raw === "operation_in_progress")
+          translated = t("browser.errors.operationInProgress");
+        else if (raw === "browser_not_installed")
+          translated = t("browser.errors.browserNotInstalled");
+        else if (raw.startsWith("ahand runtime not started"))
+          translated = t("browser.errors.runtimeNotStarted");
+        else if (raw === "browser_runtime_unavailable_in_web")
+          translated = t("browser.errors.unavailableInWeb");
+        toast.error(translated);
+      }
+    } else {
+      lastErrorMessage.current = null;
+    }
+  }, [state, t]);
+
+  const overall = overallFor(state);
+  const isBusy = state.kind === "installing" || state.kind === "reloading";
+
+  const overallLabel =
+    state.kind === "installing"
+      ? t("browser.installing")
+      : state.kind === "reloading"
+        ? t("browser.reloading")
+        : overall === "ok"
+          ? t("browser.statusInstalled")
+          : overall === "failed"
+            ? t("browser.installFailed")
+            : t("browser.statusNotInstalled");
+
+  const installButtonLabel =
+    overall === "failed" || state.kind === "error"
+      ? t("browser.retry")
+      : t("browser.install");
+  const installButtonDisabled = isBusy || state.kind === "loading";
+
+  const steps = useMemo(() => deriveSteps(state), [state]);
+
+  // Agent visibility toggle: only meaningful when overall === "ok".
+  // `enabled` reflects the on-disk config; `agentVisible` reflects whether
+  // the daemon advertises the capability (depends on enabled + daemon
+  // online). For the toggle source-of-truth we use `enabled`.
+  const enabled = state.kind === "idle" ? state.status.enabled : false;
+  const agentVisibleDisabled =
+    state.kind !== "idle" || state.status.overall !== "ok";
+
+  const drawerSteps: LogDrawerStep[] = steps
+    .filter((s) => s.logs.length > 0)
+    .map((s) => ({ name: s.name, logs: s.logs }));
+
+  // Triggered via key bump so the drawer remounts/expands when the user
+  // clicks "View logs" in a help popover.
+  const drawerExpandedByDefault = isBusy || logDrawerOpenSignal > 0;
+
+  const handleInstall = () => {
+    void install(overall === "failed");
+  };
+  const handleRetryForce = () => {
+    void install(true);
+  };
+  const handleViewLogs = () => {
+    setLogDrawerOpenSignal((n) => n + 1);
+  };
+  const handleEnabledChange = (checked: boolean) => {
+    void setEnabled(checked);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{t("browser.runtimeTitle")}</CardTitle>
+        <CardDescription>{t("browser.runtimeDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Top row: overall summary + install/retry button */}
+        <div className="flex items-center gap-3">
+          <Package className="h-5 w-5 text-muted-foreground shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">Playwright</p>
+            <p className="text-xs text-muted-foreground">
+              {t("browser.runtimeSubtitle")}
+            </p>
+          </div>
+          <Badge
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-5 shrink-0 rounded-md px-1.5 text-[10px] font-medium",
+              overall === "ok" &&
+                "border-emerald-200 bg-emerald-50 text-emerald-700",
+              overall === "failed" && "border-red-200 bg-red-50 text-red-700",
+              isBusy && "border-blue-200 bg-blue-50 text-blue-700",
+              !isBusy &&
+                overall !== "ok" &&
+                overall !== "failed" &&
+                "border-border/60 bg-background/80 text-muted-foreground",
+            )}
+          >
+            {overallLabel}
+          </Badge>
+          {overall !== "ok" && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={installButtonDisabled}
+              onClick={handleInstall}
+            >
+              {installButtonLabel}
+            </Button>
+          )}
+        </div>
+
+        {/* Per-step rows */}
+        <div className="space-y-2 border-t pt-3">
+          {steps.map((s) => (
+            <StepRow
+              key={s.name}
+              name={s.name}
+              label={s.label}
+              status={s.status}
+              detail={s.detail}
+              error={s.error}
+              busy={isBusy}
+              onRetryForce={handleRetryForce}
+              onViewLogs={handleViewLogs}
+            />
+          ))}
+        </div>
+
+        {/* Agent visibility toggle */}
+        <div className="flex items-center gap-3 border-t pt-3">
+          <div className="flex-1">
+            <p className="text-sm font-medium">
+              {t("browser.agentVisibility.toggleLabel")}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {agentVisibleDisabled && state.kind === "idle"
+                ? t("browser.agentVisibility.disabledHint")
+                : t("browser.agentVisibility.tooltip")}
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            disabled={agentVisibleDisabled}
+            onCheckedChange={handleEnabledChange}
+          />
+        </div>
+
+        {/* Log drawer — only renders when we have lines to show */}
+        <LogDrawer
+          steps={drawerSteps}
+          expandedByDefault={drawerExpandedByDefault}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Package } from "lucide-react";
+import { AlertTriangle, Package } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,9 +12,16 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   type BrowserStepStatus,
+  type ReloadFailureKind,
   type RuntimeUiState,
   type StepError,
   type TauriLogStream,
@@ -39,17 +46,41 @@ interface DerivedStep {
 // Static lookup. Avoid templated `t()` calls — the i18next typed `t` overload
 // resolution combined with a template literal key has triggered a tsc 5.8
 // internal compiler crash in this repo ("Debug Failure. No error for last
-// overload signature").
-function fallbackStepLabel(name: string): string {
+// overload signature"). The literal-union return type below is required
+// for the typed `t()` overload to resolve.
+function fallbackStepLabelKey(
+  name: string,
+):
+  | "browser.steps.node"
+  | "browser.steps.playwright"
+  | "browser.steps.browser"
+  | "browser.steps.unknown" {
   switch (name) {
     case "node":
-      return "Node.js";
+      return "browser.steps.node";
     case "playwright":
-      return "Playwright CLI";
+      return "browser.steps.playwright";
     case "browser":
-      return "System browser";
+      return "browser.steps.browser";
     default:
-      return name;
+      return "browser.steps.unknown";
+  }
+}
+
+function reloadStatusKey(
+  kind: ReloadFailureKind,
+):
+  | "browser.reloadStatus.shutdownTimeout"
+  | "browser.reloadStatus.spawnFailedRolledBack"
+  | "browser.reloadStatus.spawnFailedNoRollback" {
+  switch (kind) {
+    case "shutdownTimeout":
+      return "browser.reloadStatus.shutdownTimeout";
+    case "spawnFailedRolledBack":
+      return "browser.reloadStatus.spawnFailedRolledBack";
+    case "spawnFailedNoRollback":
+    default:
+      return "browser.reloadStatus.spawnFailedNoRollback";
   }
 }
 
@@ -94,7 +125,9 @@ function deriveSteps(state: RuntimeUiState): DerivedStep[] {
   return ordered.map((name) => {
     const snapshot = fromStatus[name];
     const live = feed[name];
-    const label = snapshot?.label ?? live?.label ?? fallbackStepLabel(name);
+    // Leave label as the wire `name` if there's no live/snapshot label;
+    // the consumer (RuntimeCard) will localize via `fallbackStepLabelKey`.
+    const label = snapshot?.label ?? live?.label ?? "";
     const status: TauriStepStatus =
       live?.status && live.status !== "notRun"
         ? live.status
@@ -143,6 +176,25 @@ export function RuntimeCard() {
     }
   }, [state, t]);
 
+  // Surface daemon reload failures the moment they're observed. The Tauri
+  // commands `browser_install` / `browser_set_enabled` resolve `Ok(status)`
+  // even when the daemon reload errored, so without this the user would
+  // see green "Installed" while the daemon is actually offline / stale.
+  // Keyed by the monotonic `seq` so re-renders don't refire and a fresh
+  // failure (same kind/message but new event) still toasts.
+  const reloadFailure =
+    state.kind !== "loading" ? state.reloadFailure : undefined;
+  const lastReloadFailureSeq = useRef<number | null>(null);
+  useEffect(() => {
+    if (!reloadFailure) {
+      lastReloadFailureSeq.current = null;
+      return;
+    }
+    if (lastReloadFailureSeq.current === reloadFailure.seq) return;
+    lastReloadFailureSeq.current = reloadFailure.seq;
+    toast.error(t(reloadStatusKey(reloadFailure.kind)));
+  }, [reloadFailure, t]);
+
   const overall = overallFor(state);
   const isBusy = state.kind === "installing" || state.kind === "reloading";
 
@@ -170,8 +222,17 @@ export function RuntimeCard() {
   // the daemon advertises the capability (depends on enabled + daemon
   // online). For the toggle source-of-truth we use `enabled`.
   const enabled = state.kind === "idle" ? state.status.enabled : false;
+  const agentVisible =
+    state.kind === "idle" ? state.status.agentVisible : false;
   const agentVisibleDisabled =
     state.kind !== "idle" || state.status.overall !== "ok";
+  // Mismatch: user wants it on, daemon hasn't picked it up yet (e.g. reload
+  // failed). Surfaces an inline warning next to the Switch.
+  const agentVisibleOutOfSync =
+    state.kind === "idle" &&
+    state.status.overall === "ok" &&
+    enabled &&
+    !agentVisible;
 
   const drawerSteps: LogDrawerStep[] = steps
     .filter((s) => s.logs.length > 0)
@@ -245,7 +306,7 @@ export function RuntimeCard() {
             <StepRow
               key={s.name}
               name={s.name}
-              label={s.label}
+              label={s.label || t(fallbackStepLabelKey(s.name))}
               status={s.status}
               detail={s.detail}
               error={s.error}
@@ -268,6 +329,30 @@ export function RuntimeCard() {
                 : t("browser.agentVisibility.tooltip")}
             </p>
           </div>
+          {agentVisibleOutOfSync && (
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    aria-label={t("browser.agentVisibility.outOfSync")}
+                    className="inline-flex items-center justify-center text-amber-600"
+                  >
+                    <AlertTriangle className="h-4 w-4" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs">
+                  <div className="text-xs">
+                    <div className="font-medium">
+                      {t("browser.agentVisibility.outOfSync")}
+                    </div>
+                    <div className="opacity-80 mt-0.5">
+                      {t("browser.agentVisibility.outOfSyncTooltip")}
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           <Switch
             checked={enabled}
             disabled={agentVisibleDisabled}

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/StepRow.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/StepRow.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Check,
+  Circle,
+  Copy,
+  ExternalLink,
+  HelpCircle,
+  Loader2,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { StepError, TauriStepStatus } from "@/hooks/useBrowserRuntime";
+
+export interface StepRowProps {
+  name: string;
+  label: string;
+  status: TauriStepStatus;
+  detail?: string;
+  error?: StepError;
+  /** Called when the user clicks "Retry with --force" inside the help popover. */
+  onRetryForce?: () => void;
+  /** Called when the user clicks "View logs" — typically opens the log drawer. */
+  onViewLogs?: () => void;
+  /** True while the parent is in `installing` or `reloading` — animates spinner. */
+  busy?: boolean;
+}
+
+function StatusIcon({
+  status,
+  busy,
+}: {
+  status: TauriStepStatus;
+  busy?: boolean;
+}) {
+  if (busy && status !== "ok" && status !== "failed") {
+    return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+  }
+  if (status === "ok") return <Check className="h-4 w-4 text-emerald-600" />;
+  if (status === "failed") return <X className="h-4 w-4 text-red-600" />;
+  if (status === "skipped")
+    return <Circle className="h-4 w-4 text-muted-foreground/60" />;
+  return <Circle className="h-4 w-4 text-muted-foreground" />;
+}
+
+// Static lookup for all 6 ErrorCodes. We avoid templated `t()` calls (e.g.
+// `` t(`browser.help.${code}`) ``) because they stress TS overload
+// resolution and have triggered a tsc 5.8 internal compiler crash
+// ("Debug Failure. No error for last overload signature") in this repo.
+function helpMessageKey(
+  code: string,
+):
+  | "browser.help.permission_denied"
+  | "browser.help.network"
+  | "browser.help.no_system_browser"
+  | "browser.help.node_missing"
+  | "browser.help.version_mismatch"
+  | "browser.help.unknown" {
+  switch (code) {
+    case "permission_denied":
+      return "browser.help.permission_denied";
+    case "network":
+      return "browser.help.network";
+    case "no_system_browser":
+      return "browser.help.no_system_browser";
+    case "node_missing":
+      return "browser.help.node_missing";
+    case "version_mismatch":
+      return "browser.help.version_mismatch";
+    case "unknown":
+    default:
+      return "browser.help.unknown";
+  }
+}
+
+function statusBadgeKey(
+  status: TauriStepStatus,
+):
+  | "browser.stepStatus.ok"
+  | "browser.stepStatus.skipped"
+  | "browser.stepStatus.failed"
+  | "browser.stepStatus.notRun" {
+  switch (status) {
+    case "ok":
+      return "browser.stepStatus.ok";
+    case "skipped":
+      return "browser.stepStatus.skipped";
+    case "failed":
+      return "browser.stepStatus.failed";
+    case "notRun":
+    default:
+      return "browser.stepStatus.notRun";
+  }
+}
+
+function HelpPopover({
+  error,
+  onRetryForce,
+  onViewLogs,
+}: {
+  error: StepError;
+  onRetryForce?: () => void;
+  onViewLogs?: () => void;
+}) {
+  const { t } = useTranslation("ahand");
+  const [copied, setCopied] = useState(false);
+
+  const messageKey = helpMessageKey(error.code);
+  const message = t(messageKey);
+
+  const onCopy = () => {
+    const cmd = "sudo chown -R $(whoami) ~/.ahand";
+    void navigator.clipboard.writeText(cmd).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={t("browser.help.aria")}
+          className="p-1 rounded hover:bg-muted text-muted-foreground"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 text-sm space-y-2" align="end">
+        <p>{message}</p>
+        {error.code === "permission_denied" && (
+          <div className="space-y-1">
+            <pre className="text-xs bg-muted p-2 rounded select-all">
+              sudo chown -R $(whoami) ~/.ahand
+            </pre>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onCopy}
+              className="w-full"
+            >
+              <Copy className="h-3 w-3 mr-1" />
+              {copied
+                ? t("browser.help.copied")
+                : t("browser.help.copyCommand")}
+            </Button>
+          </div>
+        )}
+        {error.code === "network" && (
+          <p className="text-xs text-muted-foreground">
+            {t("browser.help.networkHint")}
+          </p>
+        )}
+        {error.code === "no_system_browser" && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            asChild
+            className="w-full"
+          >
+            <a
+              href="https://www.google.com/chrome/"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <ExternalLink className="h-3 w-3 mr-1" />
+              {t("browser.help.downloadChrome")}
+            </a>
+          </Button>
+        )}
+        {error.code === "node_missing" && (
+          <p className="text-xs text-muted-foreground">
+            {t("browser.help.nodeMissingHint")}
+          </p>
+        )}
+        {error.code === "version_mismatch" && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRetryForce}
+            disabled={!onRetryForce}
+            className="w-full"
+          >
+            {t("browser.help.retryWithForce")}
+          </Button>
+        )}
+        {error.code !== "permission_denied" &&
+          error.code !== "network" &&
+          error.code !== "no_system_browser" &&
+          error.code !== "node_missing" &&
+          error.code !== "version_mismatch" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onViewLogs}
+              disabled={!onViewLogs}
+              className="w-full"
+            >
+              {t("browser.help.viewLogs")}
+            </Button>
+          )}
+        <pre className="mt-2 text-xs bg-muted p-2 rounded overflow-x-auto whitespace-pre-wrap break-all">
+          {error.message}
+        </pre>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function StepRow({
+  label,
+  status,
+  detail,
+  error,
+  onRetryForce,
+  onViewLogs,
+  busy,
+}: StepRowProps) {
+  const { t } = useTranslation("ahand");
+  const statusLabel = t(statusBadgeKey(status));
+
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <StatusIcon status={status} busy={busy} />
+      <span className="flex-1 font-medium">{label}</span>
+      <Badge
+        variant="outline"
+        size="sm"
+        className={cn(
+          "h-5 shrink-0 rounded-md px-1.5 text-[10px] font-medium",
+          status === "ok" &&
+            "border-emerald-200 bg-emerald-50 text-emerald-700",
+          status === "failed" && "border-red-200 bg-red-50 text-red-700",
+          status === "skipped" &&
+            "border-border/60 bg-background/80 text-muted-foreground",
+          status === "notRun" &&
+            "border-border/60 bg-background/80 text-muted-foreground",
+        )}
+      >
+        {statusLabel}
+      </Badge>
+      {detail && (
+        <span
+          className="text-xs text-muted-foreground truncate max-w-[14rem]"
+          title={detail}
+        >
+          {detail}
+        </span>
+      )}
+      {status === "failed" && error && (
+        <HelpPopover
+          error={error}
+          onRetryForce={onRetryForce}
+          onViewLogs={onViewLogs}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/StepRow.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/StepRow.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -117,6 +118,12 @@ function HelpPopover({
 
   const onCopy = () => {
     const cmd = "sudo chown -R $(whoami) ~/.ahand";
+    // Older platforms / non-secure-context webviews lack `navigator.clipboard`
+    // entirely. Guard so the click doesn't throw a ReferenceError.
+    if (!navigator.clipboard) {
+      toast.error(t("browser.help.clipboardUnavailable"));
+      return;
+    }
     void navigator.clipboard.writeText(cmd).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/index.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/index.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from "react-i18next";
+import { BrowserBinaryCard } from "./BrowserBinaryCard";
+import { RuntimeCard } from "./RuntimeCard";
+
+export function BrowserConfigTab() {
+  const { t } = useTranslation("ahand");
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {t("devicesTabs.browserDescription")}
+      </p>
+      <RuntimeCard />
+      <BrowserBinaryCard />
+    </div>
+  );
+}

--- a/apps/client/src/hooks/useBrowserRuntime.ts
+++ b/apps/client/src/hooks/useBrowserRuntime.ts
@@ -61,6 +61,13 @@ export interface BrowserStatus {
   queriedAt: string;
 }
 
+export interface ReloadFailure {
+  kind: ReloadFailureKind;
+  message: string;
+  /** Monotonic counter so consumers can de-dupe via React effect deps. */
+  seq: number;
+}
+
 // ---------------------------------------------------------------------------
 // In-flight per-step accumulator. Lives only while the install/reload runs.
 // ---------------------------------------------------------------------------
@@ -80,16 +87,21 @@ export interface StepFeed {
 // UI state machine
 // ---------------------------------------------------------------------------
 
+// `reloadFailure` is carried on every variant so the UI toast effect can fire
+// the moment the daemon reports a reload error — independent of when the
+// awaited Tauri command finally resolves. A monotonic `seq` lets consumers
+// de-dupe via effect deps without comparing kind/message strings.
 export type RuntimeUiState =
-  | { kind: "loading" }
-  | { kind: "idle"; status: BrowserStatus }
-  | { kind: "installing"; steps: StepFeed }
-  | { kind: "reloading"; steps: StepFeed }
+  | { kind: "loading"; reloadFailure?: ReloadFailure }
+  | { kind: "idle"; status: BrowserStatus; reloadFailure?: ReloadFailure }
+  | { kind: "installing"; steps: StepFeed; reloadFailure?: ReloadFailure }
+  | { kind: "reloading"; steps: StepFeed; reloadFailure?: ReloadFailure }
   | {
       kind: "error";
       status: BrowserStatus | null;
       message: string;
       steps: StepFeed;
+      reloadFailure?: ReloadFailure;
     };
 
 type Action =
@@ -176,10 +188,21 @@ export function applyProgress(
   }
 }
 
+// Monotonic sequence for reloadFailure events. Module-level so each event
+// gets a globally-unique number without threading state through the reducer.
+let reloadFailureSeq = 0;
+
 function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
   switch (action.type) {
     case "loaded":
-      return { kind: "idle", status: action.status };
+      // Preserve any pending reloadFailure (e.g. background daemon-reload
+      // error) so the toast effect still fires. Cleared on the next user
+      // action (install / setEnabled).
+      return {
+        kind: "idle",
+        status: action.status,
+        reloadFailure: state.reloadFailure,
+      };
 
     case "loadFailed":
       return {
@@ -187,9 +210,12 @@ function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
         status: null,
         message: action.message,
         steps: emptyFeed(),
+        reloadFailure: state.reloadFailure,
       };
 
     case "installStarted":
+      // Clear any prior reloadFailure when starting a new install — the user
+      // is acting, prior toasts should not re-fire.
       return { kind: "installing", steps: emptyFeed() };
 
     case "progress": {
@@ -205,10 +231,18 @@ function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
         return state;
       }
       if (action.event.type === "reloadFailed") {
-        // Surface as an error toast; reducer keeps current steps so the user
-        // can still inspect logs. installDone/setEnabledDone never arrives in
-        // this path — the awaited promise still resolves with a final status.
-        return state;
+        // Capture the failure so the UI can toast immediately. The awaited
+        // Tauri command still resolves with a status, which will land as
+        // installDone/setEnabledDone shortly after — we preserve this field
+        // through that transition so the effect runs even if the success
+        // dispatch arrives in the same render batch.
+        reloadFailureSeq += 1;
+        const reloadFailure: ReloadFailure = {
+          kind: action.event.kind,
+          message: action.event.message,
+          seq: reloadFailureSeq,
+        };
+        return { ...state, reloadFailure };
       }
       if (action.event.type === "allFinished") {
         return state;
@@ -221,7 +255,11 @@ function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
     }
 
     case "installDone":
-      return { kind: "idle", status: action.status };
+      return {
+        kind: "idle",
+        status: action.status,
+        reloadFailure: state.reloadFailure,
+      };
 
     case "installFailed":
       return {
@@ -229,13 +267,18 @@ function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
         status: action.status,
         message: action.message,
         steps: action.steps,
+        reloadFailure: state.reloadFailure,
       };
 
     case "setEnabledStarted":
       return { kind: "reloading", steps: currentSteps(state) };
 
     case "setEnabledDone":
-      return { kind: "idle", status: action.status };
+      return {
+        kind: "idle",
+        status: action.status,
+        reloadFailure: state.reloadFailure,
+      };
 
     case "setEnabledFailed":
       return {
@@ -243,6 +286,7 @@ function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
         status: action.status,
         message: action.message,
         steps: action.steps,
+        reloadFailure: state.reloadFailure,
       };
   }
 }
@@ -273,6 +317,13 @@ export function useBrowserRuntime(): UseBrowserRuntimeResult {
     stepsRef.current = state.steps;
   }
 
+  // Mirror the latest state in a ref so the install/setEnabled callbacks can
+  // re-entry guard against rapid double-clicks (e.g. a stale "Retry with
+  // --force" popover click during a fresh install) without recreating
+  // themselves on every reducer update.
+  const stateRef = useRef<RuntimeUiState>(state);
+  stateRef.current = state;
+
   const refresh = useCallback(async () => {
     if (!isTauriApp()) {
       // Web shell — no Tauri commands available. Surface as an idle state
@@ -300,6 +351,13 @@ export function useBrowserRuntime(): UseBrowserRuntimeResult {
 
   const install = useCallback(async (force: boolean) => {
     if (!isTauriApp()) return;
+    // Re-entry guard — drop overlapping requests while one is in flight.
+    if (
+      stateRef.current.kind === "installing" ||
+      stateRef.current.kind === "reloading"
+    ) {
+      return;
+    }
     dispatch({ type: "installStarted" });
     stepsRef.current = emptyFeed();
 
@@ -333,6 +391,13 @@ export function useBrowserRuntime(): UseBrowserRuntimeResult {
 
   const setEnabled = useCallback(async (enabled: boolean) => {
     if (!isTauriApp()) return;
+    // Re-entry guard — drop overlapping requests while one is in flight.
+    if (
+      stateRef.current.kind === "installing" ||
+      stateRef.current.kind === "reloading"
+    ) {
+      return;
+    }
     dispatch({ type: "setEnabledStarted" });
 
     const channel = new Channel<BrowserProgressEvent>();

--- a/apps/client/src/hooks/useBrowserRuntime.ts
+++ b/apps/client/src/hooks/useBrowserRuntime.ts
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { isTauriApp } from "@/lib/tauri";
+
+// ---------------------------------------------------------------------------
+// Wire types — MUST match apps/client/src-tauri/src/ahand/browser_runtime.rs.
+// `ErrorCode` is intentionally snake_case here because the Rust `ErrorCode`
+// enum serialises as snake_case strings (e.g. "permission_denied"). The plan
+// document used camelCase by mistake; the wire shape is the source of truth.
+// ---------------------------------------------------------------------------
+
+export type TauriStepStatus = "ok" | "skipped" | "failed" | "notRun";
+export type TauriLogStream = "stdout" | "stderr" | "info";
+
+export type ErrorCode =
+  | "permission_denied"
+  | "network"
+  | "no_system_browser"
+  | "node_missing"
+  | "version_mismatch"
+  | "unknown";
+
+export interface StepError {
+  code: ErrorCode | string; // accept unknown future codes without crashing
+  message: string;
+}
+
+export type ReloadFailureKind =
+  | "shutdownTimeout"
+  | "spawnFailedRolledBack"
+  | "spawnFailedNoRollback";
+
+export type BrowserProgressEvent =
+  | { type: "stepStarted"; name: string; label: string }
+  | { type: "stepLog"; name: string; line: string; stream: TauriLogStream }
+  | {
+      type: "stepFinished";
+      name: string;
+      status: TauriStepStatus;
+      error?: StepError;
+      durationMs: number;
+    }
+  | { type: "allFinished"; overall: TauriStepStatus; totalDurationMs: number }
+  | { type: "reloadStarted" }
+  | { type: "reloadOnline" }
+  | { type: "reloadFailed"; kind: ReloadFailureKind; message: string };
+
+export interface BrowserStepStatus {
+  name: string;
+  label: string;
+  status: TauriStepStatus;
+  detail?: string;
+  error?: StepError;
+}
+
+export interface BrowserStatus {
+  overall: TauriStepStatus;
+  steps: BrowserStepStatus[];
+  enabled: boolean;
+  agentVisible: boolean;
+  queriedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-flight per-step accumulator. Lives only while the install/reload runs.
+// ---------------------------------------------------------------------------
+
+export interface StepFeedEntry {
+  label: string;
+  status: TauriStepStatus;
+  logs: { line: string; stream: TauriLogStream }[];
+  error?: StepError;
+}
+
+export interface StepFeed {
+  [stepName: string]: StepFeedEntry;
+}
+
+// ---------------------------------------------------------------------------
+// UI state machine
+// ---------------------------------------------------------------------------
+
+export type RuntimeUiState =
+  | { kind: "loading" }
+  | { kind: "idle"; status: BrowserStatus }
+  | { kind: "installing"; steps: StepFeed }
+  | { kind: "reloading"; steps: StepFeed }
+  | {
+      kind: "error";
+      status: BrowserStatus | null;
+      message: string;
+      steps: StepFeed;
+    };
+
+type Action =
+  | { type: "loaded"; status: BrowserStatus }
+  | { type: "loadFailed"; message: string }
+  | { type: "progress"; event: BrowserProgressEvent }
+  | { type: "installStarted" }
+  | { type: "installDone"; status: BrowserStatus }
+  | {
+      type: "installFailed";
+      message: string;
+      status: BrowserStatus | null;
+      steps: StepFeed;
+    }
+  | { type: "setEnabledStarted" }
+  | { type: "setEnabledDone"; status: BrowserStatus }
+  | {
+      type: "setEnabledFailed";
+      message: string;
+      status: BrowserStatus | null;
+      steps: StepFeed;
+    };
+
+function emptyFeed(): StepFeed {
+  return {};
+}
+
+function currentSteps(state: RuntimeUiState): StepFeed {
+  if (state.kind === "installing" || state.kind === "reloading") {
+    return state.steps;
+  }
+  if (state.kind === "error") return state.steps;
+  return emptyFeed();
+}
+
+export function applyProgress(
+  steps: StepFeed,
+  event: BrowserProgressEvent,
+): StepFeed {
+  switch (event.type) {
+    case "stepStarted": {
+      const existing = steps[event.name];
+      return {
+        ...steps,
+        [event.name]: {
+          label: event.label,
+          status: "notRun",
+          logs: existing?.logs ?? [],
+          error: undefined,
+        },
+      };
+    }
+    case "stepLog": {
+      const existing: StepFeedEntry = steps[event.name] ?? {
+        label: event.name,
+        status: "notRun",
+        logs: [],
+      };
+      return {
+        ...steps,
+        [event.name]: {
+          ...existing,
+          logs: [...existing.logs, { line: event.line, stream: event.stream }],
+        },
+      };
+    }
+    case "stepFinished": {
+      const existing: StepFeedEntry = steps[event.name] ?? {
+        label: event.name,
+        status: "notRun",
+        logs: [],
+      };
+      return {
+        ...steps,
+        [event.name]: {
+          ...existing,
+          status: event.status,
+          error: event.error,
+        },
+      };
+    }
+    default:
+      return steps;
+  }
+}
+
+function reducer(state: RuntimeUiState, action: Action): RuntimeUiState {
+  switch (action.type) {
+    case "loaded":
+      return { kind: "idle", status: action.status };
+
+    case "loadFailed":
+      return {
+        kind: "error",
+        status: null,
+        message: action.message,
+        steps: emptyFeed(),
+      };
+
+    case "installStarted":
+      return { kind: "installing", steps: emptyFeed() };
+
+    case "progress": {
+      // We may receive progress events from a setEnabled call when the state
+      // is still "idle" (the very first reloadStarted arrives before our
+      // setEnabledStarted action lands in some races) — treat it as a
+      // transition into reloading so the log drawer keeps streaming.
+      if (action.event.type === "reloadStarted") {
+        return { kind: "reloading", steps: currentSteps(state) };
+      }
+      if (action.event.type === "reloadOnline") {
+        // Stay in current state; the awaited command resolves and flips us.
+        return state;
+      }
+      if (action.event.type === "reloadFailed") {
+        // Surface as an error toast; reducer keeps current steps so the user
+        // can still inspect logs. installDone/setEnabledDone never arrives in
+        // this path — the awaited promise still resolves with a final status.
+        return state;
+      }
+      if (action.event.type === "allFinished") {
+        return state;
+      }
+      // stepStarted / stepLog / stepFinished
+      if (state.kind !== "installing" && state.kind !== "reloading") {
+        return state;
+      }
+      return { ...state, steps: applyProgress(state.steps, action.event) };
+    }
+
+    case "installDone":
+      return { kind: "idle", status: action.status };
+
+    case "installFailed":
+      return {
+        kind: "error",
+        status: action.status,
+        message: action.message,
+        steps: action.steps,
+      };
+
+    case "setEnabledStarted":
+      return { kind: "reloading", steps: currentSteps(state) };
+
+    case "setEnabledDone":
+      return { kind: "idle", status: action.status };
+
+    case "setEnabledFailed":
+      return {
+        kind: "error",
+        status: action.status,
+        message: action.message,
+        steps: action.steps,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseBrowserRuntimeResult {
+  state: RuntimeUiState;
+  install: (force: boolean) => Promise<void>;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useBrowserRuntime(): UseBrowserRuntimeResult {
+  const [state, dispatch] = useReducer(reducer, {
+    kind: "loading",
+  } as RuntimeUiState);
+
+  // Track latest steps via a ref so install/setEnabled callbacks can read the
+  // current per-step accumulator without re-creating themselves on every
+  // reducer update (which would re-fire the useEffect that triggers refresh).
+  const stepsRef = useRef<StepFeed>(emptyFeed());
+  if (state.kind === "installing" || state.kind === "reloading") {
+    stepsRef.current = state.steps;
+  } else if (state.kind === "error") {
+    stepsRef.current = state.steps;
+  }
+
+  const refresh = useCallback(async () => {
+    if (!isTauriApp()) {
+      // Web shell — no Tauri commands available. Surface as an idle state
+      // with an unavailable status so the UI can render a graceful fallback.
+      dispatch({
+        type: "loadFailed",
+        message: "browser_runtime_unavailable_in_web",
+      });
+      return;
+    }
+    try {
+      const status = await invoke<BrowserStatus>("browser_status");
+      dispatch({ type: "loaded", status });
+    } catch (err) {
+      dispatch({
+        type: "loadFailed",
+        message: typeof err === "string" ? err : String(err),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const install = useCallback(async (force: boolean) => {
+    if (!isTauriApp()) return;
+    dispatch({ type: "installStarted" });
+    stepsRef.current = emptyFeed();
+
+    const channel = new Channel<BrowserProgressEvent>();
+    channel.onmessage = (event) => dispatch({ type: "progress", event });
+
+    try {
+      const status = await invoke<BrowserStatus>("browser_install", {
+        force,
+        onProgress: channel,
+      });
+      dispatch({ type: "installDone", status });
+    } catch (err) {
+      const message = typeof err === "string" ? err : String(err);
+      // Best-effort: re-fetch status so the UI shows whatever made it to
+      // disk before the failure (e.g. partial install).
+      let status: BrowserStatus | null = null;
+      try {
+        status = await invoke<BrowserStatus>("browser_status");
+      } catch {
+        status = null;
+      }
+      dispatch({
+        type: "installFailed",
+        message,
+        status,
+        steps: stepsRef.current,
+      });
+    }
+  }, []);
+
+  const setEnabled = useCallback(async (enabled: boolean) => {
+    if (!isTauriApp()) return;
+    dispatch({ type: "setEnabledStarted" });
+
+    const channel = new Channel<BrowserProgressEvent>();
+    channel.onmessage = (event) => dispatch({ type: "progress", event });
+
+    try {
+      const status = await invoke<BrowserStatus>("browser_set_enabled", {
+        enabled,
+        onProgress: channel,
+      });
+      dispatch({ type: "setEnabledDone", status });
+    } catch (err) {
+      const message = typeof err === "string" ? err : String(err);
+      let status: BrowserStatus | null = null;
+      try {
+        status = await invoke<BrowserStatus>("browser_status");
+      } catch {
+        status = null;
+      }
+      dispatch({
+        type: "setEnabledFailed",
+        message,
+        status,
+        steps: stepsRef.current,
+      });
+    }
+  }, []);
+
+  return { state, install, setEnabled, refresh };
+}

--- a/apps/client/src/i18n/locales/en/ahand.json
+++ b/apps/client/src/i18n/locales/en/ahand.json
@@ -129,7 +129,8 @@
     "steps": {
       "node": "Node.js",
       "playwright": "Playwright CLI",
-      "browser": "System browser"
+      "browser": "System browser",
+      "unknown": "Unknown step"
     },
     "stepStatus": {
       "ok": "Installed",
@@ -140,7 +141,14 @@
     "agentVisibility": {
       "toggleLabel": "Available to agents",
       "tooltip": "When off, agents won't see the browser skill. The installed Playwright runtime is preserved.",
-      "disabledHint": "Finish installing before enabling"
+      "disabledHint": "Finish installing before enabling",
+      "outOfSync": "Daemon hasn't picked up this setting yet",
+      "outOfSyncTooltip": "Try toggling off and on, or restart the app"
+    },
+    "reloadStatus": {
+      "shutdownTimeout": "Daemon shutdown timed out (5s); reload may have left things in a bad state",
+      "spawnFailedRolledBack": "New daemon failed to start; rolled back to previous config",
+      "spawnFailedNoRollback": "Daemon respawn failed and rollback also failed; daemon is offline. Restart app."
     },
     "logDrawer": {
       "expand": "View logs ({{count}} lines)",
@@ -160,7 +168,8 @@
       "downloadChrome": "Download Chrome",
       "nodeMissingHint": "Use \"Retry with --force\" to reinstall starting from the Node.js step.",
       "retryWithForce": "Retry with --force",
-      "viewLogs": "View logs"
+      "viewLogs": "View logs",
+      "clipboardUnavailable": "Clipboard unavailable; please copy manually"
     },
     "errors": {
       "operationInProgress": "Another browser operation is running. Please wait for it to finish.",

--- a/apps/client/src/i18n/locales/en/ahand.json
+++ b/apps/client/src/i18n/locales/en/ahand.json
@@ -105,12 +105,16 @@
     }
   },
   "browser": {
-    "runtimeTitle": "Browser automation runtime",
+    "runtimeTitle": "Browser automation runtime (Playwright CLI)",
     "runtimeDescription": "The library agents use to actually drive a browser — click, type, read the page. We use Playwright under the hood.",
     "runtimeSubtitle": "Needed for agents to open and control web pages",
     "statusNotInstalled": "Not installed",
     "statusInstalled": "Installed",
+    "installing": "Installing…",
+    "reloading": "Applying…",
+    "installFailed": "Install failed",
     "install": "Install",
+    "retry": "Retry",
     "binaryTitle": "Which browser agents use",
     "binaryDescription": "Pick the browser agents will open by default. The bundled one is safest — it's isolated from your day-to-day browser.",
     "recommended": "Recommended",
@@ -121,6 +125,48 @@
       "chrome": "Google Chrome",
       "edge": "Microsoft Edge",
       "firefox": "Firefox"
+    },
+    "steps": {
+      "node": "Node.js",
+      "playwright": "Playwright CLI",
+      "browser": "System browser"
+    },
+    "stepStatus": {
+      "ok": "Installed",
+      "skipped": "Skipped",
+      "failed": "Failed",
+      "notRun": "Pending"
+    },
+    "agentVisibility": {
+      "toggleLabel": "Available to agents",
+      "tooltip": "When off, agents won't see the browser skill. The installed Playwright runtime is preserved.",
+      "disabledHint": "Finish installing before enabling"
+    },
+    "logDrawer": {
+      "expand": "View logs ({{count}} lines)",
+      "collapse": "Hide logs"
+    },
+    "help": {
+      "aria": "Show error help",
+      "permission_denied": "The installer needs permissions. Run the command below in your terminal and retry.",
+      "network": "Network unreachable. Check your connection; corporate networks may need a proxy.",
+      "no_system_browser": "No Chrome or Edge detected. Install one and retry.",
+      "node_missing": "Node.js isn't installed. Finish the Node.js step before Playwright.",
+      "version_mismatch": "Version mismatch. Click \"Retry with --force\" to reinstall.",
+      "unknown": "Unclassified failure. Check the logs for details.",
+      "copyCommand": "Copy command",
+      "copied": "Copied",
+      "networkHint": "You can inspect npm proxy settings: npm config get proxy",
+      "downloadChrome": "Download Chrome",
+      "nodeMissingHint": "Use \"Retry with --force\" to reinstall starting from the Node.js step.",
+      "retryWithForce": "Retry with --force",
+      "viewLogs": "View logs"
+    },
+    "errors": {
+      "operationInProgress": "Another browser operation is running. Please wait for it to finish.",
+      "browserNotInstalled": "Finish installing the browser runtime before enabling agent access.",
+      "runtimeNotStarted": "The ahand runtime isn't running yet. Please try again shortly.",
+      "unavailableInWeb": "This setting is only available in the desktop app."
     }
   },
   "overview": {

--- a/apps/client/src/i18n/locales/zh-CN/ahand.json
+++ b/apps/client/src/i18n/locales/zh-CN/ahand.json
@@ -102,12 +102,16 @@
     }
   },
   "browser": {
-    "runtimeTitle": "浏览器控制运行时",
+    "runtimeTitle": "浏览器控制运行时 (Playwright CLI)",
     "runtimeDescription": "Agent 用它真实地操作网页——点击、输入、读取页面内容。底层基于 Playwright。",
     "runtimeSubtitle": "Agent 打开和控制网页需要装它",
     "statusNotInstalled": "未安装",
     "statusInstalled": "已安装",
+    "installing": "安装中…",
+    "reloading": "应用中…",
+    "installFailed": "安装失败",
     "install": "安装",
+    "retry": "重试",
     "binaryTitle": "Agent 使用的浏览器",
     "binaryDescription": "选 Agent 默认要打开的浏览器。内置版最稳——和你日常用的浏览器完全隔离。",
     "recommended": "推荐",
@@ -118,6 +122,48 @@
       "chrome": "Google Chrome",
       "edge": "Microsoft Edge",
       "firefox": "Firefox"
+    },
+    "steps": {
+      "node": "Node.js",
+      "playwright": "Playwright CLI",
+      "browser": "系统浏览器"
+    },
+    "stepStatus": {
+      "ok": "已安装",
+      "skipped": "已跳过",
+      "failed": "失败",
+      "notRun": "未运行"
+    },
+    "agentVisibility": {
+      "toggleLabel": "Agent 可以使用",
+      "tooltip": "关闭后 Agent 不会把 browser skill 列入可用技能。已装好的 Playwright 保留。",
+      "disabledHint": "先完成安装再开启"
+    },
+    "logDrawer": {
+      "expand": "查看日志 ({{count}} 行)",
+      "collapse": "收起日志"
+    },
+    "help": {
+      "aria": "查看错误说明",
+      "permission_denied": "安装需要权限。在终端运行下方命令然后重试。",
+      "network": "网络不通。检查连接；公司网可能需要配置代理。",
+      "no_system_browser": "未检测到 Chrome / Edge。请先下载安装一个。",
+      "node_missing": "Node.js 未安装。先完成 Node.js 步骤再装 Playwright。",
+      "version_mismatch": "版本不匹配。点 “强制重试” 按钮重新强制安装。",
+      "unknown": "未分类错误。查看日志获取详情。",
+      "copyCommand": "复制命令",
+      "copied": "已复制",
+      "networkHint": "可在终端检查 npm 代理设置：npm config get proxy",
+      "downloadChrome": "下载 Chrome",
+      "nodeMissingHint": "重试时点 “强制重试”，会从 Node.js 步骤重新安装。",
+      "retryWithForce": "强制重试",
+      "viewLogs": "查看日志"
+    },
+    "errors": {
+      "operationInProgress": "已有一项浏览器操作在运行，请稍候。",
+      "browserNotInstalled": "请先完成浏览器组件安装，再启用 Agent 可用。",
+      "runtimeNotStarted": "ahand 运行时未启动，请稍后再试。",
+      "unavailableInWeb": "此功能仅在桌面应用中可用。"
     }
   },
   "overview": {

--- a/apps/client/src/i18n/locales/zh-CN/ahand.json
+++ b/apps/client/src/i18n/locales/zh-CN/ahand.json
@@ -126,7 +126,8 @@
     "steps": {
       "node": "Node.js",
       "playwright": "Playwright CLI",
-      "browser": "系统浏览器"
+      "browser": "系统浏览器",
+      "unknown": "未知步骤"
     },
     "stepStatus": {
       "ok": "已安装",
@@ -137,7 +138,14 @@
     "agentVisibility": {
       "toggleLabel": "Agent 可以使用",
       "tooltip": "关闭后 Agent 不会把 browser skill 列入可用技能。已装好的 Playwright 保留。",
-      "disabledHint": "先完成安装再开启"
+      "disabledHint": "先完成安装再开启",
+      "outOfSync": "守护进程尚未应用此设置",
+      "outOfSyncTooltip": "尝试关闭后再开启，或重启应用"
+    },
+    "reloadStatus": {
+      "shutdownTimeout": "守护进程关闭超时（5s）；重启可能未完全生效",
+      "spawnFailedRolledBack": "新守护进程启动失败；已回滚到旧配置",
+      "spawnFailedNoRollback": "守护进程启动失败且回滚也失败；当前离线，请重启应用"
     },
     "logDrawer": {
       "expand": "查看日志 ({{count}} 行)",
@@ -157,7 +165,8 @@
       "downloadChrome": "下载 Chrome",
       "nodeMissingHint": "重试时点 “强制重试”，会从 Node.js 步骤重新安装。",
       "retryWithForce": "强制重试",
-      "viewLogs": "查看日志"
+      "viewLogs": "查看日志",
+      "clipboardUnavailable": "剪贴板不可用，请手动复制"
     },
     "errors": {
       "operationInProgress": "已有一项浏览器操作在运行，请稍候。",


### PR DESCRIPTION
## Summary

Phase C of the browser-runtime-install work. The desktop app now ships a working "我的设备 → 浏览器控制" tab where users can install/repair the embedded browser stack with live progress, see per-step status, view streaming logs, and toggle agent-visibility. The runtime supports hot-reload + rollback of the embedded ahandd daemon, so flipping the config doesn't require an app restart.

Builds on:
- aHand Phase A — `team9ai/aHand#32` merged at `5972ef2da4` (browser_setup progress streaming + Config::set_browser_enabled + cap rename)
- agent-pi Phase B — `team9ai/agent-pi#104` merged at `efbc56cf` (HostCapability rename, browser LLM tool removed in favor of SKILL model)
- aHand SDK follow-up — `team9ai/aHand#36` merged at `ff39bda0` (CloudClient.browser() @deprecated JSDoc)

## Changes

**Rust runtime** (`apps/client/src-tauri/`):
- Bumped `ahandd.rev` Cargo dep from `ab5290c2` to `5972ef2da4` (Phase A merge SHA)
- `AhandRuntime::reload()` — new `&self` async method that hot-respawns the daemon with the latest on-disk config, rollback on failure
  - `ReloadError` enum with `ShutdownTimeout` / `SpawnFailedRolledBack { primary }` / `SpawnFailedNoRollback { primary, rollback }`
  - 5s shutdown timeout, no force-kill (drop handles it)
  - Rollback config snapshotted before shutdown so a known-good config is always available
  - `&self` interior-mutability via `Arc<Mutex<Option<ActiveSession>>>` matches existing `start()` pattern
- Refactor: `ActiveSession` now owns `config_path`, `current_daemon_config`, `startup_inputs`. `build_daemon_config(on_disk, inputs)` helper shared by `start()` and `reload()`
- `StartConfig.config_path: Option<PathBuf>` with `#[serde(default)]` for backwards compat

**Tauri commands** (`apps/client/src-tauri/src/ahand/browser_runtime.rs`, ~1062 LoC new):
- `browser_status` — read-only; returns overall + per-step + enabled + agentVisible + queriedAt
- `browser_install` — long-running; runs `browser_setup::run_all`, streams progress via `tauri::ipc::Channel`, on success flips `[browser].enabled = true` and calls `reload()`
- `browser_set_enabled` — short; flips config + reloads (skip per-step events; only Reload* events)
- Concurrent-install gate: `static AtomicBool` + RAII `InstallGuard` (CAS) — second call returns `Err("operation_in_progress")` synchronously
- Progress adapter `AdapterState::translate(ProgressEvent) → Vec<BrowserProgressEvent>`. StepStarted on first event per step (one-shot). Phase::Done deliberately NOT emitting StepFinished from inside the callback — reconciliation post-pass after `run_all` returns uses the authoritative `Result<Vec<CheckReport>>`
- Log tee to `~/.ahand/logs/browser-setup-{YYYYMMDD-HHMMSS}.log` via `Arc<std::sync::Mutex<File>>`. 7-day retention pruned at start of install

**Renderer** (`apps/client/src/`):
- `useBrowserRuntime` hook (~365 LoC) wraps the 3 Tauri commands, uses `useReducer` with discriminated-union state (`loading | idle | installing | reloading | error`), streams via `Channel<BrowserProgressEvent>`. Re-entry guard, web-shell guard via `isTauriApp()`
- `BrowserConfigTab/` directory replaces the old flat `BrowserConfigTab.tsx`:
  - `RuntimeCard.tsx` — status badge, install/retry button, agent-visible Switch with out-of-sync indicator (`enabled && !agentVisible` warning), 3 step rows, log drawer
  - `StepRow.tsx` — per-step row + help popover (only on `failed`); 5 errorCode-specific helps: `permission_denied` → clipboard `chown`, `network` → proxy hint, `no_system_browser` → Chrome download, `node_missing` → re-run msg, `version_mismatch` → Retry-with-force, `unknown` → View logs
  - `LogDrawer.tsx` — accumulates StepLog events with stream-tagged styling (stdout/stderr/info), auto-scrolls, collapsible
  - `BrowserBinaryCard.tsx` — verbatim move from old flat file
- Surface `reloadFailed` events as toast (with monotonic seq guard against repeats) so daemon-reload failures don't silently leave the UI claiming success
- i18n: zh-CN + en `browser.*` namespace populated (status, steps, agentVisibility, logDrawer, help, reloadStatus, errors)

## Notable decisions

- **Snake_case `ErrorCode` on the wire** — TS union mirrors Rust's serde shape (`permission_denied`, `network`, `no_system_browser`, `node_missing`, `version_mismatch`, `unknown`). The plan markdown's camelCase form was incorrect.
- **Concurrent-install rejected synchronously** — UI button disable is the user-side guard; backend's `AtomicBool` CAS is the safety net.
- **Skill stays once registered (Phase B contract)** + **daemon reload preserves config_path** mean a successful install → reload → agent picks up `browser-playwright-cli` cap → SKILL becomes available end-to-end.
- **Static dispatch helpers** (`helpMessageKey`, `statusBadgeKey`, `fallbackStepLabelKey`) used in renderer to work around a TypeScript 5.8 internal compiler crash on templated `t()` keys. Documented inline.

## Test Plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` — 4 pre-existing warnings only (in untouched `lib.rs` and `identity.rs`); zero new
- [x] `cargo test` — 46 ahand:: tests pass / 4 ignored (pre-existing reload-mock TODOs blocked on DaemonHandle injection infrastructure)
- [x] `pnpm --filter @team9/client typecheck` clean
- [x] `pnpm --filter @team9/client lint` 0 errors
- [x] `pnpm --filter @team9/client build` clean (PWA service worker emitted)
- [x] zh-CN ↔ en i18n key parity (`jq paths` diff empty)
- [ ] Manual E2E smoke (Task 17): open desktop app → 我的设备 → 浏览器控制 tab → click Install → observe live progress → on success see Agent-visible toggle become enabled → toggle off + on, daemon reload completes within ~5s → restart app, verify cap persists across launch

## Out of scope / known follow-ups

- 4 reload integration tests are scaffolded as `#[ignore]`'d todos blocked on mock-DaemonHandle test infrastructure (see Task 13 Step 6 fallback). Real test bodies can land in a follow-up if mocking proves cheap.
- `app_emitter_for_session` returns `None` from reload-spawned daemons — post-reload `ahand-daemon-status` events to the renderer are stubbed. Marked with `// TODO(task-14)` for follow-up; current Task-15 UI compensates by polling fresh status after reload events.
- No vitest coverage for `useBrowserRuntime` reducer — Task 17 manual E2E provides behavioral coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)