### PR TITLE
fix(ahand): default config_path to ~/.ahand/config.toml so browser commands actually work

### DIFF
--- a/apps/client/src-tauri/src/ahand/browser_runtime.rs
+++ b/apps/client/src-tauri/src/ahand/browser_runtime.rs
@@ -375,11 +375,21 @@ pub async fn browser_status(state: State<'_, AhandRuntime>) -> Result<BrowserSta
         .config_path()
         .await
         .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
-    let config = Config::load(&config_path).map_err(|e| {
-        eprintln!("browser_status: config load failed: {e:#}");
-        "config_load_failed".to_string()
-    })?;
-    let enabled = config.browser_config().enabled.unwrap_or(false);
+    // Fresh users won't have ~/.ahand/config.toml yet; treat that as
+    // "browser disabled" rather than a hard error. The first successful
+    // browser_install or browser_set_enabled will create the file.
+    let enabled = if config_path.exists() {
+        Config::load(&config_path)
+            .map_err(|e| {
+                eprintln!("browser_status: config load failed: {e:#}");
+                "config_load_failed".to_string()
+            })?
+            .browser_config()
+            .enabled
+            .unwrap_or(false)
+    } else {
+        false
+    };
     let daemon_online = matches!(
         state.status().await,
         super::runtime::DaemonStatus::Online { .. }
@@ -511,6 +521,16 @@ pub async fn browser_install(
     // On success, flip the config flag and reload the daemon so the new
     // [browser].enabled value takes effect for the embedded ahandd.
     if matches!(overall_status, TauriStepStatus::Ok) {
+        // Fresh user: ensure the config file exists before Config::load.
+        // All Config fields are `#[serde(default)]`, so an empty TOML
+        // deserializes cleanly into a default Config that we can then
+        // mutate via set_browser_enabled (which will save_atomic and
+        // overwrite the empty file with proper TOML).
+        if !config_path.exists() {
+            if let Err(e) = std::fs::write(&config_path, "") {
+                eprintln!("browser_runtime: bootstrap empty config failed: {e:#}");
+            }
+        }
         match Config::load(&config_path) {
             Ok(mut cfg) => {
                 if let Err(e) = cfg.set_browser_enabled(&config_path, true) {
@@ -531,7 +551,7 @@ pub async fn browser_install(
                 }
             }
             Err(e) => {
-                eprintln!("browser_runtime: config reload failed: {e:#}");
+                eprintln!("browser_runtime: config load failed: {e:#}");
             }
         }
     }
@@ -590,6 +610,14 @@ pub async fn browser_set_enabled(
         }
     }
 
+    // Fresh user: bootstrap an empty config file if missing so Config::load
+    // succeeds. set_browser_enabled below will overwrite it via save_atomic.
+    if !config_path.exists() {
+        if let Err(e) = std::fs::write(&config_path, "") {
+            eprintln!("browser_set_enabled: bootstrap empty config failed: {e:#}");
+            return Err("config_load_failed".to_string());
+        }
+    }
     let mut cfg = Config::load(&config_path).map_err(|e| {
         eprintln!("browser_set_enabled: config load failed: {e:#}");
         "config_load_failed".to_string()

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -218,11 +218,28 @@ impl AhandRuntime {
             heartbeat_interval: Duration::from_secs(cfg.heartbeat_interval_seconds),
         };
 
+        // Default to ~/.ahand/config.toml when the renderer didn't supply
+        // one. This matches the documented ahandd convention so the
+        // browser_install/browser_set_enabled commands have somewhere to
+        // persist [browser].enabled across daemon restarts. The TS-side
+        // StartConfig interface intentionally does not require this field
+        // so existing renderer call sites keep working unchanged.
+        let resolved_config_path = cfg.config_path.clone().or_else(|| {
+            dirs::home_dir().map(|h| h.join(".ahand").join("config.toml"))
+        });
+
+        // Make sure the parent dir exists before any future
+        // `set_browser_enabled` write — that helper does not mkdir.
+        if let Some(p) = &resolved_config_path {
+            if let Some(parent) = p.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+
         // Optionally overlay the on-disk Config (mainly for browser.enabled).
         // Failures to read are non-fatal during start() — we fall back to
         // pure in-memory defaults so the daemon can still spawn.
-        let on_disk = cfg
-            .config_path
+        let on_disk = resolved_config_path
             .as_deref()
             .and_then(|p| ahandd::config::Config::load(p).ok());
         let daemon_cfg = build_daemon_config(on_disk.as_ref(), &startup_inputs);
@@ -253,7 +270,7 @@ impl AhandRuntime {
             status_forwarder,
             startup_inputs,
             current_daemon_config: daemon_cfg,
-            config_path: cfg.config_path,
+            config_path: resolved_config_path,
         });
 
         Ok(StartResult { device_id })


### PR DESCRIPTION
## Summary

**Cross-repo wire-shape mismatch caught by manual smoke testing.** The Phase C \`StartConfig\` Rust struct grew a \`config_path: Option<PathBuf>\` field (Task 13) with \`#[serde(default)]\`, but the corresponding TS interface (\`apps/client/src/types/tauri-ahand.ts:13-19\`) was never updated. So:

1. Renderer calls \`invoke(\"ahand_start\", { cfg })\` with the existing 5 fields, no \`config_path\`.
2. Rust deserializes \`cfg.config_path = None\` (serde default kicking in).
3. \`ActiveSession.config_path\` stored as \`None\`.
4. \`state.config_path()\` always returns \`None\` for team9 desktop.
5. All three browser commands (\`browser_status\`, \`browser_install\`, \`browser_set_enabled\`) fast-fail with the \"ahand runtime not started — call ahand_start first\" sentinel BEFORE doing any work.
6. Renderer toasts \`runtimeNotStarted\` for ~5 seconds; leaves only an opaque \"安装失败\" badge with no detail.

This was missed by the per-task code reviews because each lens looked at one side in isolation. The independent end-to-end review caught related issues (raw config-error toasts → fixed in #96) but not this one. It only surfaced when the user actually clicked Install.

## Why default to \`~/.ahand/config.toml\`

That's the documented ahandd convention (the daemon expects to read its config from this path when run as a CLI). Defaulting on the Rust side has zero blast radius:
- Existing renderer \`ahand_start\` payloads keep working unchanged
- \`Config::load\` fails gracefully when the file doesn't exist (we now bootstrap it)
- The persisted \`[browser].enabled\` flag is now actually durable across daemon restarts (which was the whole point of Phase C)

## Changes

\`apps/client/src-tauri/src/ahand/runtime.rs\`:
- In \`start()\`, when \`cfg.config_path\` is \`None\`, resolve to \`$HOME/.ahand/config.toml\` via \`dirs::home_dir()\`. \`dirs\` was already a dep.
- \`mkdir -p\` the parent dir so \`set_browser_enabled\`'s \`save_atomic\` can succeed on fresh installs (it doesn't mkdir itself).
- Store the resolved path in \`ActiveSession.config_path\` (was previously storing the raw \`cfg.config_path = None\`).

\`apps/client/src-tauri/src/ahand/browser_runtime.rs\`:
- \`browser_status\`: if the config file doesn't exist yet, return \`enabled=false\` without erroring.
- \`browser_install\` (success path): bootstrap an empty TOML if the file is missing so \`Config::load\` succeeds. \`set_browser_enabled\`'s \`save_atomic\` then overwrites it with proper contents.
- \`browser_set_enabled\`: same fresh-user bootstrap as \`browser_install\`.

## Test Plan

- [x] \`cargo build\` clean (only pre-existing 2 warnings)
- [x] \`cargo clippy --all-targets -- -D warnings\` — only the same 4 pre-existing errors in \`lib.rs\` and \`identity.rs\`; zero new
- [x] \`cargo test --lib\` — 46 passed / 4 ignored (matches Phase C baseline)
- [x] \`pnpm --filter @team9/client build\` clean
- [ ] Manual: relaunch \`tauri dev\`, click Install, verify the actual install runs (and either succeeds populating \`[browser].enabled = true\` in \`~/.ahand/config.toml\`, or surfaces a real per-step error code via \`StepFinished\` reconciliation rather than a generic \"安装失败\" badge)

## Known follow-ups (still open after this PR)

- The UX bug from the user's report still partially stands: \`state.message\` is only toasted, not inline. After this fix the most common error becomes a real per-step \`StepFinished { error: { code, message } }\` event — those DO render inline via the help popover on the failing step row. But fast-fail errors (e.g. \`operation_in_progress\`, \`config_load_failed\`) are still toast-only. Worth a follow-up to inline-render \`state.message\` below the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)