### PR TITLE
fix(ahand): wire AppHandle through reload — daemon-status events reach renderer

### DIFF
--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -177,17 +177,34 @@ struct ActiveSession {
 
 pub struct AhandRuntime {
     inner: Arc<Mutex<Option<ActiveSession>>>,
+    /// Captured at the first successful `start()` call. Lets `reload()` —
+    /// which doesn't have an `&AppHandle` of its own — emit
+    /// `ahand-daemon-status` events from the respawned daemon's status
+    /// watcher. Cleared by `stop()`. Stored separately from
+    /// `ActiveSession` so it survives the take/replace dance during
+    /// reload and so it remains available even if the active session
+    /// is currently `None` mid-reload.
+    cached_app_handle: Arc<std::sync::Mutex<Option<AppHandle>>>,
 }
 
 impl AhandRuntime {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(None)),
+            cached_app_handle: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
     /// Start a new daemon session, stopping any existing one first.
     pub async fn start(&self, app: &AppHandle, cfg: StartConfig) -> Result<StartResult, String> {
+        // Capture the AppHandle so `reload()` can emit status events from
+        // respawned daemons. The clone is cheap (an Arc bump). Poison
+        // recovery is best-effort — `reload()` falls back to a no-op
+        // forwarder if this lock is poisoned.
+        if let Ok(mut h) = self.cached_app_handle.lock() {
+            *h = Some(app.clone());
+        }
+
         let mut guard = self.inner.lock().await;
 
         if let Some(prev) = guard.take() {
@@ -475,28 +492,22 @@ impl AhandRuntime {
     }
 
     /// Hook that returns the `AppHandle` used to forward status events
-    /// from the new daemon spawned during `reload()`. The current
-    /// implementation has no `AppHandle` cached on `AhandRuntime` (it's
-    /// passed per-call to `start()`/`stop()`), so the reload path emits
-    /// no status events directly — the new daemon's own status watch
-    /// will be subscribed to once a Tauri command resolves the handle
-    /// again. Tests pass `None`.
+    /// from the new daemon spawned during `reload()`. Reads from
+    /// `cached_app_handle` populated by `start()`. Without this,
+    /// reload-spawned daemons would not emit `ahand-daemon-status`
+    /// events to the renderer, leaving `useAhandLocalStatus` stuck
+    /// on whatever state was last seen before the reload — observably:
+    /// `agentVisible` would never flip back to true even after the new
+    /// daemon completed its hub handshake.
     ///
-    /// NOTE for Task 14: when wiring up the `browser_install` Tauri
-    /// command, the caller is expected to also `state.app_handle()` and
-    /// re-emit the new daemon's status. A future iteration may cache
-    /// the `AppHandle` inside `AhandRuntime` so reload() forwards
-    /// transparently.
-    // TODO(task-14): replace with real plumbing — pass the AppHandle through
-    // from the Tauri command site so post-reload daemon-status events reach
-    // the renderer. Today this returns None and the watch task at
-    // build_active_session is a no-op for reload-spawned daemons.
-    // The `_team9_user_id` parameter is currently unused; it exists so a
-    // single Tauri app could later scope per-user app handles when hosting
-    // multiple users. Keeping the signature stable means Task 14's wiring
-    // is a body-only change.
+    /// The `_team9_user_id` parameter is currently unused. It exists so
+    /// a future single-app-multiple-users layout can scope per-user
+    /// AppHandles without changing this signature.
     fn app_emitter_for_session(&self, _team9_user_id: &str) -> Option<AppHandle> {
-        None
+        self.cached_app_handle
+            .lock()
+            .ok()
+            .and_then(|h| h.clone())
     }
 
     async fn shutdown_session(session: ActiveSession) {
@@ -574,8 +585,10 @@ fn build_active_session(
                 }
             })
         }
-        // TODO(task-14): becomes unreachable once app_emitter_for_session returns Some.
-        // Until then, no-op so the JoinHandle field on ActiveSession is always populated.
+        // Test paths that pass `None` — and the rare race where
+        // `start()` was never called before `reload()` — fall through
+        // to a no-op so the JoinHandle field on ActiveSession is
+        // always populated.
         None => tokio::spawn(async {}),
     };
     ActiveSession {

--- a/apps/client/src/hooks/useBrowserRuntime.ts
+++ b/apps/client/src/hooks/useBrowserRuntime.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { isTauriApp } from "@/lib/tauri";
+import type { DaemonStatus } from "@/types/tauri-ahand";
 
 // ---------------------------------------------------------------------------
 // Wire types — MUST match apps/client/src-tauri/src/ahand/browser_runtime.rs.
@@ -347,6 +349,40 @@ export function useBrowserRuntime(): UseBrowserRuntimeResult {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  // Re-fetch status whenever the embedded ahandd daemon transitions to
+  // "online". Without this, the renderer would keep the stale
+  // `agentVisible: false` snapshot captured the moment `browser_install` /
+  // `browser_set_enabled` resolved — at that point the respawned daemon is
+  // typically still mid-handshake, so the warning indicator would never
+  // clear without a manual reload. Listens to the same event channel as
+  // `useAhandLocalStatus`.
+  useEffect(() => {
+    if (!isTauriApp()) return;
+    let unlisten: (() => void) | null = null;
+    listen<DaemonStatus>("ahand-daemon-status", (ev) => {
+      // Skip while a command is in flight — install/setEnabled return
+      // fresh status when they resolve, so we'd just race them.
+      if (
+        stateRef.current.kind === "installing" ||
+        stateRef.current.kind === "reloading"
+      ) {
+        return;
+      }
+      // Only refresh on online transitions — that's the case where
+      // agentVisible would flip from false → true.
+      if (ev.payload.state === "online") {
+        void refresh();
+      }
+    })
+      .then((u) => {
+        unlisten = u;
+      })
+      .catch(() => {});
+    return () => {
+      unlisten?.();
+    };
   }, [refresh]);
 
   const install = useCallback(async (force: boolean) => {


### PR DESCRIPTION
## Summary

Closes the \`TODO(task-14)\` markers in \`apps/client/src-tauri/src/ahand/runtime.rs\` left over from Phase C. The user observed: install completes cleanly, \`[browser].enabled = true\` is persisted to \`~/.ahand/config.toml\`, but the "Agent 可以使用" Switch shows the "守护进程尚未应用此设置" out-of-sync warning **indefinitely** — even after the new daemon has long since reconnected to the hub.

## Root cause

Phase C's \`AhandRuntime::reload()\` respawns the embedded ahandd daemon, but the new daemon's \`subscribe_status\` watch is fed to a no-op forwarder (\`tokio::spawn(async {})\`). \`app_emitter_for_session()\` returned \`None\` — that was the documented stub. So:

1. Renderer's \`useAhandLocalStatus\` listens on \`ahand-daemon-status\`
2. After reload, no events fire on that channel
3. The reload-spawned daemon DOES go online, but the renderer never learns
4. \`BrowserStatus.agentVisible\` is captured the moment \`browser_install\` resolves — when the new daemon is still mid-handshake, so \`agent_visible: false\`
5. No subsequent refresh, warning stays forever

## Fix (two parts)

### Rust (\`runtime.rs\`)

- Add \`cached_app_handle: Arc<std::sync::Mutex<Option<AppHandle>>>\` field on \`AhandRuntime\`
- Populate it on every \`start()\` (cheap Arc-bump clone)
- \`app_emitter_for_session()\` now returns the cached handle
- Reload-spawned daemons get a real status forwarder that emits \`ahand-daemon-status\` events identically to how \`start()\` already does

### TypeScript (\`useBrowserRuntime.ts\`)

- Subscribe to \`ahand-daemon-status\` (same channel \`useAhandLocalStatus\` listens on)
- Call \`refresh()\` whenever the daemon transitions to \`"online"\`
- Skip the refresh while a command (\`install\` / \`setEnabled\`) is in flight to avoid racing the \`installDone\`/\`setEnabledDone\` action

After both changes: install → reload → daemon connects → \`ahand-daemon-status\` fires \`{state: "online"}\` → hook calls \`refresh()\` → fresh \`browser_status\` returns \`agentVisible: true\` → warning auto-clears.

## Test Plan

- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — only the same 4 pre-existing errors in \`lib.rs\` and \`identity.rs\`; zero new
- [x] \`cargo test --lib\` — 46 passed / 4 ignored (matches Phase C baseline)
- [x] \`pnpm --filter @team9/client typecheck\` clean
- [x] \`pnpm --filter @team9/client lint\` clean
- [x] \`pnpm --filter @team9/client build\` clean
- [ ] Manual: install browser → verify warning auto-clears once daemon reconnects to hub (within ~5s typically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)