### PR TITLE
refactor(client): remove unsynced-messages banner

### DIFF
--- a/apps/client/src/components/channel/ChannelContent.tsx
+++ b/apps/client/src/components/channel/ChannelContent.tsx
@@ -42,7 +42,6 @@ export interface ChannelContentProps {
   botModelSwitch?: ReturnType<typeof useBotModelSwitch>;
 
   // Optional UI controls
-  hasMoreUnsynced?: boolean;
   /** Show read-only bar at bottom (independent of readOnly which controls MessageList) */
   showReadOnlyBar?: boolean;
 }
@@ -69,19 +68,12 @@ export function ChannelContent({
   initialDraft,
   autoSendInitialDraft,
   onInitialDraftAutoSent,
-  hasMoreUnsynced,
   showReadOnlyBar,
   isBotDm,
   botModelSwitch,
 }: ChannelContentProps) {
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      {hasMoreUnsynced && (
-        <div className="bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 px-4 py-2 text-sm text-amber-700 dark:text-amber-300">
-          You have older unread messages. Scroll up to load more.
-        </div>
-      )}
-
       <MessageList
         key={`${channelId}:${highlightSeq ?? 0}`}
         channelId={channelId}

--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -227,7 +227,7 @@ export function ChannelView({
   const channel = previewChannel || memberChannel;
 
   // Sync missed messages when opening channel (lazy loading)
-  const { hasMoreUnsynced } = useSyncChannel(channelId);
+  useSyncChannel(channelId);
 
   // Dual-layer thread state
   const primaryThread = useThreadStore((state) => state.primaryThread);
@@ -665,7 +665,6 @@ export function ChannelView({
             thinkingBotIds={thinkingBotIds}
             members={members}
             lastReadMessageId={unreadAnchor}
-            hasMoreUnsynced={hasMoreUnsynced}
             showReadOnlyBar={isPreviewMode || readOnly}
             onSend={isPreviewMode || readOnly ? undefined : handleSendMessage}
             isSendDisabled={showOverlay}

--- a/apps/client/src/components/channel/TrackingModal.tsx
+++ b/apps/client/src/components/channel/TrackingModal.tsx
@@ -53,9 +53,7 @@ export function TrackingModal({
   } = useChannelMessages(isOpen ? trackingChannelId : undefined);
 
   // Catch-up sync
-  const { hasMoreUnsynced } = useSyncChannel(
-    isOpen ? trackingChannelId : undefined,
-  );
+  useSyncChannel(isOpen ? trackingChannelId : undefined);
 
   // Channel members (for MessageList member display)
   const { data: members = [] } = useChannelMembers(
@@ -164,7 +162,6 @@ export function TrackingModal({
               readOnly={!isActivated}
               showReadOnlyBar={!isActivated}
               members={members}
-              hasMoreUnsynced={hasMoreUnsynced}
               onSend={isActivated ? handleSend : undefined}
               isSendDisabled={sendMessage.isPending}
               inputPlaceholder="Send guidance to agent..."

--- a/apps/client/src/components/channel/__tests__/ChannelContent.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelContent.test.tsx
@@ -132,26 +132,6 @@ describe("ChannelContent", () => {
     expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
   });
 
-  it("renders unsynced banner when hasMoreUnsynced=true", () => {
-    render(<ChannelContent {...BASE_PROPS} hasMoreUnsynced />);
-
-    expect(
-      screen.getByText(
-        "You have older unread messages. Scroll up to load more.",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("does not render unsynced banner by default", () => {
-    render(<ChannelContent {...BASE_PROPS} />);
-
-    expect(
-      screen.queryByText(
-        "You have older unread messages. Scroll up to load more.",
-      ),
-    ).not.toBeInTheDocument();
-  });
-
   it("passes readOnly to MessageList", () => {
     render(<ChannelContent {...BASE_PROPS} readOnly />);
 
@@ -218,11 +198,6 @@ describe("ChannelContent", () => {
     // No MessageInput, no banners
     expect(screen.queryByTestId("message-input")).not.toBeInTheDocument();
     expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        "You have older unread messages. Scroll up to load more.",
-      ),
-    ).not.toBeInTheDocument();
   });
 
   it("passes readOnly=false to MessageList by default", () => {
@@ -236,16 +211,6 @@ describe("ChannelContent", () => {
     render(<ChannelContent {...BASE_PROPS} />);
 
     expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
-  });
-
-  it("does not render unsynced banner when hasMoreUnsynced=false", () => {
-    render(<ChannelContent {...BASE_PROPS} hasMoreUnsynced={false} />);
-
-    expect(
-      screen.queryByText(
-        "You have older unread messages. Scroll up to load more.",
-      ),
-    ).not.toBeInTheDocument();
   });
 
   it("does not pass disabled to MessageInput when isSendDisabled is false", () => {

--- a/apps/client/src/components/channel/__tests__/TrackingModal.test.tsx
+++ b/apps/client/src/components/channel/__tests__/TrackingModal.test.tsx
@@ -93,7 +93,6 @@ vi.mock("../ChannelContent", () => ({
         data-channel-id={props.channelId}
         data-channel-type={props.channelType}
         data-read-only={props.readOnly ? "true" : "false"}
-        data-has-more-unsynced={props.hasMoreUnsynced ? "true" : "false"}
         data-input-placeholder={props.inputPlaceholder ?? ""}
         data-is-send-disabled={props.isSendDisabled ? "true" : "false"}
         data-has-on-send={props.onSend ? "true" : "false"}
@@ -146,9 +145,7 @@ function setupDefaultMocks() {
     isPending: false,
   });
 
-  mockUseSyncChannel.mockReturnValue({
-    hasMoreUnsynced: false,
-  });
+  mockUseSyncChannel.mockReturnValue({});
 
   mockUseChannelMembers.mockReturnValue({
     data: [],
@@ -450,16 +447,6 @@ describe("TrackingModal", () => {
   it("calls useChannelMembers with undefined when closed", () => {
     render(<TrackingModal {...BASE_PROPS} isOpen={false} />);
     expect(mockUseChannelMembers).toHaveBeenCalledWith(undefined);
-  });
-
-  // ── hasMoreUnsynced ─────────────────────────────────
-
-  it("passes hasMoreUnsynced from useSyncChannel to ChannelContent", () => {
-    mockUseSyncChannel.mockReturnValue({ hasMoreUnsynced: true });
-    render(<TrackingModal {...BASE_PROPS} />);
-
-    const content = screen.getByTestId("channel-content");
-    expect(content).toHaveAttribute("data-has-more-unsynced", "true");
   });
 
   // ── Syncs isActivated prop ──────────────────────────

--- a/apps/client/src/hooks/useSyncChannel.ts
+++ b/apps/client/src/hooks/useSyncChannel.ts
@@ -350,5 +350,5 @@ export function useSyncChannel(channelId: string | undefined) {
     }
   }, [query.data, channelId, queryClient]);
 
-  return { ...query, hasMoreUnsynced: query.data?.hasMore ?? false };
+  return query;
 }


### PR DESCRIPTION
## Summary
- Remove the amber "You have older unread messages. Scroll up to load more." banner from `ChannelContent`
- Drop the `hasMoreUnsynced` prop and stop reading it from `useSyncChannel`; the hook still runs for its cache-merge side-effect
- Remove the now-obsolete banner tests

## Test plan
- [x] `pnpm exec tsc --noEmit` (client)
- [x] `pnpm exec vitest run src/components/channel/__tests__/ChannelContent.test.tsx src/components/channel/__tests__/TrackingModal.test.tsx`