### PR TITLE
feat(staff): wire folder9 + just-bash + workspace componentConfigs for Common/Personal/Base Model

### DIFF
--- a/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.service.spec.ts
@@ -436,6 +436,15 @@ describe('CommonStaffService', () => {
             'team9-staff-profile': {},
             'team9-staff-bootstrap': {},
             'team9-staff-soul': {},
+            // Virtual workspace stack — folder9.workspaceId pinned to the
+            // tenantId, just-bash with no-network policy, layout component
+            // mounts bundled team9 skills. No folder9Psk shipped:
+            // workspace mounts use externally-managed tokens.
+            folder9: expect.objectContaining({
+              workspaceId: TENANT_ID,
+            }),
+            'just-bash': { network: 'none' },
+            'just-bash-team9-workspace': { mountTeam9Skills: true },
           }),
         }),
       );
@@ -451,6 +460,20 @@ describe('CommonStaffService', () => {
       >;
       const configs = call['componentConfigs'] as Record<string, unknown>;
       expect(configs).not.toHaveProperty('common-staff-agent');
+    });
+
+    it('does not ship folder9Psk in folder9 config (workspace uses externally-managed tokens)', async () => {
+      const dto = makeCreateDto();
+      await service.createStaff(INSTALLED_APP_ID, TENANT_ID, OWNER_ID, dto);
+
+      const call = clawHiveService.registerAgent.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      const configs = call['componentConfigs'] as Record<string, unknown>;
+      const folder9Config = configs['folder9'] as Record<string, unknown>;
+      expect(folder9Config).toBeDefined();
+      expect(folder9Config).not.toHaveProperty('folder9Psk');
     });
 
     it('creates DM channel only for the mentor (not all workspace members)', async () => {

--- a/apps/server/apps/gateway/src/applications/common-staff.service.ts
+++ b/apps/server/apps/gateway/src/applications/common-staff.service.ts
@@ -152,6 +152,18 @@ export class CommonStaffService {
         // ahand-integration component in the blueprint resolves
         // callingUserId from ctx.userId and gateway/hub URLs from
         // process.env at session start — no per-agent config needed.
+        //
+        // Virtual workspace stack (folder9 + just-bash + workspace
+        // layout). folder9Psk is intentionally omitted — workspace
+        // mounts use externally-managed tokens issued lazily by
+        // Team9Component's Team9FolderTokenApi. Only the URL +
+        // workspaceId are needed at config time.
+        folder9: {
+          folder9Url: process.env.FOLDER9_API_URL,
+          workspaceId: tenantId,
+        },
+        'just-bash': { network: 'none' },
+        'just-bash-team9-workspace': { mountTeam9Skills: true },
       },
     });
 

--- a/apps/server/apps/gateway/src/applications/handlers/base-model-staff.handler.spec.ts
+++ b/apps/server/apps/gateway/src/applications/handlers/base-model-staff.handler.spec.ts
@@ -191,6 +191,30 @@ describe('BaseModelStaffHandler', () => {
       );
     });
 
+    it('passes virtual workspace componentConfigs (folder9 + just-bash + workspace layout) for every base-model agent', async () => {
+      await handler.onInstall(makeContext());
+
+      const call = clawHiveService.registerAgents.mock.calls[0][0] as {
+        agents: Array<{ componentConfigs: Record<string, unknown> }>;
+      };
+      expect(call.agents).toHaveLength(BASE_MODEL_PRESETS.length);
+      for (const agent of call.agents) {
+        const configs = agent.componentConfigs;
+        // folder9: workspaceId pinned to tenantId, no PSK shipped (workspace
+        // mounts use externally-managed tokens issued lazily by Team9Component).
+        expect(configs).toHaveProperty('folder9');
+        const folder9Config = configs['folder9'] as Record<string, unknown>;
+        expect(folder9Config.workspaceId).toBe(TENANT_ID);
+        expect(folder9Config).not.toHaveProperty('folder9Psk');
+        expect(configs).toEqual(
+          expect.objectContaining({
+            'just-bash': { network: 'none' },
+            'just-bash-team9-workspace': { mountTeam9Skills: true },
+          }),
+        );
+      }
+    });
+
     it('creates DM channels for workspace members for each bot', async () => {
       const memberIds = ['member-a', 'member-b'];
       db.where.mockResolvedValueOnce(memberIds.map((userId) => ({ userId })));

--- a/apps/server/apps/gateway/src/applications/handlers/base-model-staff.handler.ts
+++ b/apps/server/apps/gateway/src/applications/handlers/base-model-staff.handler.ts
@@ -122,6 +122,16 @@ export class BaseModelStaffHandler implements ApplicationHandler {
               team9AuthToken: accessToken,
               botUserId: bot.userId,
             },
+            // Virtual workspace stack (folder9 + just-bash + workspace
+            // layout). folder9Psk is intentionally omitted — workspace
+            // mounts use externally-managed tokens issued lazily by
+            // Team9Component's Team9FolderTokenApi.
+            folder9: {
+              folder9Url: process.env.FOLDER9_API_URL,
+              workspaceId: tenantId,
+            },
+            'just-bash': { network: 'none' },
+            'just-bash-team9-workspace': { mountTeam9Skills: true },
           },
         })),
         atomic: true,

