### PR TITLE
fix(client/browser): localize raw config-error toasts (PR #91 follow-up)

### DIFF
--- a/apps/client/src-tauri/src/ahand/browser_runtime.rs
+++ b/apps/client/src-tauri/src/ahand/browser_runtime.rs
@@ -375,7 +375,10 @@ pub async fn browser_status(state: State<'_, AhandRuntime>) -> Result<BrowserSta
         .config_path()
         .await
         .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
-    let config = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let config = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_status: config load failed: {e:#}");
+        "config_load_failed".to_string()
+    })?;
     let enabled = config.browser_config().enabled.unwrap_or(false);
     let daemon_online = matches!(
         state.status().await,
@@ -540,8 +543,10 @@ pub async fn browser_install(
     } else {
         reports_for_status
     };
-    let config_after =
-        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let config_after = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_install: config final load failed: {e:#}");
+        "config_final_load_failed".to_string()
+    })?;
     let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
     let agent_visible = enabled_after
         && matches!(
@@ -585,10 +590,16 @@ pub async fn browser_set_enabled(
         }
     }
 
-    let mut cfg = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let mut cfg = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_set_enabled: config load failed: {e:#}");
+        "config_load_failed".to_string()
+    })?;
     let old = cfg
         .set_browser_enabled(&config_path, enabled)
-        .map_err(|e| format!("config write: {e:#}"))?;
+        .map_err(|e| {
+            eprintln!("browser_set_enabled: config write failed: {e:#}");
+            "config_write_failed".to_string()
+        })?;
 
     // No-op optimisation: skip the reload if the value didn't actually
     // change. Saves ~3-5s of daemon shutdown/respawn time.
@@ -616,8 +627,10 @@ pub async fn browser_set_enabled(
     }
 
     let reports = browser_setup::inspect_all().await;
-    let config_after =
-        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let config_after = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_set_enabled: config final load failed: {e:#}");
+        "config_final_load_failed".to_string()
+    })?;
     let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
     let agent_visible = enabled_after
         && matches!(

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
@@ -169,6 +169,12 @@ export function RuntimeCard() {
           translated = t("browser.errors.runtimeNotStarted");
         else if (raw === "browser_runtime_unavailable_in_web")
           translated = t("browser.errors.unavailableInWeb");
+        else if (raw === "config_load_failed")
+          translated = t("browser.errors.configLoadFailed");
+        else if (raw === "config_write_failed")
+          translated = t("browser.errors.configWriteFailed");
+        else if (raw === "config_final_load_failed")
+          translated = t("browser.errors.configFinalLoadFailed");
         toast.error(translated);
       }
     } else {

--- a/apps/client/src/i18n/locales/en/ahand.json
+++ b/apps/client/src/i18n/locales/en/ahand.json
@@ -175,7 +175,10 @@
       "operationInProgress": "Another browser operation is running. Please wait for it to finish.",
       "browserNotInstalled": "Finish installing the browser runtime before enabling agent access.",
       "runtimeNotStarted": "The ahand runtime isn't running yet. Please try again shortly.",
-      "unavailableInWeb": "This setting is only available in the desktop app."
+      "unavailableInWeb": "This setting is only available in the desktop app.",
+      "configLoadFailed": "Failed to read the ahand config file. See logs for details.",
+      "configWriteFailed": "Failed to write the ahand config file (may be a permissions issue). See logs for details.",
+      "configFinalLoadFailed": "Couldn't re-read the config after the operation; the displayed state may be stale. See logs for details."
     }
   },
   "overview": {

--- a/apps/client/src/i18n/locales/zh-CN/ahand.json
+++ b/apps/client/src/i18n/locales/zh-CN/ahand.json
@@ -172,7 +172,10 @@
       "operationInProgress": "已有一项浏览器操作在运行，请稍候。",
       "browserNotInstalled": "请先完成浏览器组件安装，再启用 Agent 可用。",
       "runtimeNotStarted": "ahand 运行时未启动，请稍后再试。",
-      "unavailableInWeb": "此功能仅在桌面应用中可用。"
+      "unavailableInWeb": "此功能仅在桌面应用中可用。",
+      "configLoadFailed": "读取 ahand 配置文件失败。详情见日志。",
+      "configWriteFailed": "写入 ahand 配置文件失败（可能是权限问题）。详情见日志。",
+      "configFinalLoadFailed": "操作完成后读取配置失败，状态可能不准确。详情见日志。"
     }
   },
   "overview": {


### PR DESCRIPTION
## Summary

Follow-up to [#91](https://github.com/team9ai/team9/pull/91) (Phase C of the browser-runtime-install work). An independent end-to-end review caught that 5 error sites in `browser_runtime.rs` returned raw \`format!(\"config load: {e:#}\")\` / \`\"config write:\"\` / \`\"config final load:\"\` strings to the renderer.

The renderer only translated 4 sentinel IDs (\`operation_in_progress\`, \`browser_not_installed\`, \`ahand runtime not started\`, \`browser_runtime_unavailable_in_web\`); these new prose-style errors fell through to the default \`translated = raw\` branch. **A zh-CN user with corrupt or unwritable \`~/.ahand/config.toml\` would have seen English error chains in their toast** — e.g.:

> config write: Permission denied (os error 13)

## Changes

- \`apps/client/src-tauri/src/ahand/browser_runtime.rs\` — replace 5 raw \`format!(...)\` error sites with 3 stable sentinel codes:
  - \`config_load_failed\` (in \`browser_status\` + \`browser_set_enabled\`'s initial load)
  - \`config_write_failed\` (in \`browser_set_enabled\`'s \`set_browser_enabled\` call)
  - \`config_final_load_failed\` (in \`browser_install\` + \`browser_set_enabled\` post-action snapshots)

  Diagnostic detail is still logged via \`eprintln!(\"... failed: {e:#}\")\` so developers see the original anyhow cause chain in app logs.

- \`apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx\` — extend the error-translation chain (\`useEffect\` at lines ~157-177) to map the 3 new sentinels.

- \`apps/client/src/i18n/locales/zh-CN/ahand.json\` + \`apps/client/src/i18n/locales/en/ahand.json\` — add 3 new keys under \`browser.errors.*\`.

## Test Plan

- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — only the same 4 pre-existing errors in \`lib.rs\` and \`identity.rs\`; zero new
- [x] \`cargo test --lib\` — 46 passed / 4 ignored (matches Phase C baseline)
- [x] \`pnpm --filter @team9/client typecheck\` clean
- [x] \`pnpm --filter @team9/client lint\` clean
- [x] \`pnpm --filter @team9/client build\` clean
- [x] zh-CN ↔ en i18n key parity (\`jq paths\` diff empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)