### PR TITLE
fix(routines): code review fixes — C1 null-desc / C2 no-tx-around-folder9 / I1 / I4 / I5 / I7 / I8 / I12

### DIFF
--- a/apps/client/src/components/folder9-editor/Folder9FolderEditor.tsx
+++ b/apps/client/src/components/folder9-editor/Folder9FolderEditor.tsx
@@ -372,21 +372,34 @@ export function Folder9FolderEditor({
       try {
         const path = await imageUpload.upload(file, "attachments");
         const markdown = `![${file.name}](${path})`;
-        const current = latestBodyRef.current;
-        const newBody = current
-          ? `${current}\n\n${markdown}\n`
+        if (readOnly) return;
+        // I4 — race-safe append.
+        //
+        // Two concurrent paste-uploads completing near-simultaneously
+        // both used to read `latestBodyRef.current`, append, then write
+        // back. Reading + writing the ref in two non-atomic steps lets
+        // upload B clobber upload A's append. Fix: do BOTH the read
+        // and the write on the ref atomically so each upload sees the
+        // accumulated body. Then mirror the same value to React state
+        // (functional setter avoids the analogous race in
+        // setState-from-stale-closure) and to the draft store. The
+        // ref is the single source of truth for "current accumulated
+        // body" while edits are in flight.
+        const next = latestBodyRef.current
+          ? `${latestBodyRef.current}\n\n${markdown}\n`
           : `${markdown}\n`;
-        handleBodyChange(newBody);
+        latestBodyRef.current = next;
+        setBody(next);
+        setDraft({ body: next, frontmatter: {} });
       } catch (err) {
         notify(
           err instanceof Error ? err.message : t("editor.notifyUploadFailed"),
         );
       }
     },
-    // handleBodyChange's identity intentionally omitted — we read the
-    // latest body via ref so the closure stays stable across renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [imageUpload, t],
+    // setBody/setDraft are stable; readOnly may flip between renders so
+    // include it. handleBodyChange is no longer used here.
+    [imageUpload, readOnly, setDraft, t],
   );
 
   function handlePaste(e: React.ClipboardEvent<HTMLDivElement>) {

--- a/apps/client/src/components/folder9-editor/__tests__/Folder9FolderEditor.test.tsx
+++ b/apps/client/src/components/folder9-editor/__tests__/Folder9FolderEditor.test.tsx
@@ -816,6 +816,91 @@ describe("Folder9FolderEditor — image upload integration", () => {
     alertSpy.mockRestore();
   });
 
+  // I4 regression — concurrent uploads must serialize on the body ref
+  // so neither image's markdown is clobbered. Before the fix, both
+  // uploads read `latestBodyRef.current` then wrote back, so the
+  // second one's setBody erased the first's append.
+  it("I4 — two concurrent paste-uploads both end up in the final body", async () => {
+    // Two upload calls resolve at controllable timings so we can
+    // interleave their completions deterministically. We capture the
+    // setDraft calls (the only observable side-effect of body
+    // mutation, given DocumentEditor is mocked away from us) and
+    // assert that the FINAL setDraft body contains BOTH markdown
+    // strings.
+    let resolveA: (path: string) => void = () => {};
+    let resolveB: (path: string) => void = () => {};
+    const promiseA = new Promise<string>((r) => {
+      resolveA = r;
+    });
+    const promiseB = new Promise<string>((r) => {
+      resolveB = r;
+    });
+    let call = 0;
+    const uploader = {
+      upload: vi.fn().mockImplementation(() => {
+        call += 1;
+        return call === 1 ? promiseA : promiseB;
+      }),
+    };
+
+    const setDraftSpy = vi.fn();
+    draftHook.state = makeDraftState({ setDraft: setDraftSpy });
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <Folder9FolderEditor
+          {...baseProps({ initialPath: "SKILL.md", imageUpload: uploader })}
+        />
+      </Wrapper>,
+    );
+
+    const dropZone = await screen.findByTestId(
+      "folder9-folder-editor-drop-zone",
+    );
+
+    // Fire two paste events in rapid succession; neither has resolved
+    // its upload promise yet.
+    const fileA = new File(["A"], "imgA.png", { type: "image/png" });
+    const fileB = new File(["B"], "imgB.png", { type: "image/png" });
+
+    await act(async () => {
+      fireEvent.paste(dropZone, {
+        clipboardData: {
+          items: [{ kind: "file", type: "image/png", getAsFile: () => fileA }],
+        },
+      });
+      fireEvent.paste(dropZone, {
+        clipboardData: {
+          items: [{ kind: "file", type: "image/png", getAsFile: () => fileB }],
+        },
+      });
+    });
+
+    // Resolve both upload promises near-simultaneously. The order
+    // doesn't matter — the fix must keep BOTH markdown strings in the
+    // body regardless.
+    await act(async () => {
+      resolveA("attachments/A.png");
+      resolveB("attachments/B.png");
+      // Flush microtasks
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The final draft body must contain BOTH image markdowns. Before
+    // I4 fix, only one would survive (whichever ran second clobbered
+    // the other).
+    await waitFor(() => {
+      expect(setDraftSpy).toHaveBeenCalled();
+    });
+    const lastDraft =
+      setDraftSpy.mock.calls[setDraftSpy.mock.calls.length - 1]?.[0];
+    expect(lastDraft).toBeDefined();
+    expect(lastDraft.body).toContain("imgA.png");
+    expect(lastDraft.body).toContain("imgB.png");
+  });
+
   it("does not register paste/drop hooks when no uploader is provided", async () => {
     const Wrapper = makeWrapper();
     render(

--- a/apps/client/src/components/routines/RoutineSkillFolderTab.tsx
+++ b/apps/client/src/components/routines/RoutineSkillFolderTab.tsx
@@ -49,7 +49,8 @@ export interface RoutineSkillFolderTabProps {
  * sets `approvalMode: "review"`.
  */
 export function RoutineSkillFolderTab({ routine }: RoutineSkillFolderTabProps) {
-  const { data: currentUser } = useCurrentUser();
+  const { data: currentUser, isLoading: isCurrentUserLoading } =
+    useCurrentUser();
   const workspaceId = useSelectedWorkspaceId();
 
   // v1 permission: tenant membership ↔ write permission. The current
@@ -59,10 +60,13 @@ export function RoutineSkillFolderTab({ routine }: RoutineSkillFolderTabProps) {
   // enforces this on every routine endpoint. Authenticated user is
   // therefore equivalent to tenant member for this surface.
   //
-  // The server enforces the same rule on every folder endpoint, so
-  // the worst case is a ~ms-window where the user sees write-mode
-  // affordances after losing access — the API call surfaces a 403
-  // and the shell renders a friendly error toast.
+  // I12 — flicker guard: while `useCurrentUser` is still loading
+  // (data: undefined), the old code dropped to read-mode for one
+  // render, mounted the editor, then re-rendered into write-mode once
+  // the user resolved. That's expensive (DocumentEditor's mount path
+  // is non-trivial) AND visibly jittery. Defer mounting the editor
+  // until we've actually resolved the user — see `if
+  // (isCurrentUserLoading)` below.
   const canEdit = !!currentUser;
   const permission: Folder9Permission = canEdit ? "write" : "read";
 
@@ -159,6 +163,23 @@ export function RoutineSkillFolderTab({ routine }: RoutineSkillFolderTabProps) {
         data-testid="routine-skill-folder-empty"
       >
         Skill folder is not yet provisioned.
+      </div>
+    );
+  }
+
+  // I12 — defer the editor mount while currentUser is loading.
+  // Rendering with `canEdit = false` here would briefly mount the
+  // DocumentEditor in read-mode, then re-mount it in write-mode once
+  // the user query resolves. That's flicker-y AND expensive. Render a
+  // lightweight placeholder until we know what permission to mount
+  // with.
+  if (isCurrentUserLoading) {
+    return (
+      <div
+        className="p-4 text-xs text-muted-foreground"
+        data-testid="routine-skill-folder-loading"
+      >
+        Loading…
       </div>
     );
   }

--- a/apps/client/src/hooks/__tests__/useFolderDraft.test.tsx
+++ b/apps/client/src/hooks/__tests__/useFolderDraft.test.tsx
@@ -200,7 +200,12 @@ describe("useFolderDraft", () => {
     expect(localStorage.getItem(key)).toBeNull();
   });
 
-  it("treats lastCommitTime=null as epoch 0 (any draft wins, stale-alert raised)", () => {
+  it("I5 — lastCommitTime=null loads any extant draft but SUPPRESSES the stale-alert", () => {
+    // Without a commit anchor, stale-alert reconciliation is
+    // impossible. Surfacing the alert anyway (the pre-I5 behaviour)
+    // fired on every fresh page load and trained users to ignore it.
+    // After I5, the hook still loads the draft (so the user doesn't
+    // lose work) but never raises the alert.
     const key = buildFolderDraftKey(DRAFT_KEY, "index.md");
     const draft = { body: "d", frontmatter: {}, savedAt: 100 };
     localStorage.setItem(key, JSON.stringify(draft));
@@ -214,7 +219,20 @@ describe("useFolderDraft", () => {
     );
 
     expect(result.current.draft).toEqual(draft);
-    expect(result.current.hasStaleAlert).toBe(true);
+    expect(result.current.hasStaleAlert).toBe(false);
+  });
+
+  it("I5 — lastCommitTime=null with no extant draft: idle state, no alert", () => {
+    const { result } = renderHook(() =>
+      useFolderDraft(DRAFT_KEY, "index.md", {
+        body: "",
+        frontmatter: {},
+        lastCommitTime: null,
+      }),
+    );
+
+    expect(result.current.draft).toBeNull();
+    expect(result.current.hasStaleAlert).toBe(false);
   });
 
   it("ignores corrupted JSON in storage", () => {

--- a/apps/client/src/hooks/useFolderDraft.ts
+++ b/apps/client/src/hooks/useFolderDraft.ts
@@ -22,15 +22,34 @@ export interface FolderDraft {
  * Server snapshot shape `useFolderDraft` expects from its caller. Callers
  * can pass `null` before the server fetch resolves; the hook will no-op
  * (no draft load, no stale-alert) until the snapshot arrives.
+ *
+ * # `lastCommitTime` semantics
+ *
+ * - **ISO8601 string** (e.g. `"2026-04-30T12:34:56Z"`): the timestamp of
+ *   the last commit that authored the server's current copy. The hook
+ *   compares the draft's `savedAt` against this to decide whether to
+ *   raise the stale-alert.
+ *
+ * - **`null`**: the caller has no per-blob commit metadata. The generic
+ *   shell API (folder9-folder.ts) doesn't carry it on `BlobDto`, so
+ *   shells that wrap that API pass `null`.
+ *
+ *   I5: when `lastCommitTime === null`, stale-alert reconciliation is
+ *   IMPOSSIBLE (we have no anchor to compare the draft against), so the
+ *   hook treats this as "load any existing draft, but never raise the
+ *   stale-alert". The previous behaviour (treat null as epoch 0) caused
+ *   any extant draft to alert as "newer than server", which fired
+ *   spuriously on every fresh page load and trained users to ignore
+ *   the alert.
  */
 export interface FolderDraftServerSnapshot {
   body: string;
   frontmatter: Record<string, unknown>;
   /**
    * RFC3339 / ISO8601 timestamp of the last commit that authored the
-   * server's current copy. `null` is treated as epoch 0 (a server-side
-   * "we have no history" sentinel) so any extant draft wins and is
-   * surfaced via the stale-alert.
+   * server's current copy. `null` means "we have no commit metadata to
+   * reconcile against" — see the type-doc above for the suppress-alert
+   * semantics.
    */
   lastCommitTime: string | null;
 }
@@ -126,11 +145,21 @@ export function useFolderDraft(
   // Depend on the *value* we care about (the commit timestamp), not the
   // snapshot object's reference. Callers often pass a fresh literal every
   // render — keying on the reference would cause the effect to fire every
-  // render and re-set state, producing an infinite render loop. We also
-  // need to know whether we've seen *any* snapshot at all, so we coalesce
-  // null / string into a single comparable scalar.
-  const snapshotSignal =
-    serverSnapshot == null ? null : (serverSnapshot.lastCommitTime ?? "");
+  // render and re-set state, producing an infinite render loop.
+  //
+  // I5: distinguish three cases via a tagged scalar:
+  //   - `null`              → caller hasn't supplied a snapshot yet
+  //                          (don't reconcile, don't load drafts)
+  //   - `"NO_RECONCILE"`    → snapshot is present but `lastCommitTime`
+  //                          is null. We CAN load drafts but stale-
+  //                          alert reconciliation is impossible —
+  //                          suppress the alert.
+  //   - any other string    → ISO8601 timestamp; compare with draft.savedAt.
+  const NO_RECONCILE = "NO_RECONCILE" as const;
+  const snapshotSignal: string | typeof NO_RECONCILE | null =
+    serverSnapshot == null
+      ? null
+      : (serverSnapshot.lastCommitTime ?? NO_RECONCILE);
 
   // Load existing draft (if any) and reconcile with the server snapshot
   // whenever the key or the commit signal changes. A fresh server refetch
@@ -148,8 +177,17 @@ export function useFolderDraft(
       setHasStaleAlert(false);
       return;
     }
-    const serverTime =
-      snapshotSignal === "" ? 0 : new Date(snapshotSignal).getTime();
+    if (snapshotSignal === NO_RECONCILE) {
+      // I5: we have a draft but no commit anchor to compare against.
+      // Load the draft (so the user doesn't lose work) but DO NOT
+      // raise the stale-alert — we don't actually know whether the
+      // draft is newer than the server's current copy. Spuriously
+      // firing the alert here trained users to ignore it.
+      setDraftState(existing);
+      setHasStaleAlert(false);
+      return;
+    }
+    const serverTime = new Date(snapshotSignal).getTime();
     if (existing.savedAt > serverTime) {
       setDraftState(existing);
       setHasStaleAlert(true);

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
@@ -427,7 +427,80 @@ describe('FolderTokenService', () => {
       expect(db.select).not.toHaveBeenCalled();
     });
 
-    it('does not gate when caller tenant is undefined (community/edge call)', async () => {
+    it('I8 — fails closed (403) when caller tenant is undefined', async () => {
+      // After I8, missing tenant context is no longer a fail-soft
+      // bypass. Any caller without a tenant must be rejected with a
+      // structured log. Bot/routine fixtures are intentionally not
+      // queued — the request must bail out before any DB lookup.
+      await expect(
+        service.issueToken(makeDto(), BOT_USER_ID, undefined),
+      ).rejects.toThrow(ForbiddenException);
+      // The reason string is part of the public 403 contract — clients
+      // distinguish "tenant missing" from "tenant mismatch" by message.
+      await expect(
+        service.issueToken(makeDto(), BOT_USER_ID, undefined),
+      ).rejects.toThrow(/tenant context missing/);
+      // Bail before any DB lookup.
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── I7: stub-authz scopes are read-only ────────────────────────────────
+  //
+  // session.{tmp,home}, agent.{tmp,home}, user.{tmp,home},
+  // routine.{tmp,home} ride a stub authz path until real RBAC lands.
+  // Until then, write/propose tokens through this endpoint would
+  // silently widen the trust boundary, so the v1 endpoint caps the
+  // permitted action at `read`. routine.document keeps its own real
+  // authz and is unaffected.
+  describe('I7 — stub-authz scopes are read-only', () => {
+    const STUB_KEYS = [
+      'session.tmp',
+      'session.home',
+      'agent.tmp',
+      'agent.home',
+      'user.tmp',
+      'user.home',
+      'routine.tmp',
+      'routine.home',
+    ] as const;
+
+    for (const logicalKey of STUB_KEYS) {
+      it(`403: ${logicalKey} rejects permission=write before any token mint`, async () => {
+        // The I7 gate runs after the bot identity lookup but before
+        // any logical-key authz (mount row check, ownership, etc).
+        // Each `await ... rejects` consumes one full call, so we
+        // queue a bot row per call here (two assertions = two calls).
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        const dto = makeDto({
+          logicalKey,
+          permission: 'write',
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(ForbiddenException);
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(/stub authz; only read permitted/);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+
+      it(`403: ${logicalKey} rejects permission=propose`, async () => {
+        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
+        const dto = makeDto({
+          logicalKey,
+          permission: 'propose',
+        });
+        await expect(
+          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
+        ).rejects.toThrow(/stub authz; only read permitted/);
+        expect(folder9Client.createToken).not.toHaveBeenCalled();
+      });
+    }
+
+    it('routine.document is NOT a stub-authz scope: write is still allowed', async () => {
+      // I7 must not regress routine.document, which has real authz.
       queueBot({ userId: BOT_USER_ID });
       queueRoutine({
         id: ROUTINE_ID,
@@ -435,9 +508,12 @@ describe('FolderTokenService', () => {
         folderId: FOLDER_ID,
       });
 
-      await expect(
-        service.issueToken(makeDto(), BOT_USER_ID, undefined),
-      ).resolves.toBeDefined();
+      const dto = makeDto({
+        logicalKey: 'routine.document',
+        permission: 'write',
+      });
+      const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
+      expect(result.token).toBe('opaque-token');
     });
   });
 
@@ -478,9 +554,12 @@ describe('FolderTokenService', () => {
     it('rejects when caller bot is not active or not found', async () => {
       queueBot(null);
 
+      // Use `permission: 'read'` so the request bypasses the I7
+      // stub-authz read-only gate and actually exercises the bot
+      // identity lookup (the next gate after the early checks).
       await expect(
         service.issueToken(
-          makeDto({ logicalKey: 'session.tmp' }),
+          makeDto({ logicalKey: 'session.tmp', permission: 'read' }),
           BOT_USER_ID,
           TENANT_ID,
         ),
@@ -513,7 +592,12 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        const dto = makeDto({ logicalKey });
+        // Use `permission: 'read'` here so the rejection path runs the
+        // real authz logic (mount row absent → 403). I7 caps stub-authz
+        // scopes at read; with the default 'write' the test would
+        // short-circuit at the I7 gate and never exercise the mount
+        // check we're trying to verify.
+        const dto = makeDto({ logicalKey, permission: 'read' });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -524,7 +608,7 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount({ scopeId: 'other-agent' });
 
-        const dto = makeDto({ logicalKey });
+        const dto = makeDto({ logicalKey, permission: 'read' });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -535,7 +619,7 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: null });
         queueMount({ scopeId: AGENT_ID });
 
-        const dto = makeDto({ logicalKey });
+        const dto = makeDto({ logicalKey, permission: 'read' });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -570,7 +654,12 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        // permission: 'read' — see the agent.* tests above for rationale.
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -581,7 +670,11 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount({ scopeId: 'whatever' });
 
-        const dto = makeDto({ logicalKey, sessionId: 'garbage-session-id' });
+        const dto = makeDto({
+          logicalKey,
+          sessionId: 'garbage-session-id',
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -592,7 +685,11 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: 'wrong-agent' } });
         queueMount({ scopeId: DM_SESSION_ID });
 
-        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -603,7 +700,11 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount({ scopeId: 'team9/tenant-1/agent-1/dm/other-channel' });
 
-        const dto = makeDto({ logicalKey, sessionId: DM_SESSION_ID });
+        const dto = makeDto({
+          logicalKey,
+          sessionId: DM_SESSION_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -640,10 +741,12 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
+        // permission: 'read' required by I7 — see agent.* tests.
         const dto = makeDto({
           logicalKey,
           sessionId: DM_SESSION_ID,
           userId: USER_ID,
+          permission: 'read',
         });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -659,6 +762,7 @@ describe('FolderTokenService', () => {
           logicalKey,
           sessionId: ROUTINE_SESSION_ID,
           userId: USER_ID,
+          permission: 'read',
         });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -674,6 +778,7 @@ describe('FolderTokenService', () => {
           logicalKey,
           sessionId: DM_SESSION_ID,
           userId: undefined,
+          permission: 'read',
         });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -690,6 +795,7 @@ describe('FolderTokenService', () => {
           logicalKey,
           sessionId: DM_SESSION_ID,
           userId: USER_ID,
+          permission: 'read',
         });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -706,6 +812,7 @@ describe('FolderTokenService', () => {
           logicalKey,
           sessionId: DM_SESSION_ID,
           userId: USER_ID,
+          permission: 'read',
         });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -715,24 +822,32 @@ describe('FolderTokenService', () => {
     }
   });
 
-  // ── TTL on real authz path (1h propose) ───────────────────────────────────
-
+  // ── TTL on real authz path ────────────────────────────────────────────────
+  //
+  // After I7, stub-authz logical keys (agent.*, session.*, user.*,
+  // routine.{tmp,home}) are read-only. Read tokens use a 6h TTL on
+  // those scopes. (The `propose` 1h-TTL path remains exercised
+  // indirectly via routine.document tests above.)
   describe('TTL on real authz path', () => {
-    it('uses 1h propose TTL on agent.home with permission=propose', async () => {
+    it('uses 6h read TTL on agent.home with permission=read', async () => {
       queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
       queueMount({ scopeId: AGENT_ID });
       const before = Date.now();
 
       const dto = makeDto({
         logicalKey: 'agent.home',
-        permission: 'propose',
+        permission: 'read',
       });
       await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
 
       const mintArg = folder9Client.createToken.mock.calls[0][0];
       const expiresAtMs = Date.parse(mintArg.expires_at as string);
-      expect(expiresAtMs).toBeGreaterThanOrEqual(before + 60 * 60_000 - 5_000);
-      expect(expiresAtMs).toBeLessThanOrEqual(Date.now() + 60 * 60_000 + 5_000);
+      expect(expiresAtMs).toBeGreaterThanOrEqual(
+        before + 6 * 60 * 60_000 - 5_000,
+      );
+      expect(expiresAtMs).toBeLessThanOrEqual(
+        Date.now() + 6 * 60 * 60_000 + 5_000,
+      );
     });
   });
 
@@ -763,7 +878,11 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        const dto = makeDto({
+          logicalKey,
+          routineId: ROUTINE_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -774,7 +893,11 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount({ scopeId: ROUTINE_ID });
 
-        const dto = makeDto({ logicalKey, routineId: undefined });
+        const dto = makeDto({
+          logicalKey,
+          routineId: undefined,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -786,7 +909,11 @@ describe('FolderTokenService', () => {
         queueMount({ scopeId: ROUTINE_ID });
         queueRoutineForBot(null);
 
-        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        const dto = makeDto({
+          logicalKey,
+          routineId: ROUTINE_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);
@@ -798,7 +925,11 @@ describe('FolderTokenService', () => {
         queueMount({ scopeId: 'other-routine' });
         queueRoutineForBot({ id: ROUTINE_ID });
 
-        const dto = makeDto({ logicalKey, routineId: ROUTINE_ID });
+        const dto = makeDto({
+          logicalKey,
+          routineId: ROUTINE_ID,
+          permission: 'read',
+        });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
         ).rejects.toThrow(ForbiddenException);

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.ts
@@ -158,7 +158,20 @@ export class FolderTokenService {
       );
     }
 
-    if (callerTenantId !== undefined && callerTenantId !== req.workspaceId) {
+    // I8: fail-closed cross-tenant gate.
+    //
+    // Previously, an undefined callerTenantId silently bypassed the
+    // workspace-id check. That's the wrong default for an authz layer:
+    // a caller without a known tenant has no claim on any workspace's
+    // resources. Refuse the request loudly with a structured log so
+    // ops can spot misconfigured ingress (e.g. middleware not running).
+    if (callerTenantId === undefined) {
+      this.logger.warn(
+        `folder-token: refusing — tenant context missing on caller (botUserId=${callerBotUserId}, workspaceId=${req.workspaceId}, logicalKey=${req.logicalKey})`,
+      );
+      throw new ForbiddenException('tenant context missing');
+    }
+    if (callerTenantId !== req.workspaceId) {
       throw new ForbiddenException(
         'Caller tenant does not match requested workspaceId',
       );
@@ -171,6 +184,31 @@ export class FolderTokenService {
     const bot = await this.loadActiveBotByUserId(callerBotUserId);
     if (!bot) {
       throw new ForbiddenException('Caller is not a known bot user');
+    }
+
+    // I7: stub authz scopes are read-only.
+    //
+    // session.{tmp,home}, agent.{tmp,home}, user.{tmp,home},
+    // routine.{tmp,home} ride a stub authz path until real RBAC lands
+    // (per design spec). Until then, write/propose access through this
+    // endpoint would silently widen the trust boundary, so we cap the
+    // permitted action at `read`. routine.document keeps its own real
+    // authz (already gated above) and is unaffected.
+    const STUB_AUTHZ_LOGICAL_KEYS = new Set([
+      'session.tmp',
+      'session.home',
+      'agent.tmp',
+      'agent.home',
+      'user.tmp',
+      'user.home',
+      'routine.tmp',
+      'routine.home',
+    ]);
+    if (
+      STUB_AUTHZ_LOGICAL_KEYS.has(req.logicalKey) &&
+      req.permission !== 'read'
+    ) {
+      throw new ForbiddenException('stub authz; only read permitted');
     }
 
     // Resolve the audit `scopeId` and run logical-key-specific authz.

--- a/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
+++ b/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
@@ -332,9 +332,15 @@ describe('Routine Creation Flow — integration', () => {
     // returning 1-row array means we won the race
     db.returning.mockResolvedValueOnce([{ id: ROUTINE_ID }] as any);
 
-    // A.8: ensureRoutineFolder fast path — SELECT ... FOR UPDATE returns
-    // a row with a populated folderId so no provision is invoked.
+    // A.8 / C2: ensureRoutineFolder fast path — uses optimistic
+    // `.limit(1)` (no row lock). Returns a row with a populated
+    // folderId so no provision is invoked. Vestigial `.for('update')`
+    // mock kept for any code path that still references it (none in
+    // current code).
     db.for.mockResolvedValueOnce([
+      { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
+    ]);
+    db.limit.mockResolvedValueOnce([
       { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
     ]);
 
@@ -480,10 +486,12 @@ describe('Routine Creation Flow — integration', () => {
       },
     } as any);
 
-    // Mock: SELECT ... FOR UPDATE inside ensureRoutineFolder — fast path
-    // returns the same row so `folderId` is already populated and no
-    // provision call is made.
+    // C2: ensureRoutineFolder optimistic SELECT — fast path returns a
+    // row with populated folderId so no provision call is made.
+    // Vestigial `.for('update')` left in case any test path still
+    // reaches the legacy mock.
     db.for.mockResolvedValueOnce([COMPLETED_DRAFT] as any);
+    db.limit.mockResolvedValueOnce([COMPLETED_DRAFT] as any);
 
     // Mock: db.update().set().where().returning() → upcoming routine
     db.returning.mockResolvedValueOnce([UPCOMING_ROUTINE] as any);
@@ -561,8 +569,11 @@ describe('Routine Creation Flow — integration', () => {
     // Atomic claim UPDATE returning 1 row = won the race
     db.returning.mockResolvedValueOnce([{ id: ROUTINE_ID }] as any);
 
-    // A.8: ensureRoutineFolder fast path
+    // A.8 / C2: ensureRoutineFolder fast path (optimistic .limit(1))
     db.for.mockResolvedValueOnce([
+      { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
+    ]);
+    db.limit.mockResolvedValueOnce([
       { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
     ]);
 

--- a/apps/server/apps/gateway/src/routines/folder/__tests__/ensure-routine-folder.spec.ts
+++ b/apps/server/apps/gateway/src/routines/folder/__tests__/ensure-routine-folder.spec.ts
@@ -25,8 +25,6 @@ interface RoutineRow {
 /**
  * Build a thenable Drizzle-style query chain. Every chain method returns
  * the same object; awaiting the chain resolves the supplied resolver.
- *
- * Mirrors the chain mock used in `bot-staff-profile.service.spec.ts`.
  */
 function createQuery(resolve: () => unknown) {
   const query: Record<string, MockFn> & {
@@ -38,7 +36,6 @@ function createQuery(resolve: () => unknown) {
     from: jest.fn<any>(),
     where: jest.fn<any>(),
     set: jest.fn<any>(),
-    for: jest.fn<any>(),
     limit: jest.fn<any>(),
     returning: jest.fn<any>(),
     then(onfulfilled, onrejected) {
@@ -46,81 +43,80 @@ function createQuery(resolve: () => unknown) {
     },
   };
 
-  for (const key of [
-    'from',
-    'where',
-    'set',
-    'for',
-    'limit',
-    'returning',
-  ] as const) {
+  for (const key of ['from', 'where', 'set', 'limit', 'returning'] as const) {
     query[key].mockReturnValue(query as never);
   }
 
   return query;
 }
 
+/**
+ * State for the mock DB. After C2, ensureRoutineFolder no longer uses
+ * `db.transaction` or `.for('update')` — it just runs an optimistic
+ * SELECT, the slow folder9 provision, then an UPDATE-WHERE-NULL whose
+ * `returning()` decides race winner vs loser.
+ *
+ * We model both:
+ * - `selectResults`: FIFO queue of rows for each `db.select()` call
+ *   (used for the initial fetch + the optional race-loss re-read).
+ * - `updateReturningResults`: FIFO queue of rows for `update().returning()`.
+ *   Empty array `[]` simulates "another caller raced and won" (0 rows
+ *   matched the `folder_id IS NULL` predicate). One-element array
+ *   `[winnerRow]` simulates a successful claim.
+ */
 interface DbState {
-  /** Sequence of rows the next select should return (FIFO). */
   selectResults: (RoutineRow | undefined)[][];
+  updateReturningResults: RoutineRow[][];
 }
 
-/**
- * Mock db.transaction()/select()/update() that:
- * - serializes transaction callbacks (later transactions await earlier ones,
- *   matching SELECT FOR UPDATE row-lock semantics on a single key)
- * - reuses the same chain mock for select/update
- * - records a copy of the queries so tests can assert on call shape
- */
 function mockDb() {
-  const state: DbState = { selectResults: [] };
+  const state: DbState = {
+    selectResults: [],
+    updateReturningResults: [],
+  };
 
   const queries = {
     select: [] as ReturnType<typeof createQuery>[],
     update: [] as ReturnType<typeof createQuery>[],
   };
 
-  const baseTx = {
-    select: jest.fn<any>(() => {
-      const q = createQuery(() =>
-        state.selectResults.length > 0 ? state.selectResults.shift() : [],
-      );
-      queries.select.push(q);
-      return q as never;
-    }),
-    update: jest.fn<any>(() => {
-      const q = createQuery(() => undefined);
-      queries.update.push(q);
-      return q as never;
-    }),
-  };
+  const select = jest.fn<any>(() => {
+    const q = createQuery(() =>
+      state.selectResults.length > 0 ? state.selectResults.shift() : [],
+    );
+    queries.select.push(q);
+    return q as never;
+  });
 
-  // Serializes overlapping transaction callbacks. The second caller waits
-  // until the first finishes — matches the SELECT FOR UPDATE invariant
-  // on a single routine row.
-  let prev: Promise<unknown> = Promise.resolve();
-  const transaction = jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
-    const release = prev;
-    let resolveSelf!: () => void;
-    prev = new Promise<void>((r) => {
-      resolveSelf = r;
-    });
-    await release;
-    try {
-      return await cb(baseTx);
-    } finally {
-      resolveSelf();
-    }
+  const update = jest.fn<any>(() => {
+    // The chain `set().where().returning()` is the terminal awaited call.
+    // Resolve the chain itself to the FIFO `updateReturningResults` head;
+    // when the implementation does NOT call `.returning()` at all (legacy
+    // pattern, shouldn't happen post-C2), we still resolve to whatever
+    // the head says so the test stays observable.
+    const head =
+      state.updateReturningResults.length > 0
+        ? state.updateReturningResults.shift()!
+        : [];
+    const q = createQuery(() => head);
+    queries.update.push(q);
+    return q as never;
   });
 
   return {
     __state: state,
     __queries: queries,
-    transaction,
-    // Tests don't call `db.select`/`db.update` directly — the transaction
-    // callback gets `baseTx` — but include them for shape compatibility.
-    select: baseTx.select,
-    update: baseTx.update,
+    select,
+    update,
+    // A vestigial transaction stub — the new code path never invokes it,
+    // but leaving it here means any accidental regression that
+    // re-introduces tx wrapping fails loudly in tests rather than
+    // silently passing.
+    transaction: jest.fn<any>(async () => {
+      throw new Error(
+        'ensureRoutineFolder must not open a DB transaction (C2 regression)',
+      );
+    }),
   };
 }
 
@@ -179,10 +175,11 @@ describe('ensureRoutineFolder', () => {
       expect(result).toBe(row);
       expect(provision).not.toHaveBeenCalled();
       expect(db.__queries.update).toHaveLength(0);
-      expect(db.transaction).toHaveBeenCalledTimes(1);
+      // No transaction is opened on any path — the mock throws if it is.
+      expect(db.transaction).not.toHaveBeenCalled();
     });
 
-    it('locks the row with .for("update") inside the transaction', async () => {
+    it('uses optimistic SELECT (no .for("update"), no transaction)', async () => {
       db.__state.selectResults.push([makeRow({ folderId: 'folder-1' })]);
       const provision = jest.fn<any>();
 
@@ -193,14 +190,19 @@ describe('ensureRoutineFolder', () => {
       });
 
       expect(db.__queries.select).toHaveLength(1);
-      expect(db.__queries.select[0].for).toHaveBeenCalledWith('update');
+      // The new shape uses .limit(1) instead of .for('update').
+      expect(db.__queries.select[0].limit).toHaveBeenCalledWith(1);
+      expect(db.transaction).not.toHaveBeenCalled();
     });
   });
 
   describe('slow path', () => {
-    it('provisions, persists folder_id, and returns the merged row', async () => {
+    it('provisions, persists folder_id via UPDATE-WHERE-NULL, and returns the merged row', async () => {
       const row = makeRow({ folderId: null });
       db.__state.selectResults.push([row]);
+      // UPDATE-WHERE-NULL succeeds — RETURNING yields the freshly-claimed row.
+      const claimed = { ...row, folderId: 'folder-new-1' };
+      db.__state.updateReturningResults.push([claimed]);
       const provision = jest
         .fn<any>()
         .mockResolvedValue({ folderId: 'folder-new-1' });
@@ -221,23 +223,20 @@ describe('ensureRoutineFolder', () => {
         provisionDeps,
       );
       expect(db.__queries.update).toHaveLength(1);
-      // Returned row carries the freshly-provisioned folderId
       expect(result.folderId).toBe('folder-new-1');
-      // Other fields preserved
       expect(result.id).toBe(ROUTINE_ID);
       expect(result.title).toBe('Daily Standup');
     });
 
     it('passes id/title/description to provisionFn with documentContent=null', async () => {
-      // The routines table no longer carries documentContent (deprecated in
-      // A.1). ensureRoutineFolder MUST pass `documentContent: null` so the
-      // provisioner falls back to the initial-scaffold commit message and
-      // an empty SKILL.md body.
       const row = makeRow({
         folderId: null,
         description: 'Custom desc',
       });
       db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([
+        { ...row, folderId: 'folder-new-2' },
+      ]);
       const provision = jest
         .fn<any>()
         .mockResolvedValue({ folderId: 'folder-new-2' });
@@ -260,6 +259,9 @@ describe('ensureRoutineFolder', () => {
     it('passes a null description through to provisionFn unchanged', async () => {
       const row = makeRow({ folderId: null, description: null });
       db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([
+        { ...row, folderId: 'folder-new-3' },
+      ]);
       const provision = jest
         .fn<any>()
         .mockResolvedValue({ folderId: 'folder-new-3' });
@@ -271,6 +273,28 @@ describe('ensureRoutineFolder', () => {
       });
 
       expect(provision.mock.calls[0][0].description).toBeNull();
+    });
+
+    it('does not open a DB transaction for the slow path', async () => {
+      // C2 regression guard — folder9 HTTP I/O must NOT happen inside
+      // a tx, otherwise a PG connection gets pinned for the worst-case
+      // ~75s folder9 latency.
+      const row = makeRow({ folderId: null });
+      db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([
+        { ...row, folderId: 'folder-new' },
+      ]);
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-new' });
+
+      await ensureRoutineFolder(ROUTINE_ID, {
+        db: db as unknown as EnsureRoutineFolderDeps['db'],
+        provisionDeps,
+        provision,
+      });
+
+      expect(db.transaction).not.toHaveBeenCalled();
     });
   });
 
@@ -320,10 +344,10 @@ describe('ensureRoutineFolder', () => {
       ).rejects.toThrow(ServiceUnavailableException);
 
       expect(provision).toHaveBeenCalledTimes(1);
-      // No UPDATE issued — the failure is raised before persistence so the
-      // transaction rolls back and folder_id stays NULL.
+      // No UPDATE issued — the failure is raised before persistence so
+      // folder_id stays NULL (the row in the real DB is untouched).
       expect(db.__queries.update).toHaveLength(0);
-      // Row in storage (mocked) stays untouched
+      // Row object in our mock storage stays untouched too.
       expect(row.folderId).toBeNull();
     });
 
@@ -341,9 +365,6 @@ describe('ensureRoutineFolder', () => {
     });
 
     it('handles non-Error throwables from provision (still 503; logs the stringified value)', async () => {
-      // Defensive: provision could in theory throw a non-Error value.
-      // The catch branch must still produce a 503 and not crash the
-      // logger format string.
       db.__state.selectResults.push([makeRow({ folderId: null })]);
       const provision = jest.fn<any>().mockRejectedValue('plain-string-error');
 
@@ -357,8 +378,6 @@ describe('ensureRoutineFolder', () => {
     });
 
     it('preserves NotFoundException without converting it to 503', async () => {
-      // Verifies the catch is scoped to the provision call only — the
-      // upstream "row not found" 404 must NOT be rewritten to 503.
       db.__state.selectResults.push([undefined]);
       const provision = jest.fn<any>();
 
@@ -374,10 +393,11 @@ describe('ensureRoutineFolder', () => {
 
   describe('default provision binding', () => {
     it('falls back to the real provisionFolder9SkillFolder when deps.provision is omitted', async () => {
-      // We can't easily exercise the real provisioner here without a folder9
-      // client, so instead assert the contract: when `provision` is not
-      // supplied the function still runs (fast path: folder already set),
-      // proving the optional `provision` field has a sensible default.
+      // We can't easily exercise the real provisioner here without a
+      // folder9 client, so instead assert the contract: when `provision`
+      // is not supplied the function still runs (fast path: folder
+      // already set), proving the optional `provision` field has a
+      // sensible default.
       const row = makeRow({ folderId: 'folder-prov-default' });
       db.__state.selectResults.push([row]);
 
@@ -390,63 +410,105 @@ describe('ensureRoutineFolder', () => {
     });
   });
 
-  describe('serialization under concurrency', () => {
-    it('FOR UPDATE serializes two concurrent first-access calls — provision runs once, second observes folder_id', async () => {
-      const row = makeRow({ folderId: null });
-
-      // Both calls find the row. After the first transaction populates
-      // folder_id (via UPDATE), subsequent SELECTs should see it set.
-      // We simulate this by mutating `row.folderId` inside the provision spy
-      // (which is what the real UPDATE inside the transaction would
-      // effectively do for any subsequent reader) — but since each select
-      // gets its own copy via `selectResults`, we instead push two distinct
-      // results: the second SELECT result reflects the post-update state.
-      let provisionCalls = 0;
-      const provision = jest.fn<any>(async () => {
-        provisionCalls += 1;
-        // Mutate the shared row so any later reader sees the populated id.
-        // Mock-side simulation of the post-UPDATE state; the real DB does
-        // this via the row lock + UPDATE inside the same transaction.
-        row.folderId = 'folder-concurrent-1';
-        return { folderId: 'folder-concurrent-1' };
-      });
-
-      // Both transactions read the same row reference — when the second
-      // transaction picks up its result (after the first releases the
-      // lock), the shared row already carries folderId.
-      db.__state.selectResults.push([row]);
-      db.__state.selectResults.push([row]);
-
-      const [r1, r2] = await Promise.all([
-        ensureRoutineFolder(ROUTINE_ID, {
-          db: db as unknown as EnsureRoutineFolderDeps['db'],
-          provisionDeps,
-          provision,
-        }),
-        ensureRoutineFolder(ROUTINE_ID, {
-          db: db as unknown as EnsureRoutineFolderDeps['db'],
-          provisionDeps,
-          provision,
-        }),
+  describe('race resolution under concurrency (C2)', () => {
+    it('UPDATE-WHERE-NULL race-loss: returns the winner row, abandons our provisioned folder', async () => {
+      // Two callers race on the same routine. Caller B's provision
+      // completes after caller A's UPDATE has already claimed the
+      // folder_id slot. Caller B's UPDATE returns 0 rows (the
+      // `folder_id IS NULL` predicate no longer matches), so it
+      // re-reads and observes A's folderId — abandoning B's freshly-
+      // provisioned folder (orphan, GC'd later).
+      const initialRow = makeRow({ folderId: null });
+      // Step 1: SELECT sees folder_id = null
+      db.__state.selectResults.push([initialRow]);
+      // Step 3: UPDATE returns [] (race-loss — A already claimed the slot)
+      db.__state.updateReturningResults.push([]);
+      // Step 3b: re-read SELECT sees A's published folderId
+      db.__state.selectResults.push([
+        { ...initialRow, folderId: 'folder-winner-A' },
       ]);
 
-      expect(provisionCalls).toBe(1);
-      expect(r1.folderId).toBe('folder-concurrent-1');
-      expect(r2.folderId).toBe('folder-concurrent-1');
-      // Exactly one UPDATE — only the slow path persists; the second call
-      // takes the fast path.
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-loser-B' });
+
+      const result = await ensureRoutineFolder(ROUTINE_ID, {
+        db: db as unknown as EnsureRoutineFolderDeps['db'],
+        provisionDeps,
+        provision,
+      });
+
+      // We followed through with our provision call.
+      expect(provision).toHaveBeenCalledTimes(1);
+      // We attempted the UPDATE.
       expect(db.__queries.update).toHaveLength(1);
-      expect(db.transaction).toHaveBeenCalledTimes(2);
+      // We re-read after the race-loss.
+      expect(db.__queries.select).toHaveLength(2);
+      // We returned the WINNER's folderId, not our own.
+      expect(result.folderId).toBe('folder-winner-A');
+    });
+
+    it('UPDATE-WHERE-NULL race-loss + winner row vanishes: throws 503', async () => {
+      // Pathological case — UPDATE returns 0 rows AND the re-read finds
+      // no row (or a row with folderId still null). Treat as 503 so the
+      // caller retries cleanly.
+      const initialRow = makeRow({ folderId: null });
+      db.__state.selectResults.push([initialRow]);
+      db.__state.updateReturningResults.push([]);
+      // Re-read: no row at all (extremely rare)
+      db.__state.selectResults.push([undefined]);
+
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-loser' });
+
+      await expect(
+        ensureRoutineFolder(ROUTINE_ID, {
+          db: db as unknown as EnsureRoutineFolderDeps['db'],
+          provisionDeps,
+          provision,
+        }),
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('UPDATE-WHERE-NULL claim-success: returns the row from RETURNING, no re-read', async () => {
+      // The common slow-path case — no concurrent caller, our UPDATE
+      // claims the slot, RETURNING gives us the freshly-updated row,
+      // and we don't need to re-read.
+      const initialRow = makeRow({ folderId: null });
+      db.__state.selectResults.push([initialRow]);
+      db.__state.updateReturningResults.push([
+        { ...initialRow, folderId: 'folder-claimed' },
+      ]);
+
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-claimed' });
+
+      const result = await ensureRoutineFolder(ROUTINE_ID, {
+        db: db as unknown as EnsureRoutineFolderDeps['db'],
+        provisionDeps,
+        provision,
+      });
+
+      expect(result.folderId).toBe('folder-claimed');
+      // Only the initial SELECT happened — no race-loss re-read.
+      expect(db.__queries.select).toHaveLength(1);
     });
 
     it('two SEQUENTIAL calls — second hits fast path after first persists folder_id', async () => {
+      // First call: slow path
       const row = makeRow({ folderId: null });
-      const provision = jest.fn<any>(async () => {
-        row.folderId = 'folder-seq-1';
-        return { folderId: 'folder-seq-1' };
-      });
       db.__state.selectResults.push([row]);
-      db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([
+        { ...row, folderId: 'folder-seq-1' },
+      ]);
+      // Second call: fast path (DB now has the populated row)
+      db.__state.selectResults.push([{ ...row, folderId: 'folder-seq-1' }]);
+
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-seq-1' });
 
       const r1 = await ensureRoutineFolder(ROUTINE_ID, {
         db: db as unknown as EnsureRoutineFolderDeps['db'],
@@ -466,12 +528,6 @@ describe('ensureRoutineFolder', () => {
   });
 
   // ── A.11 — lazy-provision metrics ─────────────────────────────────
-  //
-  // ensureRoutineFolder emits two metrics on the slow path:
-  //   - counter `routines_lazy_provision_total{result="ok|fail"}`
-  //   - histogram `routines_lazy_provision_duration_ms`
-  // Fast path emits neither — the counter measures slow-path frequency
-  // and the histogram would flatten if we logged sub-ms fast samples.
   describe('lazy provision metrics', () => {
     let counterAdd: ReturnType<typeof jest.fn>;
     let histogramRecord: ReturnType<typeof jest.fn>;
@@ -488,7 +544,11 @@ describe('ensureRoutineFolder', () => {
     });
 
     it('slow-path success: increments counter with result=ok and records duration', async () => {
-      db.__state.selectResults.push([makeRow({ folderId: null })]);
+      const row = makeRow({ folderId: null });
+      db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([
+        { ...row, folderId: 'folder-metric-ok' },
+      ]);
       const provision = jest
         .fn<any>()
         .mockResolvedValue({ folderId: 'folder-metric-ok' });
@@ -502,8 +562,6 @@ describe('ensureRoutineFolder', () => {
       expect(counterAdd).toHaveBeenCalledTimes(1);
       expect(counterAdd).toHaveBeenCalledWith(1, { result: 'ok' });
       expect(histogramRecord).toHaveBeenCalledTimes(1);
-      // Sample is a small non-negative number (mocked clock not used —
-      // assert it's a finite number ≥ 0 to avoid timing flakes).
       const [sample] = histogramRecord.mock.calls[0];
       expect(typeof sample).toBe('number');
       expect(sample).toBeGreaterThanOrEqual(0);
@@ -523,8 +581,6 @@ describe('ensureRoutineFolder', () => {
 
       expect(counterAdd).toHaveBeenCalledTimes(1);
       expect(counterAdd).toHaveBeenCalledWith(1, { result: 'fail' });
-      // Histogram fires on both success and failure — we want to see
-      // fail-mode tail latency on the dashboard.
       expect(histogramRecord).toHaveBeenCalledTimes(1);
     });
 
@@ -542,8 +598,6 @@ describe('ensureRoutineFolder', () => {
     });
 
     it('NotFound (routine missing) emits NEITHER metric', async () => {
-      // 404 is a caller mistake (or a cleanup race), not a Layer 2
-      // signal. The slow-path code never runs, so neither metric fires.
       db.__state.selectResults.push([undefined]);
 
       await expect(
@@ -556,6 +610,26 @@ describe('ensureRoutineFolder', () => {
 
       expect(counterAdd).not.toHaveBeenCalled();
       expect(histogramRecord).not.toHaveBeenCalled();
+    });
+
+    it('race-loss: counter increments with result=ok (race-loss is still a successful outcome)', async () => {
+      const row = makeRow({ folderId: null });
+      db.__state.selectResults.push([row]);
+      db.__state.updateReturningResults.push([]);
+      db.__state.selectResults.push([{ ...row, folderId: 'folder-winner' }]);
+
+      const provision = jest
+        .fn<any>()
+        .mockResolvedValue({ folderId: 'folder-loser' });
+
+      await ensureRoutineFolder(ROUTINE_ID, {
+        db: db as unknown as EnsureRoutineFolderDeps['db'],
+        provisionDeps,
+        provision,
+      });
+
+      expect(counterAdd).toHaveBeenCalledTimes(1);
+      expect(counterAdd).toHaveBeenCalledWith(1, { result: 'ok' });
     });
   });
 });

--- a/apps/server/apps/gateway/src/routines/folder/__tests__/provision-routine-folder.spec.ts
+++ b/apps/server/apps/gateway/src/routines/folder/__tests__/provision-routine-folder.spec.ts
@@ -122,7 +122,11 @@ describe('provisionFolder9SkillFolder', () => {
       expect(bodyStart).toBeGreaterThan(frontmatterEnd);
     });
 
-    it('falls back to "Generated from routine: <title>" when description is null', async () => {
+    it('falls back to "Generated from routine - <title>" when description is null', async () => {
+      // C1: fallback uses a dash separator (no `: `) so it parses
+      // cleanly as an unquoted YAML scalar — a colon-followed-by-space
+      // would trigger "Nested mappings are not allowed in compact
+      // mappings" in the validator.
       await provisionFolder9SkillFolder(
         { ...baseRoutine, description: null },
         deps,
@@ -130,11 +134,11 @@ describe('provisionFolder9SkillFolder', () => {
       const skillMd = folder9Client.commit.mock.calls[0][3].files[0]
         .content as string;
       expect(skillMd).toContain(
-        'description: Generated from routine: Daily Standup',
+        'description: Generated from routine - Daily Standup',
       );
     });
 
-    it('falls back to "Generated from routine: <title>" when description is empty/whitespace-only', async () => {
+    it('falls back to "Generated from routine - <title>" when description is empty/whitespace-only', async () => {
       await provisionFolder9SkillFolder(
         { ...baseRoutine, description: '   ' },
         deps,
@@ -142,7 +146,7 @@ describe('provisionFolder9SkillFolder', () => {
       const skillMd = folder9Client.commit.mock.calls[0][3].files[0]
         .content as string;
       expect(skillMd).toContain(
-        'description: Generated from routine: Daily Standup',
+        'description: Generated from routine - Daily Standup',
       );
     });
 
@@ -195,10 +199,19 @@ describe('provisionFolder9SkillFolder', () => {
       );
       const skillMd = folder9Client.commit.mock.calls[0][3].files[0]
         .content as string;
-      // Title flows into the description via fallback; the same newline-strip
-      // and trim rules apply so frontmatter stays single-line.
+      // Title flows into the description via fallback; the same
+      // newline-strip and trim rules apply so frontmatter stays
+      // single-line. Note the title still contains a colon (`: `) so
+      // the rendered description has one too — this is a known sharp
+      // edge: a title with `: ` makes the auto-generated SKILL.md
+      // unparseable. The fallback's own `:` separator was changed to
+      // `-` to avoid this problem (see C1), but we can't sanitize
+      // user-provided title strings without changing the agent
+      // contract. validateSkillMd will still reject such files; the
+      // user has to either set a description manually or rename the
+      // routine.
       expect(skillMd).toMatch(
-        /description: Generated from routine: Routine: weekly report — v2\n/,
+        /description: Generated from routine - Routine: weekly report — v2\n/,
       );
     });
   });

--- a/apps/server/apps/gateway/src/routines/folder/ensure-routine-folder.ts
+++ b/apps/server/apps/gateway/src/routines/folder/ensure-routine-folder.ts
@@ -11,23 +11,40 @@
  * is non-null. Callers can therefore treat `routine.folderId` as
  * non-nullable in any code path downstream of `ensureRoutineFolder`.
  *
- * # Concurrency model
+ * # Concurrency model — no row lock, optimistic claim
  *
- * Two callers racing on the same routine MUST not double-provision (would
- * leak an orphan folder9 folder). The function opens a DB transaction and
- * issues `SELECT ... FOR UPDATE` on the routine row, which serializes the
- * critical section: the second caller blocks on the row lock until the
- * first commits, then re-reads and sees `folder_id` already populated —
- * fast path returns the row, no second provision call.
+ * The previous version held a `SELECT ... FOR UPDATE` row lock for the
+ * full duration of the (3 sequential HTTP roundtrips, up to ~75s) folder9
+ * provision. That pinned a Postgres connection for the worst-case latency
+ * of folder9 — concurrent reads on the same routine queued behind it.
+ *
+ * The current shape avoids that hazard:
+ *   1. Optimistic SELECT (no `.for('update')`, no transaction). If
+ *      `folder_id` is already set, return the row as-is — the common case
+ *      for any post-first-access routine.
+ *   2. Provision OUTSIDE any tx — the slow folder9 calls run with no
+ *      DB-side resources held.
+ *   3. Race-resolved UPDATE: `UPDATE routines SET folder_id = $new
+ *      WHERE id = $routineId AND folder_id IS NULL RETURNING *`. If
+ *      another caller raced ahead and won, the WHERE returns 0 rows; we
+ *      discard our newly-provisioned folder (orphan GC reclaims it after
+ *      24h), re-read the routine, and return the winner's folderId.
+ *      Otherwise we observe our claim and return the merged row.
+ *
+ * Two callers racing on the same routine never double-publish a folderId,
+ * but they MAY both call folder9 — the loser's folder becomes an orphan
+ * collected by the existing 24h GC sweep. The trade-off is intentional:
+ * orphan folders are cheap, pinned DB connections aren't.
  *
  * # Failure modes
  *
- * - **Routine not found** → `NotFoundException` (404). The transaction
- *   rolls back; nothing is persisted.
- * - **Provision throws** (folder9 down / token mint failed / commit
- *   failed) → caught and rewritten to `ServiceUnavailableException`
- *   (503). The transaction rolls back, so `folder_id` stays NULL and the
- *   next call will retry — self-healing.
+ * - **Routine not found** → `NotFoundException` (404).
+ * - **Provision throws** → caught and rewritten to
+ *   `ServiceUnavailableException` (503). No DB write happens, so
+ *   `folder_id` stays NULL and the next call self-heals.
+ * - **UPDATE-WHERE-NULL returns 0 rows (race-loss)** → re-read and return
+ *   the winner's row. The current caller's freshly-provisioned folder is
+ *   abandoned (orphan).
  *
  * # Pure function, not a NestJS service
  *
@@ -42,7 +59,7 @@ import {
   NotFoundException,
   ServiceUnavailableException,
 } from '@nestjs/common';
-import { eq, type PostgresJsDatabase } from '@team9/database';
+import { and, eq, isNull, type PostgresJsDatabase } from '@team9/database';
 import * as schema from '@team9/database/schemas';
 import { appMetrics } from '@team9/observability';
 
@@ -84,7 +101,7 @@ export interface EnsureRoutineFolderDeps {
  * @returns the routine row with `folderId` guaranteed non-null.
  * @throws {NotFoundException} if no routine row exists for `routineId`.
  * @throws {ServiceUnavailableException} if folder9 provisioning fails.
- *   The DB transaction rolls back so `folder_id` stays NULL and the call
+ *   No DB write happens, so `folder_id` stays NULL and the call
  *   self-heals on retry.
  */
 export async function ensureRoutineFolder(
@@ -93,91 +110,127 @@ export async function ensureRoutineFolder(
 ): Promise<RoutineRow> {
   const provisionFn = deps.provision ?? provisionFolder9SkillFolder;
 
-  return await deps.db.transaction(async (tx) => {
-    // SELECT ... FOR UPDATE — locks the row for the duration of this
-    // transaction. A racing transaction on the same routineId blocks
-    // until we commit, then re-reads with the row lock and observes
-    // the populated folder_id (fast path).
-    const [row] = (await tx
+  // ── Step 1: optimistic check — NO row lock, NO transaction ──
+  //
+  // The vast majority of calls hit this fast path (any routine that has
+  // been touched at least once already has a folderId). Reading without
+  // FOR UPDATE means no PG connection is pinned across folder9 latency.
+  const [row] = (await deps.db
+    .select()
+    .from(schema.routines)
+    .where(eq(schema.routines.id, routineId))
+    .limit(1)) as RoutineRow[];
+
+  if (!row) {
+    throw new NotFoundException(`routine ${routineId} not found`);
+  }
+
+  // Fast path — already provisioned. Return the row as-is.
+  if (row.folderId) {
+    return row;
+  }
+
+  // ── Step 2: provision OUTSIDE any tx ──
+  //
+  // Up to 3 sequential HTTP roundtrips; folder9 client timeouts are 15s
+  // (metadata) + 60s (commit). Holding a tx across this would pin a PG
+  // connection for ~75s worst case and serialize concurrent reads on the
+  // same routine — exactly the hazard this refactor is fixing.
+  const slowPathStartedAt = Date.now();
+  let provisioned: { folderId: string };
+  try {
+    provisioned = await provisionFn(
+      {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        // The provision helper accepts a `RoutineLike` shape with
+        // `documentContent` (a virtual field used by legacy migration
+        // flows). The routines table no longer carries that column, so
+        // we pass `null` — the helper falls back to its initial-scaffold
+        // commit message and an empty SKILL.md body.
+        documentContent: null,
+      },
+      deps.provisionDeps,
+    );
+  } catch (err) {
+    // Record duration + fail counter BEFORE we throw — the OTEL
+    // pipeline already has the sample by the time the 503 escapes.
+    appMetrics.routinesLazyProvisionDurationMs.record(
+      Date.now() - slowPathStartedAt,
+    );
+    appMetrics.routinesLazyProvisionTotal.add(1, { result: 'fail' });
+    logger.warn(
+      `provision failed for routine ${routineId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    throw new ServiceUnavailableException(
+      'folder storage temporarily unavailable, please retry',
+    );
+  }
+
+  // ── Step 3: race-resolved UPDATE ──
+  //
+  // `WHERE folder_id IS NULL` makes this a CAS-style claim. If another
+  // caller already published a folder9 folder for this routine, our
+  // WHERE matches zero rows; we then re-read and return the winner. The
+  // folder we just minted becomes an orphan reclaimed by the existing
+  // 24h GC sweep (see design §11).
+  const updateResult = (await deps.db
+    .update(schema.routines)
+    .set({ folderId: provisioned.folderId, updatedAt: new Date() })
+    .where(
+      and(eq(schema.routines.id, routineId), isNull(schema.routines.folderId)),
+    )
+    .returning()) as RoutineRow[];
+
+  if (updateResult.length === 0) {
+    // Race-loss — another caller claimed the folderId slot first. Our
+    // provisioned folder is now orphaned (will be reaped by GC). Re-read
+    // and return the winner so the caller still gets a row with a
+    // non-null folderId.
+    logger.warn(
+      `provision race-loss for routine ${routineId}; abandoning provisioned folder ${provisioned.folderId} (orphan GC will reclaim)`,
+    );
+
+    const [winner] = (await deps.db
       .select()
       .from(schema.routines)
       .where(eq(schema.routines.id, routineId))
-      .for('update')) as RoutineRow[];
+      .limit(1)) as RoutineRow[];
 
-    if (!row) {
-      throw new NotFoundException(`routine ${routineId} not found`);
-    }
-
-    // Fast path — already provisioned. Return the row as-is; no provision
-    // call, no UPDATE.
-    if (row.folderId) {
-      return row;
-    }
-
-    // Slow path — first access since the routine was created (or a
-    // legacy row that pre-dates the folder column). Provision a folder9
-    // managed folder and persist its id.
-    //
-    // Metrics: time the provision call itself (the dominant cost), AND
-    // emit a `lazy_provision_total{result}` counter increment AFTER the
-    // success/failure resolves. The duration histogram covers BOTH
-    // branches so dashboards can see fail-mode latency tails (folder9
-    // timeouts are often the worst-case slow samples).
-    const slowPathStartedAt = Date.now();
-    let provisioned: { folderId: string };
-    try {
-      // The provision helper accepts a `RoutineLike` shape with
-      // `documentContent` (a virtual field used by legacy migration
-      // flows). The routines table no longer carries that column, so we
-      // pass `null` — the helper falls back to its initial-scaffold
-      // commit message and an empty SKILL.md body.
-      provisioned = await provisionFn(
-        {
-          id: row.id,
-          title: row.title,
-          description: row.description,
-          documentContent: null,
-        },
-        deps.provisionDeps,
-      );
-    } catch (err) {
-      // Record duration + fail counter BEFORE we throw — a throw escapes
-      // the transaction callback, Drizzle ROLLBACKs, and the metric
-      // emit happens against the OTEL pipeline (no DB coupling).
+    if (!winner || !winner.folderId) {
+      // Defensive: extremely rare path — the row vanished or stayed NULL
+      // between our UPDATE attempt and the re-read. Treat as a 503 to
+      // get a clean retry.
       appMetrics.routinesLazyProvisionDurationMs.record(
         Date.now() - slowPathStartedAt,
       );
       appMetrics.routinesLazyProvisionTotal.add(1, { result: 'fail' });
-      logger.warn(
-        `provision failed for routine ${routineId}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-      // Re-throw as 503 so API callers get a retryable signal. The DB
-      // transaction rolls back when this throws — folder_id stays NULL
-      // and the next ensureRoutineFolder call retries cleanly.
       throw new ServiceUnavailableException(
         'folder storage temporarily unavailable, please retry',
       );
     }
 
-    await tx
-      .update(schema.routines)
-      .set({ folderId: provisioned.folderId, updatedAt: new Date() })
-      .where(eq(schema.routines.id, routineId));
-
-    // Slow-path success — duration covers the provision + UPDATE pair, the
-    // counter records `result=ok`. We intentionally measure here (after
-    // the UPDATE) and not after `tx` commits — Drizzle commits the tx on
-    // callback return, and the additional commit RTT is not part of
-    // "lazy provision latency" as users see it.
     appMetrics.routinesLazyProvisionDurationMs.record(
       Date.now() - slowPathStartedAt,
     );
+    // Race-loss is still a "successful" provision-attempt outcome from
+    // the dashboard's perspective — the caller observes a populated
+    // folder_id. The `result` label stays `ok` to keep the failure rate
+    // alert untouched by ordinary contention.
     appMetrics.routinesLazyProvisionTotal.add(1, { result: 'ok' });
+    return winner;
+  }
 
-    // Return the merged row — the SELECT result with the new folderId
-    // splatted in. Avoids a second SELECT round-trip.
-    return { ...row, folderId: provisioned.folderId };
-  });
+  appMetrics.routinesLazyProvisionDurationMs.record(
+    Date.now() - slowPathStartedAt,
+  );
+  appMetrics.routinesLazyProvisionTotal.add(1, { result: 'ok' });
+
+  // Drizzle's UPDATE ... RETURNING returned exactly the row we just
+  // claimed. Trust its folderId rather than splatting from the stale
+  // SELECT result.
+  return updateResult[0];
 }

--- a/apps/server/apps/gateway/src/routines/folder/provision-routine-folder.ts
+++ b/apps/server/apps/gateway/src/routines/folder/provision-routine-folder.ts
@@ -171,10 +171,20 @@ export async function provisionFolder9SkillFolder(
   // Step 3 — compose SKILL.md and commit it as the seed of the folder.
   // Fallback fires whenever the description is null OR whitespace-only after
   // newlines collapse — both cases produce no useful frontmatter content.
+  //
+  // Fallback policy: use a dash-separated form (no `: `) so the YAML
+  // parser at validation time treats the value as a plain unquoted
+  // scalar. A colon followed by space inside an unquoted scalar
+  // triggers `Nested mappings are not allowed in compact mappings`,
+  // which would fail validateSkillMd before the agent can even read
+  // the file. routines.service.ts#completeCreation uses the same
+  // string when computing `expectedDescription` for the
+  // mismatch-comparison — keep both call sites in sync if you ever
+  // change this format.
   const normalized = normalizeDescription(routine.description ?? '');
   const description = normalized
     ? normalized
-    : normalizeDescription(`Generated from routine: ${routine.title}`);
+    : normalizeDescription(`Generated from routine - ${routine.title}`);
 
   const body = routine.documentContent ?? '';
   const skillMd = composeSkillMd({

--- a/apps/server/apps/gateway/src/routines/routines.service.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.spec.ts
@@ -578,15 +578,16 @@ describe('RoutinesService — TaskCast integration', () => {
         creatorId: 'user-1',
         title: 'New task',
         documentId: 'doc-new',
-        // folderId starts NULL — the atomic flow back-fills it via the
-        // post-INSERT UPDATE inside the same transaction.
+        // folderId starts NULL — the create flow back-fills it via the
+        // post-INSERT UPDATE (run after the folder9 provision call,
+        // outside any DB transaction — see C2 refactor).
         folderId: null,
       };
 
       documentsService.create.mockResolvedValueOnce({ id: 'doc-new' } as any);
       db.returning.mockResolvedValueOnce([createdTask] as any);
 
-      // The atomic flow returns the inserted row spread with the
+      // The flow returns the inserted row spread with the
       // newly-provisioned folderId. Default folder9 mock returns
       // `{id: 'folder-new'}` — so the resolved object equals the row
       // with folderId overridden.
@@ -674,12 +675,17 @@ describe('RoutinesService — TaskCast integration', () => {
       expect(wsGateway.broadcastToWorkspace).not.toHaveBeenCalled();
     });
 
-    // ── A.4: atomic create + folder9 provision flow ────────────────────
+    // ── A.4 + C2: create + folder9 provision flow ───────────────────────
     //
-    // The new create() wraps INSERT + provision + UPDATE in a single DB
-    // transaction. Each test below pins a specific outcome of that flow.
+    // create() now runs INSERT + provision + UPDATE folderId as three
+    // separate DB operations (NOT in a single transaction). Folder9's
+    // long HTTP I/O happens OUTSIDE any tx, so we don't pin a PG
+    // connection across folder9 latency. On failure AFTER the INSERT,
+    // the row is best-effort DELETEd so the caller doesn't observe a
+    // half-baked routine; if DELETE itself fails, lazy-provision in
+    // ensureRoutineFolder will heal the row on next access.
 
-    describe('atomic flow (A.4)', () => {
+    describe('create + folder9 flow (A.4 / C2)', () => {
       it('happy path: provisions folder9, persists folderId, returns routine with non-null folderId', async () => {
         const createdTask = {
           id: 'task-atomic-happy',
@@ -718,20 +724,20 @@ describe('RoutinesService — TaskCast integration', () => {
         expect(folder9Client.commit).toHaveBeenCalledTimes(1);
 
         // The returned row carries the new folderId — proves we splatted it
-        // in after the post-INSERT UPDATE inside the transaction.
+        // in after the post-INSERT UPDATE.
         expect(result).toMatchObject({
           id: 'task-atomic-happy',
           folderId: 'folder-atomic-happy',
         });
 
-        // The DB transaction wrapper was used.
-        expect(db.transaction).toHaveBeenCalledTimes(1);
+        // C2 contract: NO transaction wrapper around the slow flow.
+        expect(db.transaction).not.toHaveBeenCalled();
         // Both an INSERT and an UPDATE were issued (UPDATE sets folderId).
         expect(db.insert).toHaveBeenCalled();
         expect(db.update).toHaveBeenCalled();
       });
 
-      it('folder9 createFolder fails: throws 503, no UPDATE, no committed row leak', async () => {
+      it('folder9 createFolder fails: throws 503, no UPDATE, best-effort DELETE of the just-INSERTed row', async () => {
         const draftRow = {
           id: 'task-atomic-fail-create',
           tenantId: 'tenant-1',
@@ -750,7 +756,6 @@ describe('RoutinesService — TaskCast integration', () => {
           new Error('folder9 unreachable'),
         );
 
-        // The transaction-callback throw bubbles up as a 503.
         await expect(
           service.create(
             { title: 'Atomic fail-create', botId: 'bot-1' } as never,
@@ -762,21 +767,16 @@ describe('RoutinesService — TaskCast integration', () => {
         // Token mint and commit must never have been attempted.
         expect(folder9Client.createToken).not.toHaveBeenCalled();
         expect(folder9Client.commit).not.toHaveBeenCalled();
-        // The post-INSERT UPDATE must NOT have been issued — its work
-        // would have been rolled back anyway, but we want to verify the
-        // try/catch correctly fast-fails before the UPDATE step.
+        // The post-INSERT UPDATE for folderId must NOT have been issued.
         expect(db.update).not.toHaveBeenCalled();
+        // C2 contract: best-effort cleanup DELETEs the just-INSERTed row
+        // so the caller doesn't see a half-baked routine.
+        expect(db.delete).toHaveBeenCalled();
 
-        // No-leak verification: with the mocked db, "rows committed" is
-        // approximated by counting rows the service believes it wrote. A
-        // failed transaction means our caller cannot observe the routine
-        // — the function threw before it could return a routine row.
-        // Triggers must also have been skipped (we never reached the
-        // post-INSERT branch).
         expect(routineTriggersService.createBatch).not.toHaveBeenCalled();
       });
 
-      it('folder9 commit fails (orphan-folder window): throws 503, post-INSERT UPDATE skipped', async () => {
+      it('folder9 commit fails (orphan-folder window): throws 503, no folderId UPDATE, DELETEs the inserted row', async () => {
         const draftRow = {
           id: 'task-atomic-fail-commit',
           tenantId: 'tenant-1',
@@ -798,11 +798,10 @@ describe('RoutinesService — TaskCast integration', () => {
           token: 'tok-orphan',
           expires_at: '2099-01-01',
         });
-        // Folder created, token minted, then commit dies — this is the
-        // worst-case path because folder9 has a folder that the routines
-        // table will never reference. Orphan GC handles the cleanup
-        // separately; this test only verifies the local invariant: no
-        // partial routine row reaches the DB.
+        // Folder created, token minted, then commit dies — folder9 has a
+        // folder that the routines table will never reference. Orphan GC
+        // reclaims it; this test verifies the local invariant: caller
+        // sees no half-baked row.
         folder9Client.commit.mockRejectedValueOnce(
           new Error('folder9 commit timeout'),
         );
@@ -818,68 +817,130 @@ describe('RoutinesService — TaskCast integration', () => {
         expect(folder9Client.createFolder).toHaveBeenCalledTimes(1);
         expect(folder9Client.createToken).toHaveBeenCalledTimes(1);
         expect(folder9Client.commit).toHaveBeenCalledTimes(1);
-        // Critical: the UPDATE that writes folderId back must NOT have
-        // been issued. The INSERT happened inside the transaction
-        // callback, but Drizzle's ROLLBACK semantics mean the row is
-        // reverted; the lack of an UPDATE is the local proof that we
-        // did not even try to persist a folderId on a row we know is
-        // about to be rolled back.
+        // The folderId UPDATE must NOT have been issued.
         expect(db.update).not.toHaveBeenCalled();
+        // DELETE issued as best-effort cleanup so the caller doesn't see
+        // the half-baked row.
+        expect(db.delete).toHaveBeenCalled();
         expect(routineTriggersService.createBatch).not.toHaveBeenCalled();
       });
 
-      it('rolls back on folder9 failure: transaction callback throws, no row visible to caller', async () => {
-        // This test pins the ROLLBACK contract by making the DB-mock
-        // transaction wrapper observable: it captures whether the
-        // callback threw, which is how Drizzle decides to ROLLBACK.
+      it('cleanup DELETE failure is non-fatal: still throws 503, log records the failure', async () => {
+        // Pathological case — provision throws, then our best-effort
+        // DELETE also throws. We must still surface 503 to the caller
+        // (the orphan row will be lazy-provisioned on next access).
         const draftRow = {
-          id: 'task-atomic-rollback',
+          id: 'task-atomic-delete-fail',
           tenantId: 'tenant-1',
           creatorId: 'user-1',
-          title: 'Atomic rollback',
+          title: 'Atomic delete-fail',
           description: null,
-          documentId: 'doc-atomic-rollback',
+          documentId: 'doc-atomic-delete-fail',
           folderId: null,
         };
         documentsService.create.mockResolvedValueOnce({
-          id: 'doc-atomic-rollback',
+          id: 'doc-atomic-delete-fail',
         } as any);
         db.returning.mockResolvedValueOnce([draftRow] as any);
-        folder9Client.createFolder.mockRejectedValueOnce(new Error('boom'));
+        folder9Client.createFolder.mockRejectedValueOnce(
+          new Error('folder9 down'),
+        );
+        // Make the cleanup DELETE itself reject. The mock chain's
+        // `where(...)` returns `chain` (a thenable-by-await? no — a
+        // plain object). To force the promise to reject we wire
+        // `db.delete().where(...)` via mock that throws on await — the
+        // simplest way is to override `db.where` to throw once when the
+        // delete sequence picks it up. But since `where` is shared, we
+        // override `db.delete` itself to return an object whose `where`
+        // returns a rejected promise.
+        const rejectingChain = {
+          where: jest.fn<any>(() =>
+            Promise.reject(new Error('cleanup db down')),
+          ),
+        };
+        db.delete.mockReturnValueOnce(rejectingChain as any);
 
-        let callbackThrew = false;
-        db.transaction.mockImplementationOnce(async (cb: any) => {
-          try {
-            return await cb(db);
-          } catch (e) {
-            callbackThrew = true;
-            throw e;
-          }
-        });
+        const loggerErrorSpy = jest.spyOn((service as any).logger, 'error');
 
         await expect(
           service.create(
-            { title: 'Atomic rollback', botId: 'bot-1' } as never,
+            { title: 'Atomic delete-fail', botId: 'bot-1' } as never,
             'user-1',
             'tenant-1',
           ),
         ).rejects.toBeInstanceOf(ServiceUnavailableException);
 
-        // Drizzle issues ROLLBACK iff the callback throws — this is the
-        // exact contract we lean on.
-        expect(callbackThrew).toBe(true);
+        // Both errors logged: the original folder9 failure AND the
+        // best-effort DELETE failure.
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('best-effort cleanup DELETE failed'),
+        );
+        loggerErrorSpy.mockRestore();
       });
 
-      it('exposes a self-counted DB-row leak proof: simulated query against routines table sees zero rows after a failed provision', async () => {
-        // The mocked db is in-memory and stateless, but we can still
-        // simulate "is there a routine row?" by tracking what the
-        // service committed via tx.insert + tx.update vs what it tried
-        // to commit. After a folder9 failure, any caller-visible SELECT
-        // (post-call) must return zero rows. We approximate that by
-        // asserting (a) the function rejected so the caller never got a
-        // row reference, AND (b) no UPDATE that would have given the
-        // INSERT a folderId was issued — combining (a) and (b) means
-        // the route-side observable state is "no routine for this id".
+      it('UPDATE folderId failure after folder9 success: throws 503, DELETEs the inserted row', async () => {
+        // Provision succeeded but the local UPDATE folderId fails. The
+        // folder is real on folder9 (will be GC'd as orphan); we DELETE
+        // the routine row so the caller doesn't see it pointing nowhere.
+        const draftRow = {
+          id: 'task-atomic-update-fail',
+          tenantId: 'tenant-1',
+          creatorId: 'user-1',
+          title: 'Atomic update-fail',
+          description: null,
+          documentId: 'doc-atomic-update-fail',
+          folderId: null,
+        };
+        documentsService.create.mockResolvedValueOnce({
+          id: 'doc-atomic-update-fail',
+        } as any);
+        db.returning.mockResolvedValueOnce([draftRow] as any);
+        folder9Client.createFolder.mockResolvedValueOnce({
+          id: 'folder-orphan',
+          workspace_id: 'tenant-1',
+        });
+        folder9Client.createToken.mockResolvedValueOnce({
+          token: 'tok-update-fail',
+          expires_at: '2099-01-01',
+        });
+        folder9Client.commit.mockResolvedValueOnce({
+          commit_id: 'commit-update-fail',
+        });
+        // Make the UPDATE chain reject when awaited. Override
+        // db.update().set().where() to return a rejecting thenable.
+        const rejectingChain = {
+          set: jest.fn<any>().mockReturnThis(),
+          where: jest.fn<any>(() =>
+            Promise.reject(new Error('UPDATE constraint violation')),
+          ),
+        };
+        // Explicitly set `set` to return the same chain so .where(...)
+        // is reachable.
+        rejectingChain.set.mockReturnValue(rejectingChain);
+        db.update.mockReturnValueOnce(rejectingChain as any);
+
+        await expect(
+          service.create(
+            { title: 'Atomic update-fail', botId: 'bot-1' } as never,
+            'user-1',
+            'tenant-1',
+          ),
+        ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+        // Folder9 was reached.
+        expect(folder9Client.createFolder).toHaveBeenCalledTimes(1);
+        expect(folder9Client.commit).toHaveBeenCalledTimes(1);
+        // Best-effort cleanup DELETE happened.
+        expect(db.delete).toHaveBeenCalled();
+      });
+
+      it('exposes a self-counted DB-row leak proof: caller never gets a row reference back after a failed provision', async () => {
+        // After a folder9 failure, the caller cannot observe the routine
+        // because (a) the function rejected, and (b) we issued a
+        // best-effort DELETE for the just-INSERTed row. Combining (a)
+        // and (b) means the post-call observable state is "no routine
+        // for this id" — even though the INSERT happened, the DELETE
+        // erases it.
         const draftRow = {
           id: 'task-atomic-leak-proof',
           tenantId: 'tenant-1',
@@ -903,10 +964,11 @@ describe('RoutinesService — TaskCast integration', () => {
           ),
         ).rejects.toBeInstanceOf(ServiceUnavailableException);
 
-        // Simulate a follow-up SELECT for the same routineId — under
-        // ROLLBACK semantics this returns []. We make the mock return []
-        // to pin the post-rollback expectation explicitly. (The unit-
-        // test mock is stateless; a real DB would do this naturally.)
+        // Best-effort cleanup DELETE issued.
+        expect(db.delete).toHaveBeenCalled();
+
+        // Simulate a follow-up SELECT for the same routineId — after
+        // DELETE this returns [].
         db.limit.mockResolvedValueOnce([] as any);
         const after = await db
           .select()
@@ -2584,10 +2646,18 @@ describe('RoutinesService — TaskCast integration', () => {
         userId: 'user-1',
       } as any);
 
-      // `for('update')` is the SELECT ... FOR UPDATE inside
-      // ensureRoutineFolder. Default to the DRAFT_ROUTINE so the fast
-      // path returns immediately. Individual tests override per-call.
+      // After C2: `ensureRoutineFolder` reads via plain `.limit(1)`
+      // (no row lock). The chain's `.limit` mock is shared with
+      // `getRoutineOrThrow` — tests use `db.limit.mockResolvedValueOnce`
+      // to set the FIRST call (getRoutineOrThrow) and we set a default
+      // here so the SECOND call (ensureRoutineFolder's optimistic read)
+      // also observes the DRAFT_ROUTINE row, which has folderId set so
+      // ensureRoutineFolder takes the fast path.
+      //
+      // Vestigial: `.for('update')` is no longer used; leaving the
+      // default in place doesn't matter (the spy is just never hit).
       db.for.mockResolvedValue([DRAFT_ROUTINE]);
+      db.limit.mockResolvedValue([DRAFT_ROUTINE]);
 
       // Default SKILL.md read returns the valid fixture so happy-path
       // tests don't have to redeclare it. Failure-path tests override.
@@ -2763,22 +2833,27 @@ describe('RoutinesService — TaskCast integration', () => {
       });
     });
 
-    it('throws 400 with validation error when document content is empty', async () => {
+    it('I1 — empty legacy documents-table content NO LONGER fails completeCreation', async () => {
+      // I1 removed the documents-table gate. SKILL.md is now the source
+      // of truth; an empty legacy document does not block status flip
+      // as long as SKILL.md content validates. The default fixture
+      // SKILL.md (VALID_SKILL_MD) already passes validation, so the
+      // routine flips to upcoming successfully.
       db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
+      db.returning.mockResolvedValueOnce([UPDATED_ROUTINE] as any);
       documentsService.getById.mockResolvedValueOnce({
         id: 'doc-1',
         tenantId: 'tenant-1',
         currentVersion: { versionIndex: 1, content: '' },
       } as any);
 
-      await expect(
-        service.completeCreation('routine-1', {}, 'user-1', 'tenant-1'),
-      ).rejects.toMatchObject({
-        response: {
-          message: 'Missing required fields',
-          errors: expect.arrayContaining(['documentContent is required']),
-        },
-      });
+      const result = await service.completeCreation(
+        'routine-1',
+        {},
+        'user-1',
+        'tenant-1',
+      );
+      expect(result.status).toBe('upcoming');
     });
 
     it('calls archiveCreationChannel with the correct channel and tenant when creationChannelId is set', async () => {
@@ -2893,66 +2968,55 @@ describe('RoutinesService — TaskCast integration', () => {
       });
     });
 
-    it('treats missing document as empty content (validation error)', async () => {
-      // documentId is set but documentsService.getById throws (doc deleted)
+    it('I1 — missing legacy document NO LONGER fails completeCreation', async () => {
+      // documentId is set but documentsService.getById throws (doc
+      // deleted). After I1 the documents-table content is irrelevant —
+      // only SKILL.md validation matters. SKILL.md still passes so the
+      // status flip succeeds.
       db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
-      documentsService.getById.mockRejectedValueOnce(
-        new Error('not found') as any,
-      );
+      db.returning.mockResolvedValueOnce([UPDATED_ROUTINE] as any);
 
-      await expect(
-        service.completeCreation('routine-1', {}, 'user-1', 'tenant-1'),
-      ).rejects.toMatchObject({
-        response: {
-          message: 'Missing required fields',
-          errors: expect.arrayContaining(['documentContent is required']),
-        },
-      });
+      const result = await service.completeCreation(
+        'routine-1',
+        {},
+        'user-1',
+        'tenant-1',
+      );
+      expect(result.status).toBe('upcoming');
     });
 
-    it('returns validation error when routine has no linked document (documentId null)', async () => {
+    it('I1 — null documentId NO LONGER fails completeCreation', async () => {
+      // After I1 the documents-table content is irrelevant. The routine
+      // can finish creation as long as SKILL.md validates — which it
+      // does in the default fixture.
       db.limit.mockResolvedValueOnce([
         { ...DRAFT_ROUTINE, documentId: null },
       ] as any);
+      db.returning.mockResolvedValueOnce([UPDATED_ROUTINE] as any);
 
-      await expect(
-        service.completeCreation('routine-1', {}, 'user-1', 'tenant-1'),
-      ).rejects.toMatchObject({
-        response: {
-          message: 'Missing required fields',
-          errors: expect.arrayContaining(['documentContent is required']),
-        },
-      });
+      const result = await service.completeCreation(
+        'routine-1',
+        {},
+        'user-1',
+        'tenant-1',
+      );
+      expect(result.status).toBe('upcoming');
     });
 
-    // ── documentContent shape + tenant-guard tests ────────────────────
+    // ── (post-I1) document-table tenant-guard tests are obsolete ──────
+    //
+    // The legacy documents-table content gate was removed in I1 — only
+    // SKILL.md validation matters now. Tenant-mismatch / "real shape"
+    // tests against the documents service are therefore covered by
+    // SKILL.md tests below; we keep one positive smoke test that pins
+    // "happy SKILL.md flow → upcoming" to make sure the I1 removal
+    // didn't accidentally change that path.
 
-    it('completeCreation: tenant mismatch on document treats content as empty (rejects with documentContent required)', async () => {
-      db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
-      documentsService.getById.mockResolvedValueOnce({
-        id: 'doc-1',
-        tenantId: 'other-tenant',
-        currentVersion: { versionIndex: 1, content: 'foo' },
-      } as any);
-
-      await expect(
-        service.completeCreation('routine-1', {}, 'user-1', 'tenant-1'),
-      ).rejects.toMatchObject({
-        response: {
-          message: 'Missing required fields',
-          errors: expect.arrayContaining(['documentContent is required']),
-        },
-      });
-    });
-
-    it('completeCreation: validates documentContent via doc.currentVersion.content (real shape)', async () => {
+    it('I1 — happy SKILL.md flow flips to upcoming regardless of legacy doc content shape', async () => {
       db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
       db.returning.mockResolvedValueOnce([UPDATED_ROUTINE] as any);
-      documentsService.getById.mockResolvedValueOnce({
-        id: 'doc-1',
-        tenantId: 'tenant-1',
-        currentVersion: { versionIndex: 1, content: 'real content' },
-      } as any);
+      // The documents-service mock could return literally anything
+      // here — completeCreation no longer calls it on the new path.
 
       const result = await service.completeCreation(
         'routine-1',
@@ -3222,8 +3286,10 @@ describe('RoutinesService — TaskCast integration', () => {
 
         await service.completeCreation('routine-1', {}, 'user-1', 'tenant-1');
 
-        // ensureRoutineFolder ran exactly once (SELECT ... FOR UPDATE).
-        expect(db.for).toHaveBeenCalledWith('update');
+        // After C2: ensureRoutineFolder uses plain `.limit(1)` (no row
+        // lock). It still ran (the SKILL.md read+validation requires it),
+        // observable via the createToken call below.
+
         // Read token minted with read scope, short TTL, and routine-scoped
         // creator label.
         expect(folder9Client.createToken).toHaveBeenCalledWith(
@@ -3439,16 +3505,117 @@ describe('RoutinesService — TaskCast integration', () => {
         expect(db.update).not.toHaveBeenCalled();
       });
 
+      // ── C1 regression: null routine description ────────────────────
+      //
+      // Before C1 fix, `expectedDescription = ensured.description ?? ''`
+      // — when the routine has a null description, the expected value
+      // collapsed to `''`, which fails BOTH `description_empty` (must
+      // be non-empty) AND `description_mismatch` (must equal). After
+      // C1 fix, the expected value falls back to the same string the
+      // provisioner seeds: `Generated from routine: <title>`. The agent
+      // can then write SKILL.md frontmatter that matches and finish
+      // creation cleanly.
+      it('C1 — null routine description: completeCreation succeeds when SKILL.md mirrors the provisioner fallback', async () => {
+        const draftWithNullDesc = {
+          ...DRAFT_ROUTINE,
+          description: null,
+          // Provisioner-derived fallback is `Generated from routine - <title>`.
+        };
+        const upcomingFromNullDesc = {
+          ...draftWithNullDesc,
+          status: 'upcoming' as const,
+        };
+        db.limit.mockResolvedValueOnce([draftWithNullDesc] as any);
+        // ensureRoutineFolder optimistic read sees the same row; folder
+        // is already provisioned (fast path).
+        db.limit.mockResolvedValueOnce([draftWithNullDesc] as any);
+
+        // SKILL.md exactly matches what `provisionFolder9SkillFolder`
+        // would have written: description = `Generated from routine - <title>`.
+        folder9Client.getBlob.mockResolvedValueOnce({
+          path: 'SKILL.md',
+          size: 200,
+          content: [
+            '---',
+            'name: routine-routine-1',
+            `description: Generated from routine - ${draftWithNullDesc.title}`,
+            '---',
+            '',
+            'A complete body that easily clears the 20-char threshold.',
+          ].join('\n'),
+          encoding: 'text' as const,
+        } as any);
+
+        db.returning.mockResolvedValueOnce([upcomingFromNullDesc] as any);
+
+        const result = await service.completeCreation(
+          'routine-1',
+          {},
+          'user-1',
+          'tenant-1',
+        );
+
+        expect(result).toEqual(upcomingFromNullDesc);
+        // Status flip happened — proves SKILL.md validation passed.
+        expect(db.update).toHaveBeenCalled();
+      });
+
+      it('C1 — whitespace-only routine description treated as null (provisioner fallback applies)', async () => {
+        // Mirror the provisioner's behaviour: a whitespace-only
+        // description normalizes to empty, and the fallback fires.
+        const draftWithBlankDesc = {
+          ...DRAFT_ROUTINE,
+          description: '   \n\n ',
+        };
+        const upcoming = {
+          ...draftWithBlankDesc,
+          status: 'upcoming' as const,
+        };
+        db.limit.mockResolvedValueOnce([draftWithBlankDesc] as any);
+        db.limit.mockResolvedValueOnce([draftWithBlankDesc] as any);
+
+        folder9Client.getBlob.mockResolvedValueOnce({
+          path: 'SKILL.md',
+          size: 200,
+          content: [
+            '---',
+            'name: routine-routine-1',
+            `description: Generated from routine - ${draftWithBlankDesc.title}`,
+            '---',
+            '',
+            'A complete body that easily clears the 20-char threshold.',
+          ].join('\n'),
+          encoding: 'text' as const,
+        } as any);
+
+        db.returning.mockResolvedValueOnce([upcoming] as any);
+
+        const result = await service.completeCreation(
+          'routine-1',
+          {},
+          'user-1',
+          'tenant-1',
+        );
+
+        expect(result.status).toBe('upcoming');
+      });
+
       it('lazy-provisions folder9 folder when folderId is null then validates', async () => {
         // routine.folderId is null on the initial fetch (slow path of
-        // ensureRoutineFolder will call provision via the folder9 client).
+        // ensureRoutineFolder will call provision via the folder9
+        // client). After C2, ensureRoutineFolder uses plain `.limit(1)`
+        // for both reads — getRoutineOrThrow + the optimistic read.
         const draftNoFolder = { ...DRAFT_ROUTINE, folderId: null };
+        const ensuredNoFolder = {
+          ...draftNoFolder,
+          folderId: 'folder-fresh',
+        };
+        // First .limit() call: getRoutineOrThrow
         db.limit.mockResolvedValueOnce([draftNoFolder] as any);
-        // ensureRoutineFolder reads via SELECT ... FOR UPDATE; the row
-        // also lacks folderId, so the provision branch fires.
-        db.for.mockResolvedValueOnce([draftNoFolder] as any);
+        // Second .limit() call: ensureRoutineFolder optimistic read
+        db.limit.mockResolvedValueOnce([draftNoFolder] as any);
         // Provision creates folder, mints write token, commits, then
-        // UPDATEs the row. Mock the folder creation chain.
+        // UPDATEs the row via UPDATE-WHERE-NULL with .returning().
         folder9Client.createFolder.mockResolvedValueOnce({
           id: 'folder-fresh',
           workspace_id: 'tenant-1',
@@ -3472,11 +3639,9 @@ describe('RoutinesService — TaskCast integration', () => {
           commit: 'sha-1',
           branch: 'main',
         } as any);
-        documentsService.getById.mockResolvedValueOnce({
-          id: 'doc-1',
-          tenantId: 'tenant-1',
-          currentVersion: { versionIndex: 1, content: 'some content' },
-        } as any);
+        // First .returning() call: ensureRoutineFolder slow-path UPDATE
+        db.returning.mockResolvedValueOnce([ensuredNoFolder] as any);
+        // Second .returning() call: completeCreation status flip
         db.returning.mockResolvedValueOnce([UPDATED_ROUTINE] as any);
 
         const result = await service.completeCreation(
@@ -3724,9 +3889,14 @@ describe('RoutinesService — TaskCast integration', () => {
         { id: draftRoutine.id } as any,
       ] as any);
 
-      //   9. ensureRoutineFolder (A.8) SELECT ... FOR UPDATE — returning a
-      //      row with a populated folderId puts it on the fast path.
+      //   9. ensureRoutineFolder (A.8 / C2) — uses optimistic
+      //      `.limit(1)`. Returning a row with a populated folderId
+      //      puts it on the fast path. Vestigial `.for('update')` mock
+      //      kept for any path that still references it (none after C2).
       db.for.mockResolvedValueOnce([
+        { ...draftRoutine, folderId: 'folder-existing' } as any,
+      ] as any);
+      db.limit.mockResolvedValueOnce([
         { ...draftRoutine, folderId: 'folder-existing' } as any,
       ] as any);
     }
@@ -4039,11 +4209,20 @@ describe('RoutinesService — TaskCast integration', () => {
       // Step 6: atomic claim UPDATE returning()
       db.returning.mockResolvedValueOnce(claimResult as any);
 
-      // Step 7 (A.8): ensureRoutineFolder runs SELECT ... FOR UPDATE.
-      // Returning a row with a populated folderId puts it on the fast
-      // path (no provision call, no follow-up UPDATE).
-      if (ensuredFolderRow !== null) {
+      // Step 7 (A.8 / C2): ensureRoutineFolder runs an optimistic
+      // `.limit(1)` (no row lock). Returning a row with a populated
+      // folderId puts it on the fast path (no provision call, no
+      // follow-up UPDATE). Vestigial `.for('update')` mock kept.
+      //
+      // Skip queuing this when the atomic claim is configured to lose
+      // (claimResult = []) — in that branch, startCreationSession
+      // returns early via re-read and never calls ensureRoutineFolder.
+      // Queuing the mock anyway would shift the limit FIFO and feed
+      // the wrong row to the winner re-read.
+      const claimWonRow = claimResult.length > 0;
+      if (ensuredFolderRow !== null && claimWonRow) {
         db.for.mockResolvedValueOnce([ensuredFolderRow] as any);
+        db.limit.mockResolvedValueOnce([ensuredFolderRow] as any);
       }
 
       return routine;
@@ -4168,8 +4347,11 @@ describe('RoutinesService — TaskCast integration', () => {
       // Step 4: atomic claim UPDATE returning 1 row = won
       db.returning.mockResolvedValueOnce([{ id: ROUTINE_ID }]);
 
-      // Step 5 (A.8): ensureRoutineFolder fast path
+      // Step 5 (A.8 / C2): ensureRoutineFolder fast path via .limit(1)
       db.for.mockResolvedValueOnce([
+        { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
+      ]);
+      db.limit.mockResolvedValueOnce([
         { id: ROUTINE_ID, folderId: 'folder-existing' } as any,
       ]);
 
@@ -4441,10 +4623,13 @@ describe('RoutinesService — TaskCast integration', () => {
       });
 
       it('lazy-provisions the folder when routine.folderId is NULL and uses the new id', async () => {
-        // Routine row read at step 1 has a NULL folderId. The
-        // ensureRoutineFolder transaction will SELECT-FOR-UPDATE,
-        // see the NULL, call provisionFolder9SkillFolder, persist
-        // the new id, then return the row with the populated id.
+        // Routine row read at step 1 has a NULL folderId. With C2
+        // ensureRoutineFolder uses a plain `.limit(1)` for the
+        // optimistic read; the row's folderId is NULL so the slow
+        // path fires (provision via folder9 + UPDATE-WHERE-NULL via
+        // .returning()). The slow-path UPDATE returns the
+        // freshly-claimed row, then we use its `folderId` for
+        // `routine.document` in the session config.
         const draft = {
           id: ROUTINE_ID,
           tenantId: TENANT_ID,
@@ -4478,6 +4663,10 @@ describe('RoutinesService — TaskCast integration', () => {
         folder9Client.commit.mockResolvedValueOnce({
           commit_id: 'commit-init',
         });
+        // C2: UPDATE-WHERE-NULL claim returns the freshly-claimed row.
+        db.returning.mockResolvedValueOnce([
+          { ...draft, folderId: 'folder-new' },
+        ]);
 
         await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
 
@@ -4714,8 +4903,11 @@ describe('RoutinesService — TaskCast integration', () => {
       db.where.mockResolvedValueOnce(expectedTriggers as any);
       // atomic claim
       db.returning.mockResolvedValueOnce([{ id: ROUTINE_ID }] as any);
-      // ensureRoutineFolder (A.8) fast path
+      // ensureRoutineFolder (A.8 / C2) fast path via .limit(1)
       db.for.mockResolvedValueOnce([
+        { ...DRAFT, folderId: 'folder-existing' } as any,
+      ]);
+      db.limit.mockResolvedValueOnce([
         { ...DRAFT, folderId: 'folder-existing' } as any,
       ]);
 
@@ -4756,8 +4948,11 @@ describe('RoutinesService — TaskCast integration', () => {
       });
       // atomic claim
       db.returning.mockResolvedValueOnce([{ id: ROUTINE_ID }] as any);
-      // ensureRoutineFolder (A.8) fast path
+      // ensureRoutineFolder (A.8 / C2) fast path via .limit(1)
       db.for.mockResolvedValueOnce([
+        { ...DRAFT, folderId: 'folder-existing' } as any,
+      ]);
+      db.limit.mockResolvedValueOnce([
         { ...DRAFT, folderId: 'folder-existing' } as any,
       ]);
 
@@ -4973,8 +5168,12 @@ describe('RoutinesService — TaskCast integration', () => {
     };
 
     beforeEach(() => {
-      // Default: ensureRoutineFolder fast-path (folderId already populated).
+      // Default: ensureRoutineFolder fast-path (folderId already
+      // populated). Both legacy `.for('update')` and new `.limit(1)`
+      // mocks return the same row so any test that overrides one but
+      // not the other still observes a consistent fast path.
       db.for.mockResolvedValue([PROVISIONED_ROUTINE]);
+      db.limit.mockResolvedValue([PROVISIONED_ROUTINE]);
       folder9Client.createToken.mockResolvedValue({
         token: 'tok-folder-proxy',
         expires_at: '2099-01-01T00:00:00Z',
@@ -5020,18 +5219,24 @@ describe('RoutinesService — TaskCast integration', () => {
       });
 
       it('triggers lazy provision when folderId is NULL', async () => {
-        // SELECT ... FOR UPDATE returns row with NULL folderId; transaction
-        // wrapper provisions and returns the row with the new folderId.
+        // C2: ensureRoutineFolder uses `.limit(1)` for the optimistic
+        // read. Returns row with NULL folderId so the slow path
+        // (provision + UPDATE-WHERE-NULL) fires.
         const draftRoutine = {
           ...PROVISIONED_ROUTINE,
           folderId: null as string | null,
         };
         db.for.mockResolvedValueOnce([draftRoutine] as any);
+        db.limit.mockResolvedValueOnce([draftRoutine] as any);
         folder9Client.createFolder.mockResolvedValueOnce({
           id: 'folder-new',
           workspace_id: TENANT_ID,
         });
         folder9Client.commit.mockResolvedValueOnce({ commit_id: 'init' });
+        // The UPDATE-WHERE-NULL claim returns the freshly-claimed row.
+        db.returning.mockResolvedValueOnce([
+          { ...draftRoutine, folderId: 'folder-new' } as any,
+        ]);
         folder9Client.getTree.mockResolvedValueOnce([]);
 
         await service.getRoutineFolderTree(ROUTINE_ID, USER_ID, TENANT_ID);
@@ -5057,6 +5262,7 @@ describe('RoutinesService — TaskCast integration', () => {
 
       it('rejects with 404 when routine does not exist', async () => {
         db.for.mockResolvedValueOnce([] as any);
+        db.limit.mockResolvedValueOnce([] as any);
         await expect(
           service.getRoutineFolderTree(ROUTINE_ID, USER_ID, TENANT_ID),
         ).rejects.toThrow(/not found/);
@@ -5229,7 +5435,10 @@ describe('RoutinesService — TaskCast integration', () => {
           ...PROVISIONED_ROUTINE,
           folderId: null as string | null,
         };
+        // C2: ensureRoutineFolder uses `.limit(1)` for the optimistic
+        // read, then UPDATE-WHERE-NULL with `.returning()` for the claim.
         db.for.mockResolvedValueOnce([draftRoutine] as any);
+        db.limit.mockResolvedValueOnce([draftRoutine] as any);
         folder9Client.createFolder.mockResolvedValueOnce({
           id: 'folder-new',
           workspace_id: TENANT_ID,
@@ -5239,6 +5448,10 @@ describe('RoutinesService — TaskCast integration', () => {
         folder9Client.commit
           .mockResolvedValueOnce({ commit_id: 'init' })
           .mockResolvedValueOnce({ commit_id: 'c-after-provision' });
+        // UPDATE-WHERE-NULL claim returns the freshly-claimed row.
+        db.returning.mockResolvedValueOnce([
+          { ...draftRoutine, folderId: 'folder-new' } as any,
+        ]);
         folder9Client.getFolder.mockResolvedValueOnce({
           id: 'folder-new',
           workspace_id: TENANT_ID,
@@ -5535,10 +5748,13 @@ describe('RoutinesService — completeCreation race guard', () => {
       }),
       log: jest.fn<any>().mockResolvedValue([]),
     };
-    // Default `for` mock returns the draft routine so ensureRoutineFolder
-    // takes the fast path. Tests that need the slow-path (lazy provision)
-    // override per-call.
+    // Default mocks: ensureRoutineFolder takes the fast path. Both
+    // legacy `.for('update')` and new `.limit(1)` return the same row
+    // so tests that override one or the other still observe a
+    // consistent fast path (post-C2 the new code only calls .limit(1),
+    // but we leave .for as a vestige).
     db.for.mockResolvedValue([DRAFT_ROUTINE]);
+    db.limit.mockResolvedValue([DRAFT_ROUTINE]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -5561,7 +5777,12 @@ describe('RoutinesService — completeCreation race guard', () => {
   });
 
   it('race-loss: returns winner state without dispatching autoRunFirst', async () => {
-    // Initial read: sees status='draft'
+    // After C2, completeCreation triggers FOUR `db.limit` calls in
+    // order: (1) getRoutineOrThrow, (2) ensureRoutineFolder optimistic
+    // SELECT, (3) re-fetch via getRoutineOrThrow on race-loss.
+    // (1) sees draft
+    db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
+    // (2) ensureRoutineFolder: same row, already has folderId (fast path)
     db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
     // Bot validation
     botsService.getBotById.mockResolvedValueOnce({
@@ -5576,7 +5797,7 @@ describe('RoutinesService — completeCreation race guard', () => {
     } as any);
     // Conditional UPDATE returns empty (lost the race)
     db.returning.mockResolvedValueOnce([] as any);
-    // Re-fetch via getRoutineOrThrow returns the winner's upcoming state
+    // (3) Re-fetch via getRoutineOrThrow returns the winner's upcoming state
     db.limit.mockResolvedValueOnce([
       { ...DRAFT_ROUTINE, status: 'upcoming' },
     ] as any);
@@ -5604,6 +5825,9 @@ describe('RoutinesService — completeCreation race guard', () => {
   });
 
   it('race-loss: archives channel best-effort even when archiveCreationChannel throws', async () => {
+    // Same call ordering as the previous test — one extra .limit for
+    // ensureRoutineFolder's optimistic SELECT after C2.
+    db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
     db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
     botsService.getBotById.mockResolvedValueOnce({
       botId: 'bot-1',
@@ -5645,6 +5869,8 @@ describe('RoutinesService — completeCreation race guard', () => {
   it('winner: still dispatches autoRunFirst when conditional UPDATE returns a row', async () => {
     const UPDATED = { ...DRAFT_ROUTINE, status: 'upcoming' as const };
 
+    // (1) getRoutineOrThrow + (2) ensureRoutineFolder optimistic SELECT
+    db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
     db.limit.mockResolvedValueOnce([DRAFT_ROUTINE] as any);
     botsService.getBotById.mockResolvedValueOnce({
       botId: 'bot-1',

--- a/apps/server/apps/gateway/src/routines/routines.service.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.ts
@@ -134,133 +134,165 @@ export class RoutinesService {
     );
     const documentId = doc.id;
 
-    // ── Atomic INSERT + folder9 provision + UPDATE ──────────────────
+    // ── INSERT (short tx) → provision (no tx) → UPDATE folderId (short tx) ──
     //
-    // Wrapping the routine INSERT and the folder9 provision in a single DB
-    // transaction guarantees one of two outcomes:
-    //   (a) routine row exists with non-null `folder_id` → fully provisioned
-    //   (b) no routine row exists at all → folder9 was unreachable
+    // Previously this whole flow ran inside a single `db.transaction()`,
+    // pinning a Postgres connection across folder9's 3 sequential HTTP
+    // roundtrips (~75s worst-case timeout). That serialized concurrent
+    // reads on the same routine and starved the pool under folder9
+    // outages. The current shape is:
     //
-    // We never persist a routine row with `folder_id IS NULL` from this
-    // path. The half-baked state (folder created on folder9 but DB
-    // committed without writing the id back) is impossible because the
-    // UPDATE happens *inside* the same JS transaction-callback before
-    // commit, so a network failure between createFolder and commit either
-    // throws (causing rollback) or completes successfully and lets the
-    // tx commit cleanly.
+    //   1. Short tx (or implicit autocommit): INSERT routine row with
+    //      folderId NULL. Commits immediately so the row is visible.
+    //   2. NO TX: provision folder9 (long HTTP I/O).
+    //   3. Short UPDATE: claim folderId. If provision/UPDATE fails AFTER
+    //      the INSERT, the row exists with NULL folderId — `ensureRoutineFolder`
+    //      will lazy-provision on the next access, so the orphan-row
+    //      case heals itself naturally.
     //
-    // Failure modes:
-    // - folder9 step fails (createFolder / createToken / commit) → caught
-    //   here, logged, then rethrown as 503. The thrown error escapes the
-    //   transaction callback, so Drizzle issues ROLLBACK. The orphan
-    //   folder (if createFolder succeeded but commit failed) is reaped
-    //   later by the orphan GC sweep (see design §11).
-    // - DB INSERT fails → bubbles up unchanged (e.g., FK violation on
-    //   botId → 500 / BadRequest depending on the caller's error mapper).
-    //   No folder9 call was made, so nothing leaks.
+    // Caller-facing contract is preserved: folder9 failure ⇒ 503, and
+    // there is no half-baked routine in the caller's view. We achieve
+    // that by best-effort DELETE-ing the just-INSERTed row before
+    // throwing; if the DELETE itself fails we still throw 503 (lazy
+    // provision will heal the row on next access — the routine reappears
+    // for the user with the same id, but that's acceptable: the next
+    // /v1/routines/:id read transparently provisions and returns it).
     //
-    // The trigger creation (`createBatch`) intentionally runs *outside*
-    // the transaction. It does not affect the routine.folder_id invariant
-    // and the existing behavior is "create routine first, then triggers
-    // best-effort" — preserving that means a trigger insert failure
-    // surfaces as a 500 but the routine row already has its folderId set,
-    // which is the desired half-success state (caller can retry trigger
-    // setup against an existing routine).
-    return await this.db.transaction(async (tx) => {
-      const insertValues: schema.NewRoutine = {
-        id: routineId,
-        tenantId,
-        botId: dto.botId ?? null,
-        creatorId: userId,
-        title: dto.title,
-        description: dto.description ?? null,
-        scheduleType: dto.scheduleType ?? 'once',
-        scheduleConfig: (dto.scheduleConfig as ScheduleConfig) ?? null,
-        documentId,
-      };
-      // status, sourceRef, and folderId are new schema columns added in
-      // Task 0 / Task A.1 — cast to bypass stale type resolution in pnpm
-      // workspaces / worktrees environment.
-      (insertValues as Record<string, unknown>).status = status;
-      (insertValues as Record<string, unknown>).sourceRef =
-        options?.sourceRef ?? null;
-      (insertValues as Record<string, unknown>).folderId = null;
+    // Triggers: drafts skip trigger registration (existing rule). For
+    // non-drafts, trigger creation runs AFTER the row has its folderId
+    // claimed — a trigger failure leaves a fully-provisioned routine
+    // (the caller can retry trigger setup later), matching the legacy
+    // best-effort behaviour.
+    const insertValues: schema.NewRoutine = {
+      id: routineId,
+      tenantId,
+      botId: dto.botId ?? null,
+      creatorId: userId,
+      title: dto.title,
+      description: dto.description ?? null,
+      scheduleType: dto.scheduleType ?? 'once',
+      scheduleConfig: (dto.scheduleConfig as ScheduleConfig) ?? null,
+      documentId,
+    };
+    // status, sourceRef, and folderId are new schema columns added in
+    // Task 0 / Task A.1 — cast to bypass stale type resolution in pnpm
+    // workspaces / worktrees environment.
+    (insertValues as Record<string, unknown>).status = status;
+    (insertValues as Record<string, unknown>).sourceRef =
+      options?.sourceRef ?? null;
+    (insertValues as Record<string, unknown>).folderId = null;
 
-      const [routine] = await tx
-        .insert(schema.routines)
-        .values(insertValues)
-        .returning();
+    // ── Step 1: INSERT (immediate commit, folderId NULL) ──
+    const [routine] = await this.db
+      .insert(schema.routines)
+      .values(insertValues)
+      .returning();
 
-      let provisioned: { folderId: string };
+    // ── Step 2: provision OUTSIDE any tx ──
+    let provisioned: { folderId: string };
+    try {
+      provisioned = await provisionFolder9SkillFolder(
+        {
+          id: routine.id,
+          title: routine.title,
+          description: routine.description,
+          // documentContent is a virtual field on the helper's input;
+          // pass null so the helper emits an "Initial scaffold" commit
+          // message and an empty SKILL.md body.
+          documentContent: null,
+        },
+        {
+          folder9Client: this.folder9Client,
+          workspaceId: tenantId,
+          // Folder9ClientService reads FOLDER9_PSK from process.env;
+          // this field is retained for forward-compat with the helper's
+          // public deps shape but currently unused by the underlying
+          // client. See provision-routine-folder.ts header.
+          psk: '',
+        },
+      );
+    } catch (err) {
+      // Metric: per-failure counter that pairs with the request-rate
+      // alert in §10.8 of the design doc.
+      appMetrics.routinesCreateFolder9FailureTotal.add(1);
+      this.logger.warn(
+        `create: folder9 provision failed for routine ${routine.id}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      // Best-effort cleanup: delete the just-INSERTed row so the caller
+      // doesn't see a half-baked routine. If this DELETE itself fails
+      // we still throw 503 — lazy-provision in `ensureRoutineFolder`
+      // will heal the row on next access.
       try {
-        provisioned = await provisionFolder9SkillFolder(
-          {
-            id: routine.id,
-            title: routine.title,
-            description: routine.description,
-            // documentContent is a virtual field on the helper's input;
-            // pass null so the helper emits an "Initial scaffold" commit
-            // message and an empty SKILL.md body.
-            documentContent: null,
-          },
-          {
-            folder9Client: this.folder9Client,
-            workspaceId: tenantId,
-            // Folder9ClientService reads FOLDER9_PSK from process.env;
-            // this field is retained for forward-compat with the helper's
-            // public deps shape but currently unused by the underlying
-            // client. See provision-routine-folder.ts header.
-            psk: '',
-          },
-        );
-      } catch (err) {
-        // Metric: per-failure counter that pairs with the
-        // request-rate alert in §10.8 of the design doc (5-min rate >
-        // 1% pages on-call). Increment BEFORE the throw — once the
-        // 503 escapes, the OTEL pipeline already has the sample.
-        appMetrics.routinesCreateFolder9FailureTotal.add(1);
-        this.logger.warn(
-          `create: folder9 provision failed for routine ${routine.id}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-        // Re-throw as 503 so the API caller gets a retryable signal. The
-        // throw escapes the transaction callback → Drizzle ROLLBACKs → no
-        // routine row persists.
-        throw new ServiceUnavailableException(
-          'folder storage temporarily unavailable, please retry',
+        await this.db
+          .delete(schema.routines)
+          .where(eq(schema.routines.id, routine.id));
+      } catch (delErr) {
+        this.logger.error(
+          `create: best-effort cleanup DELETE failed for routine ${
+            routine.id
+          } after folder9 failure: ${
+            delErr instanceof Error ? delErr.message : String(delErr)
+          }. Lazy provision will heal on next access.`,
         );
       }
 
-      await tx
+      throw new ServiceUnavailableException(
+        'folder storage temporarily unavailable, please retry',
+      );
+    }
+
+    // ── Step 3: short UPDATE to claim folderId ──
+    try {
+      await this.db
         .update(schema.routines)
         .set({
           folderId: provisioned.folderId,
           updatedAt: new Date(),
         } as Record<string, unknown>)
         .where(eq(schema.routines.id, routine.id));
-
-      // Skip trigger registration for drafts. Triggers are created
-      // outside the routine.folder_id invariant — a trigger failure must
-      // NOT roll back the now-committed folder. Run AFTER the tx commits
-      // (i.e., after this callback returns) by deferring with the
-      // post-commit await below.
-      //
-      // We still call this inside the transaction callback because the
-      // existing fixture mocks (and the createBatch implementation) do
-      // not rely on the outer `tx` handle. Trigger writes use the same
-      // injected `db`, which is fine — they participate in their own
-      // transactional scope, not this one.
-      if ((status as string) !== 'draft' && dto.triggers?.length) {
-        await this.routineTriggersService.createBatch(
-          routineId,
-          dto.triggers,
-          tenantId,
+    } catch (updateErr) {
+      // The folderId UPDATE failed AFTER folder9 provisioning succeeded.
+      // The folder is already created on folder9; we just couldn't
+      // record its id locally. Log loudly and rethrow as 503 — the
+      // orphan folder will be reaped by GC, and `ensureRoutineFolder`
+      // will provision a fresh folder on the next access.
+      appMetrics.routinesCreateFolder9FailureTotal.add(1);
+      this.logger.error(
+        `create: UPDATE folderId failed for routine ${routine.id} after folder9 success (folder ${provisioned.folderId} will be GC'd): ${
+          updateErr instanceof Error ? updateErr.message : String(updateErr)
+        }`,
+      );
+      try {
+        await this.db
+          .delete(schema.routines)
+          .where(eq(schema.routines.id, routine.id));
+      } catch (delErr) {
+        this.logger.error(
+          `create: best-effort cleanup DELETE failed for routine ${
+            routine.id
+          } after UPDATE failure: ${
+            delErr instanceof Error ? delErr.message : String(delErr)
+          }`,
         );
       }
+      throw new ServiceUnavailableException(
+        'folder storage temporarily unavailable, please retry',
+      );
+    }
 
-      return { ...routine, folderId: provisioned.folderId };
-    });
+    // ── Triggers: best-effort, post-folder-claim ──
+    if ((status as string) !== 'draft' && dto.triggers?.length) {
+      await this.routineTriggersService.createBatch(
+        routineId,
+        dto.triggers,
+        tenantId,
+      );
+    }
+
+    return { ...routine, folderId: provisioned.folderId };
   }
 
   async list(
@@ -978,33 +1010,14 @@ export class RoutinesService {
       }
     }
 
-    // Check document content — documentContent lives on the linked Document,
-    // not on the routines row.
-    let documentContentEmpty = true;
-    if (routine.documentId) {
-      try {
-        const doc: DocumentResponse = await this.documentsService.getById(
-          routine.documentId,
-        );
-        if (doc.tenantId !== tenantId) {
-          this.logger.warn(
-            `completeCreation: routine ${routineId} document ${routine.documentId} tenant mismatch (got ${doc.tenantId}, expected ${tenantId}); treating content as empty`,
-          );
-          // documentContentEmpty remains true → will push error below
-        } else {
-          const content = doc.currentVersion?.content;
-          if (content && content.trim() !== '') {
-            documentContentEmpty = false;
-          }
-        }
-      } catch {
-        // Doc not found — treat as empty content
-        documentContentEmpty = true;
-      }
-    }
-    if (documentContentEmpty) {
-      errors.push('documentContent is required');
-    }
+    // NOTE: the legacy "documentContent is required" gate was REMOVED
+    // (I1 from code review). With A.4 the routine body of truth lives in
+    // SKILL.md inside the folder9 folder; the legacy `documents` table
+    // is a stub for migration compatibility and no longer carries
+    // authoritative content. The "agent never wrote anything" case is
+    // covered by Step 5b (SKILL.md validation) via the `body_empty` /
+    // `body_too_short` rules, so a separate documents-table gate would
+    // double-fail new-world routines.
 
     if (errors.length > 0) {
       throw new BadRequestException({
@@ -1098,7 +1111,22 @@ export class RoutinesService {
     // value (the row was SELECT ... FOR UPDATE locked at provision time),
     // so it cannot be stale relative to whatever the agent saw when it
     // wrote SKILL.md.
-    const expectedDescription = ensured.description ?? '';
+    //
+    // Fallback policy MUST mirror provisionFolder9SkillFolder's
+    // normalize-then-fallback logic — otherwise a routine with a null
+    // (or whitespace-only) description gets seeded with one string in
+    // SKILL.md, but the validator expects a different one, which
+    // fails BOTH `description_empty` (non-empty required) AND
+    // `description_mismatch` (must equal). The fallback uses a dash
+    // separator (no `: `) because a colon-followed-by-space in an
+    // unquoted YAML scalar parses as a nested mapping and breaks
+    // validation. Keep this string in sync with the fallback in
+    // provision-routine-folder.ts#provisionFolder9SkillFolder.
+    const trimmedDescription = ensured.description?.trim() ?? '';
+    const expectedDescription =
+      trimmedDescription.length > 0
+        ? trimmedDescription
+        : `Generated from routine - ${ensured.title}`;
     const validation = validateSkillMd(
       skillMdContent,
       expectedSkillName,


### PR DESCRIPTION
Code review fixes for PRs #100/#85/#105 (server + client side). Companion agent-pi PR: team9ai/agent-pi#110.

## Critical

- **C1** `completeCreation` now derives `expectedDescription` from the same fallback the provisioner writes (`Generated from routine - <title>`), so routines created with null description can complete. Provisioner separator changed from `: ` to ` - ` to avoid YAML mapping ambiguity.
- **C2** `ensureRoutineFolder` and `routines.service.create` no longer hold DB transactions across folder9 HTTP I/O. Pattern: optimistic SELECT (no lock) → provision OUTSIDE tx → short UPDATE-WHERE-NULL `.returning()` to claim folderId. Race-loss path discards the orphan folder (24h GC reclaims). `create` flow: INSERT immediately, provision outside tx, UPDATE folderId; on failure, best-effort DELETE the routine row.

## Important

- **I1** `completeCreation` drops the legacy `documentContent is required` gate — SKILL.md `body_empty`/`body_too_short` rules already cover it.
- **I7** Stub-authz folder-token branch (`session.*`/`agent.*`/`user.*`/`routine.{tmp,home}`) now rejects `permission !== 'read'` with 403. `routine.document` continues to allow read|write.
- **I8** Cross-tenant gate fail-closed: undefined `callerTenantId` → 403 "tenant context missing" + structured warn log.
- **I4** `Folder9FolderEditor` image upload race fixed via atomic ref read+write inside `handleImageUpload`.
- **I5** `useFolderDraft` adds NO_RECONCILE sentinel; `lastCommitTime: null` no longer fires the always-stale alert (still loads the draft).
- **I12** `RoutineSkillFolderTab` reads `isLoading` from `useCurrentUser`; renders `Loading…` placeholder until resolved (no flicker into wrong-permission state).

## Test plan

- [x] gateway: 3230 tests pass; 5 skipped (pre-existing, unrelated)
- [x] client: 2280 tests pass; 191 test files
- [x] typecheck clean (gateway + client)
- [x] gateway build clean
- [x] coverage on all modified files ≥95% statements/lines (routines.service.ts branch coverage 85.25% is the existing baseline of a 2000-line file; new C2 cleanup-DELETE branches are covered)

## Concerns flagged for review

1. C1 fallback string `Generated from routine - <title>` is YAML-safe with the new dash separator, BUT if a routine title itself contains `: `, the frontmatter still becomes unparseable. Current scope leaves the agent contract unchanged. Worth a follow-up to YAML-quote the description value.
2. C2 race-loss may leak folder9 folders by design — the loser's folder is reclaimed by the 24h orphan GC. Documented in `ensure-routine-folder.ts` header.
3. C2 `create` weakens the visibility contract slightly: the routine row exists momentarily with `folderId: null` between INSERT and provision UPDATE. Lazy provision heals subsequent reads. Documented.
4. I7's stub-authz gate runs AFTER bot identity lookup (defense-in-depth, accepts the extra DB roundtrip).
5. I8 fail-closed is a behavior change for any caller currently relying on undefined tenant context — flagged for any internal/ops paths that may be affected.

## Branch state

`feat/routine-skill-fixes` is currently 1 ahead, 1 behind `origin/dev` at push time. Will need a merge/rebase before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)