--- a/apps/server/apps/gateway/src/applications/personal-staff.service.spec.ts
+++ b/apps/server/apps/gateway/src/applications/personal-staff.service.spec.ts
@@ -464,9 +464,32 @@ describe('PersonalStaffService', () => {
             'team9-staff-profile': {},
             'team9-staff-bootstrap': {},
             'team9-staff-soul': {},
+            // Virtual workspace stack — folder9.workspaceId pinned to the
+            // tenantId, just-bash with no-network policy, layout component
+            // mounts bundled team9 skills. No folder9Psk shipped:
+            // workspace mounts use externally-managed tokens.
+            folder9: expect.objectContaining({
+              workspaceId: TENANT_ID,
+            }),
+            'just-bash': { network: 'none' },
+            'just-bash-team9-workspace': { mountTeam9Skills: true },
           }),
         }),
       );
+    });
+
+    it('does not ship folder9Psk in folder9 config (workspace uses externally-managed tokens)', async () => {
+      const dto = makeCreateDto();
+      await service.createStaff(INSTALLED_APP_ID, TENANT_ID, OWNER_ID, dto);
+
+      const call = clawHiveService.registerAgent.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      const configs = call['componentConfigs'] as Record<string, unknown>;
+      const folder9Config = configs['folder9'] as Record<string, unknown>;
+      expect(folder9Config).toBeDefined();
+      expect(folder9Config).not.toHaveProperty('folder9Psk');
     });
 
     it('returns correct result object', async () => {

--- a/apps/server/apps/gateway/src/applications/personal-staff.service.ts
+++ b/apps/server/apps/gateway/src/applications/personal-staff.service.ts
@@ -220,6 +220,16 @@ export class PersonalStaffService {
           'team9-staff-profile': {},
           'team9-staff-bootstrap': {},
           'team9-staff-soul': {},
+          // Virtual workspace stack (folder9 + just-bash + workspace
+          // layout). folder9Psk is intentionally omitted — workspace
+          // mounts use externally-managed tokens issued lazily by
+          // Team9Component's Team9FolderTokenApi.
+          folder9: {
+            folder9Url: process.env.FOLDER9_API_URL,
+            workspaceId: tenantId,
+          },
+          'just-bash': { network: 'none' },
+          'just-bash-team9-workspace': { mountTeam9Skills: true },
         },
       });
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Small follow-up to [#90 Phase A](https://github.com/team9ai/team9/pull/90). Companion to [agent-pi#109](https://github.com/team9ai/agent-pi/pull/109) which adds the workspace mount components to the 3 staff blueprints. This PR provides the per-staff componentConfigs those new blueprint components need.

For each of \`common-staff.service\`, \`personal-staff.service\`, \`base-model-staff.handler\`, the staff registration now passes:

\`\`\`ts
folder9: {
  folder9Url: process.env.FOLDER9_API_URL,
  // folder9Psk omitted — workspace mount uses externally-managed tokens
  workspaceId: tenantId,
},
"just-bash": { network: "none" },
"just-bash-team9-workspace": { mountTeam9Skills: true },
\`\`\`

**No PSK shipped intentionally.** Workspace mounts use externally-managed tokens (issued lazily by the now-shipped \`/bot/folder-token\` endpoint per logical mount key). Test cases explicitly assert PSK absence to catch regressions.

## Test plan

- [ ] CI passes
- [ ] Common Staff session creation passes new componentConfigs
- [ ] Personal Staff session creation passes new componentConfigs
- [ ] Base Model Staff registers with the new componentConfigs
- [ ] No regressions in existing staff registration tests

## Rollback

Revert → the new blueprint components on agent-pi side will receive empty config and degrade to skills-only mounts (verified by Task 9 / 11 fallback path). Harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)