### PR TITLE
Release: dev → main (folder mount widening, ahand fixes, client polish)

### DIFF
--- a/apps/client/src-tauri/src/ahand/browser_runtime.rs
+++ b/apps/client/src-tauri/src/ahand/browser_runtime.rs
@@ -375,7 +375,10 @@ pub async fn browser_status(state: State<'_, AhandRuntime>) -> Result<BrowserSta
         .config_path()
         .await
         .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
-    let config = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let config = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_status: config load failed: {e:#}");
+        "config_load_failed".to_string()
+    })?;
     let enabled = config.browser_config().enabled.unwrap_or(false);
     let daemon_online = matches!(
         state.status().await,
@@ -540,8 +543,10 @@ pub async fn browser_install(
     } else {
         reports_for_status
     };
-    let config_after =
-        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let config_after = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_install: config final load failed: {e:#}");
+        "config_final_load_failed".to_string()
+    })?;
     let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
     let agent_visible = enabled_after
         && matches!(
@@ -585,10 +590,16 @@ pub async fn browser_set_enabled(
         }
     }
 
-    let mut cfg = Config::load(&config_path).map_err(|e| format!("config load: {e:#}"))?;
+    let mut cfg = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_set_enabled: config load failed: {e:#}");
+        "config_load_failed".to_string()
+    })?;
     let old = cfg
         .set_browser_enabled(&config_path, enabled)
-        .map_err(|e| format!("config write: {e:#}"))?;
+        .map_err(|e| {
+            eprintln!("browser_set_enabled: config write failed: {e:#}");
+            "config_write_failed".to_string()
+        })?;
 
     // No-op optimisation: skip the reload if the value didn't actually
     // change. Saves ~3-5s of daemon shutdown/respawn time.
@@ -616,8 +627,10 @@ pub async fn browser_set_enabled(
     }
 
     let reports = browser_setup::inspect_all().await;
-    let config_after =
-        Config::load(&config_path).map_err(|e| format!("config final load: {e:#}"))?;
+    let config_after = Config::load(&config_path).map_err(|e| {
+        eprintln!("browser_set_enabled: config final load failed: {e:#}");
+        "config_final_load_failed".to_string()
+    })?;
     let enabled_after = config_after.browser_config().enabled.unwrap_or(false);
     let agent_visible = enabled_after
         && matches!(

--- a/apps/client/src-tauri/src/ahand/browser_runtime.rs
+++ b/apps/client/src-tauri/src/ahand/browser_runtime.rs
@@ -375,11 +375,21 @@ pub async fn browser_status(state: State<'_, AhandRuntime>) -> Result<BrowserSta
         .config_path()
         .await
         .ok_or_else(|| "ahand runtime not started — call ahand_start first".to_string())?;
-    let config = Config::load(&config_path).map_err(|e| {
-        eprintln!("browser_status: config load failed: {e:#}");
-        "config_load_failed".to_string()
-    })?;
-    let enabled = config.browser_config().enabled.unwrap_or(false);
+    // Fresh users won't have ~/.ahand/config.toml yet; treat that as
+    // "browser disabled" rather than a hard error. The first successful
+    // browser_install or browser_set_enabled will create the file.
+    let enabled = if config_path.exists() {
+        Config::load(&config_path)
+            .map_err(|e| {
+                eprintln!("browser_status: config load failed: {e:#}");
+                "config_load_failed".to_string()
+            })?
+            .browser_config()
+            .enabled
+            .unwrap_or(false)
+    } else {
+        false
+    };
     let daemon_online = matches!(
         state.status().await,
         super::runtime::DaemonStatus::Online { .. }
@@ -511,6 +521,16 @@ pub async fn browser_install(
     // On success, flip the config flag and reload the daemon so the new
     // [browser].enabled value takes effect for the embedded ahandd.
     if matches!(overall_status, TauriStepStatus::Ok) {
+        // Fresh user: ensure the config file exists before Config::load.
+        // All Config fields are `#[serde(default)]`, so an empty TOML
+        // deserializes cleanly into a default Config that we can then
+        // mutate via set_browser_enabled (which will save_atomic and
+        // overwrite the empty file with proper TOML).
+        if !config_path.exists() {
+            if let Err(e) = std::fs::write(&config_path, "") {
+                eprintln!("browser_runtime: bootstrap empty config failed: {e:#}");
+            }
+        }
         match Config::load(&config_path) {
             Ok(mut cfg) => {
                 if let Err(e) = cfg.set_browser_enabled(&config_path, true) {
@@ -531,7 +551,7 @@ pub async fn browser_install(
                 }
             }
             Err(e) => {
-                eprintln!("browser_runtime: config reload failed: {e:#}");
+                eprintln!("browser_runtime: config load failed: {e:#}");
             }
         }
     }
@@ -590,6 +610,14 @@ pub async fn browser_set_enabled(
         }
     }
 
+    // Fresh user: bootstrap an empty config file if missing so Config::load
+    // succeeds. set_browser_enabled below will overwrite it via save_atomic.
+    if !config_path.exists() {
+        if let Err(e) = std::fs::write(&config_path, "") {
+            eprintln!("browser_set_enabled: bootstrap empty config failed: {e:#}");
+            return Err("config_load_failed".to_string());
+        }
+    }
     let mut cfg = Config::load(&config_path).map_err(|e| {
         eprintln!("browser_set_enabled: config load failed: {e:#}");
         "config_load_failed".to_string()

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -177,17 +177,34 @@ struct ActiveSession {
 
 pub struct AhandRuntime {
     inner: Arc<Mutex<Option<ActiveSession>>>,
+    /// Captured at the first successful `start()` call. Lets `reload()` —
+    /// which doesn't have an `&AppHandle` of its own — emit
+    /// `ahand-daemon-status` events from the respawned daemon's status
+    /// watcher. Cleared by `stop()`. Stored separately from
+    /// `ActiveSession` so it survives the take/replace dance during
+    /// reload and so it remains available even if the active session
+    /// is currently `None` mid-reload.
+    cached_app_handle: Arc<std::sync::Mutex<Option<AppHandle>>>,
 }
 
 impl AhandRuntime {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(None)),
+            cached_app_handle: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
     /// Start a new daemon session, stopping any existing one first.
     pub async fn start(&self, app: &AppHandle, cfg: StartConfig) -> Result<StartResult, String> {
+        // Capture the AppHandle so `reload()` can emit status events from
+        // respawned daemons. The clone is cheap (an Arc bump). Poison
+        // recovery is best-effort — `reload()` falls back to a no-op
+        // forwarder if this lock is poisoned.
+        if let Ok(mut h) = self.cached_app_handle.lock() {
+            *h = Some(app.clone());
+        }
+
         let mut guard = self.inner.lock().await;
 
         if let Some(prev) = guard.take() {
@@ -475,28 +492,22 @@ impl AhandRuntime {
     }
 
     /// Hook that returns the `AppHandle` used to forward status events
-    /// from the new daemon spawned during `reload()`. The current
-    /// implementation has no `AppHandle` cached on `AhandRuntime` (it's
-    /// passed per-call to `start()`/`stop()`), so the reload path emits
-    /// no status events directly — the new daemon's own status watch
-    /// will be subscribed to once a Tauri command resolves the handle
-    /// again. Tests pass `None`.
+    /// from the new daemon spawned during `reload()`. Reads from
+    /// `cached_app_handle` populated by `start()`. Without this,
+    /// reload-spawned daemons would not emit `ahand-daemon-status`
+    /// events to the renderer, leaving `useAhandLocalStatus` stuck
+    /// on whatever state was last seen before the reload — observably:
+    /// `agentVisible` would never flip back to true even after the new
+    /// daemon completed its hub handshake.
     ///
-    /// NOTE for Task 14: when wiring up the `browser_install` Tauri
-    /// command, the caller is expected to also `state.app_handle()` and
-    /// re-emit the new daemon's status. A future iteration may cache
-    /// the `AppHandle` inside `AhandRuntime` so reload() forwards
-    /// transparently.
-    // TODO(task-14): replace with real plumbing — pass the AppHandle through
-    // from the Tauri command site so post-reload daemon-status events reach
-    // the renderer. Today this returns None and the watch task at
-    // build_active_session is a no-op for reload-spawned daemons.
-    // The `_team9_user_id` parameter is currently unused; it exists so a
-    // single Tauri app could later scope per-user app handles when hosting
-    // multiple users. Keeping the signature stable means Task 14's wiring
-    // is a body-only change.
+    /// The `_team9_user_id` parameter is currently unused. It exists so
+    /// a future single-app-multiple-users layout can scope per-user
+    /// AppHandles without changing this signature.
     fn app_emitter_for_session(&self, _team9_user_id: &str) -> Option<AppHandle> {
-        None
+        self.cached_app_handle
+            .lock()
+            .ok()
+            .and_then(|h| h.clone())
     }
 
     async fn shutdown_session(session: ActiveSession) {
@@ -574,8 +585,10 @@ fn build_active_session(
                 }
             })
         }
-        // TODO(task-14): becomes unreachable once app_emitter_for_session returns Some.
-        // Until then, no-op so the JoinHandle field on ActiveSession is always populated.
+        // Test paths that pass `None` — and the rare race where
+        // `start()` was never called before `reload()` — fall through
+        // to a no-op so the JoinHandle field on ActiveSession is
+        // always populated.
         None => tokio::spawn(async {}),
     };
     ActiveSession {

--- a/apps/client/src-tauri/src/ahand/runtime.rs
+++ b/apps/client/src-tauri/src/ahand/runtime.rs
@@ -218,11 +218,28 @@ impl AhandRuntime {
             heartbeat_interval: Duration::from_secs(cfg.heartbeat_interval_seconds),
         };
 
+        // Default to ~/.ahand/config.toml when the renderer didn't supply
+        // one. This matches the documented ahandd convention so the
+        // browser_install/browser_set_enabled commands have somewhere to
+        // persist [browser].enabled across daemon restarts. The TS-side
+        // StartConfig interface intentionally does not require this field
+        // so existing renderer call sites keep working unchanged.
+        let resolved_config_path = cfg.config_path.clone().or_else(|| {
+            dirs::home_dir().map(|h| h.join(".ahand").join("config.toml"))
+        });
+
+        // Make sure the parent dir exists before any future
+        // `set_browser_enabled` write — that helper does not mkdir.
+        if let Some(p) = &resolved_config_path {
+            if let Some(parent) = p.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+
         // Optionally overlay the on-disk Config (mainly for browser.enabled).
         // Failures to read are non-fatal during start() — we fall back to
         // pure in-memory defaults so the daemon can still spawn.
-        let on_disk = cfg
-            .config_path
+        let on_disk = resolved_config_path
             .as_deref()
             .and_then(|p| ahandd::config::Config::load(p).ok());
         let daemon_cfg = build_daemon_config(on_disk.as_ref(), &startup_inputs);
@@ -253,7 +270,7 @@ impl AhandRuntime {
             status_forwarder,
             startup_inputs,
             current_daemon_config: daemon_cfg,
-            config_path: cfg.config_path,
+            config_path: resolved_config_path,
         });
 
         Ok(StartResult { device_id })

--- a/apps/client/src/components/channel/MessageList.tsx
+++ b/apps/client/src/components/channel/MessageList.tsx
@@ -41,8 +41,7 @@ import { cn } from "@/lib/utils";
 import { MessageItem } from "./MessageItem";
 import { DeleteMessageDialog } from "./DeleteMessageDialog";
 import { ToolCallBlock } from "./ToolCallBlock";
-import { StreamingMessageItem } from "./StreamingMessageItem";
-import { StreamingThinkingRow } from "./StreamingThinkingRow";
+import { StreamingMessageParts } from "./StreamingMessageParts";
 import { A2UISurfaceBlock } from "./A2UISurfaceBlock";
 import { A2UIResponseItem } from "./A2UIResponseItem";
 import { BotThinkingIndicator } from "./BotThinkingIndicator";
@@ -443,8 +442,7 @@ export function MessageList({
         // finalizes, which can be several seconds in).
         return (
           <div className="py-2">
-            <StreamingThinkingRow stream={item.stream} />
-            <StreamingMessageItem stream={item.stream} members={members} />
+            <StreamingMessageParts stream={item.stream} members={members} />
           </div>
         );
       }

--- a/apps/client/src/components/channel/StreamingMessageParts.tsx
+++ b/apps/client/src/components/channel/StreamingMessageParts.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+import { StreamingMessageItem } from "./StreamingMessageItem";
+import { StreamingThinkingRow } from "./StreamingThinkingRow";
+import type {
+  StreamingMessage,
+  StreamingPart,
+} from "@/stores/useStreamingStore";
+import type { ChannelMember } from "@/types/im";
+
+interface StreamingMessagePartsProps {
+  stream: StreamingMessage;
+  members: ChannelMember[];
+}
+
+function streamForContentPart(
+  stream: StreamingMessage,
+  part: StreamingPart,
+): StreamingMessage {
+  return {
+    ...stream,
+    content: part.content,
+    thinking: "",
+    isThinking: false,
+    isStreaming: part.isStreaming,
+  };
+}
+
+export const StreamingMessageParts = memo(function StreamingMessageParts({
+  stream,
+  members,
+}: StreamingMessagePartsProps) {
+  if (stream.parts.length === 0) {
+    return (
+      <>
+        <StreamingThinkingRow stream={stream} />
+        <StreamingMessageItem stream={stream} members={members} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {stream.parts.map((part) =>
+        part.type === "thinking" ? (
+          <StreamingThinkingRow
+            key={part.id}
+            stream={stream}
+            thinking={part.content}
+            startedAt={part.startedAt}
+            isLive={part.isStreaming}
+            durationMs={part.durationMs}
+          />
+        ) : (
+          <StreamingMessageItem
+            key={part.id}
+            stream={streamForContentPart(stream, part)}
+            members={members}
+          />
+        ),
+      )}
+    </>
+  );
+});

--- a/apps/client/src/components/channel/StreamingThinkingRow.tsx
+++ b/apps/client/src/components/channel/StreamingThinkingRow.tsx
@@ -36,13 +36,23 @@ import type { AgentEventMetadata } from "@/types/im";
  */
 interface StreamingThinkingRowProps {
   stream: StreamingMessage;
+  thinking?: string;
+  startedAt?: number;
+  isLive?: boolean;
+  durationMs?: number;
 }
 
 export const StreamingThinkingRow = memo(function StreamingThinkingRow({
   stream,
+  thinking,
+  startedAt,
+  isLive,
+  durationMs,
 }: StreamingThinkingRowProps) {
-  const hasContent = stream.content.length > 0;
-  const hasThinking = stream.thinking.length > 0;
+  const thinkingContent = thinking ?? stream.thinking;
+  const thinkingStartedAt = startedAt ?? stream.startedAt;
+  const hasContent = isLive === undefined ? stream.content.length > 0 : !isLive;
+  const hasThinking = thinkingContent.length > 0;
 
   // Freeze the elapsed duration at the exact moment reply text first
   // arrives, instead of recomputing `Date.now() - startedAt` on every
@@ -53,7 +63,8 @@ export const StreamingThinkingRow = memo(function StreamingThinkingRow({
   // when the stream ended and the persisted row took over.
   const frozenDurationMsRef = useRef<number | null>(null);
   if (hasContent && frozenDurationMsRef.current === null) {
-    frozenDurationMsRef.current = Math.max(0, Date.now() - stream.startedAt);
+    frozenDurationMsRef.current =
+      durationMs ?? Math.max(0, Date.now() - thinkingStartedAt);
   }
 
   // Once the reply text has started arriving, only keep the row around
@@ -66,7 +77,7 @@ export const StreamingThinkingRow = memo(function StreamingThinkingRow({
     return null;
   }
 
-  const startedAtIso = new Date(stream.startedAt).toISOString();
+  const startedAtIso = new Date(thinkingStartedAt).toISOString();
 
   // Freeze the row into its completed state once the reply text starts
   // streaming — thinking is definitely done by then, so show
@@ -79,14 +90,14 @@ export const StreamingThinkingRow = memo(function StreamingThinkingRow({
     ? {
         agentEventType: "thinking",
         status: "completed",
-        thinking: stream.thinking,
+        thinking: thinkingContent,
         durationMs: frozenDurationMsRef.current ?? 0,
       }
     : {
         agentEventType: "thinking",
         status: "running",
         startedAt: startedAtIso,
-        thinking: stream.thinking,
+        thinking: thinkingContent,
       };
 
   return (
@@ -96,7 +107,7 @@ export const StreamingThinkingRow = memo(function StreamingThinkingRow({
     >
       <TrackingEventItem
         metadata={metadata}
-        content={stream.thinking}
+        content={thinkingContent}
         isStreaming={!hasContent}
       />
     </div>

--- a/apps/client/src/components/channel/ThreadPanel.tsx
+++ b/apps/client/src/components/channel/ThreadPanel.tsx
@@ -19,8 +19,7 @@ import type { StreamingMessage } from "@/stores/useStreamingStore";
 import wsService from "@/services/websocket";
 import { MessageItem } from "./MessageItem";
 import { MessageInput } from "./MessageInput";
-import { StreamingMessageItem } from "./StreamingMessageItem";
-import { StreamingThinkingRow } from "./StreamingThinkingRow";
+import { StreamingMessageParts } from "./StreamingMessageParts";
 import { BotThinkingIndicator } from "./BotThinkingIndicator";
 import { ResizeHandle } from "./ResizeHandle";
 import { PropertyPanel } from "./properties/PropertyPanel";
@@ -325,8 +324,7 @@ export function ThreadPanel({
         // on thinking content.
         return (
           <div className="py-0.5">
-            <StreamingThinkingRow stream={item.stream} />
-            <StreamingMessageItem stream={item.stream} members={members} />
+            <StreamingMessageParts stream={item.stream} members={members} />
           </div>
         );
       }

--- a/apps/client/src/components/channel/__tests__/StreamingMessageParts.test.tsx
+++ b/apps/client/src/components/channel/__tests__/StreamingMessageParts.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import { StreamingMessageParts } from "../StreamingMessageParts";
+import type { StreamingMessage } from "@/stores/useStreamingStore";
+
+vi.mock("../MessageContent", () => ({
+  MessageContent: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+beforeEach(async () => {
+  if (i18n.language !== "en") {
+    await i18n.changeLanguage("en");
+  }
+});
+
+function makeStream(
+  overrides: Partial<StreamingMessage> = {},
+): StreamingMessage {
+  return {
+    streamId: "stream-1",
+    channelId: "channel-1",
+    senderId: "bot-1",
+    content: "first replysecond reply",
+    thinking: "first thinkingsecond thinking",
+    isThinking: false,
+    isStreaming: true,
+    startedAt: Date.now() - 5000,
+    parts: [
+      {
+        id: "stream-1-0",
+        type: "thinking",
+        content: "first thinking",
+        startedAt: Date.now() - 5000,
+        isStreaming: false,
+        durationMs: 1000,
+      },
+      {
+        id: "stream-1-1",
+        type: "content",
+        content: "first reply",
+        startedAt: Date.now() - 4000,
+        isStreaming: false,
+      },
+      {
+        id: "stream-1-2",
+        type: "thinking",
+        content: "second thinking",
+        startedAt: Date.now() - 3000,
+        isStreaming: false,
+        durationMs: 2000,
+      },
+      {
+        id: "stream-1-3",
+        type: "content",
+        content: "second reply",
+        startedAt: Date.now() - 1000,
+        isStreaming: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("StreamingMessageParts", () => {
+  it("renders thinking and text parts in arrival order", () => {
+    const { container } = render(
+      <StreamingMessageParts stream={makeStream()} members={[]} />,
+    );
+
+    expect(screen.getByText("first reply")).toBeInTheDocument();
+    expect(screen.getByText("second reply")).toBeInTheDocument();
+
+    const text = container.textContent ?? "";
+    const firstThinking = text.indexOf("Thought for 1s");
+    const firstReply = text.indexOf("first reply");
+    const secondThinking = text.indexOf("Thought for 2s");
+    const secondReply = text.indexOf("second reply");
+
+    expect(firstThinking).toBeGreaterThanOrEqual(0);
+    expect(firstThinking).toBeLessThan(firstReply);
+    expect(firstReply).toBeLessThan(secondThinking);
+    expect(secondThinking).toBeLessThan(secondReply);
+  });
+});

--- a/apps/client/src/components/channel/__tests__/StreamingThinkingRow.test.tsx
+++ b/apps/client/src/components/channel/__tests__/StreamingThinkingRow.test.tsx
@@ -22,6 +22,7 @@ function makeStream(
     isThinking: true,
     isStreaming: true,
     startedAt: Date.now(),
+    parts: [],
     ...overrides,
   };
 }
@@ -135,6 +136,7 @@ describe("StreamingThinkingRow", () => {
         isThinking: false,
         isStreaming: true,
         startedAt,
+        parts: [],
       };
       const { rerender } = render(<StreamingThinkingRow stream={firstFrame} />);
       expect(screen.getByText("Thought for 4s")).toBeInTheDocument();

--- a/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
+++ b/apps/client/src/components/layout/contents/devices/BrowserConfigTab/RuntimeCard.tsx
@@ -169,6 +169,12 @@ export function RuntimeCard() {
           translated = t("browser.errors.runtimeNotStarted");
         else if (raw === "browser_runtime_unavailable_in_web")
           translated = t("browser.errors.unavailableInWeb");
+        else if (raw === "config_load_failed")
+          translated = t("browser.errors.configLoadFailed");
+        else if (raw === "config_write_failed")
+          translated = t("browser.errors.configWriteFailed");
+        else if (raw === "config_final_load_failed")
+          translated = t("browser.errors.configFinalLoadFailed");
         toast.error(translated);
       }
     } else {

--- a/apps/client/src/components/sidebar/UserListItem.tsx
+++ b/apps/client/src/components/sidebar/UserListItem.tsx
@@ -80,12 +80,12 @@ export function UserListItem({
       onClick={channelId ? undefined : onClick}
       disabled={disabled}
       className={cn(
-        "w-full justify-start gap-2 px-2 h-auto py-2 text-sm text-nav-foreground-muted hover:bg-nav-hover hover:text-nav-foreground",
+        "w-full min-w-0 overflow-hidden justify-start gap-2 px-2 h-auto py-2 text-sm text-nav-foreground-muted hover:bg-nav-hover hover:text-nav-foreground",
         isSelected && "bg-nav-active text-nav-foreground",
         disabled && "opacity-50",
       )}
     >
-      <div className="relative">
+      <div className="relative shrink-0">
         <UserAvatar
           userId={userId}
           name={name || avatar}
@@ -118,7 +118,10 @@ export function UserListItem({
             ownerName={ownerName}
           />
         ) : subtitle ? (
-          <div className="text-xs text-nav-foreground-faint truncate">
+          <div
+            className="min-w-0 max-w-full truncate text-xs text-nav-foreground-faint"
+            title={subtitle}
+          >
             {subtitle}
           </div>
         ) : null}

--- a/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
+++ b/apps/client/src/components/sidebar/__tests__/UserListItem.avatar.test.tsx
@@ -42,4 +42,20 @@ describe("UserListItem avatar fallback", () => {
     );
     expect(screen.getByText("OpenClaw")).toHaveClass("shrink-0");
   });
+
+  it("clips a long start-conversation subtitle inside the sidebar row", () => {
+    render(
+      <UserListItem
+        name="Personal Assistant"
+        userId="bot_2ca59e7a_1777056260734"
+        subtitle="@bot_2ca59e7a_1777056260734_very_long_workspace_id"
+        isBot
+      />,
+    );
+
+    expect(screen.getByRole("button")).toHaveClass("min-w-0");
+    expect(
+      screen.getByText("@bot_2ca59e7a_1777056260734_very_long_workspace_id"),
+    ).toHaveClass("min-w-0", "max-w-full", "truncate");
+  });
 });

--- a/apps/client/src/hooks/__tests__/useWebSocketEvents.test.ts
+++ b/apps/client/src/hooks/__tests__/useWebSocketEvents.test.ts
@@ -133,6 +133,19 @@ const mockQueryClient = vi.hoisted(() => ({
     queryCache.set(cacheKey, next);
     return next;
   }),
+  setQueriesData: vi.fn(
+    (filters: { queryKey: unknown[] }, updater: unknown) => {
+      const prefix = JSON.stringify(filters.queryKey).slice(0, -1);
+      for (const [cacheKey, previous] of queryCache.entries()) {
+        if (!cacheKey.startsWith(prefix)) continue;
+        const next =
+          typeof updater === "function"
+            ? (updater as (value: unknown) => unknown)(previous)
+            : updater;
+        queryCache.set(cacheKey, next);
+      }
+    },
+  ),
   invalidateQueries: vi.fn(),
 }));
 
@@ -552,6 +565,47 @@ describe("useWebSocketEvents", () => {
     // Second call with same ID: should be skipped by idempotency check
     callback?.(sampleNotificationEvent);
     expect(mockShowTauriNotification).toHaveBeenCalledTimes(1);
+  });
+
+  // ==================== Topic Session Updated ====================
+
+  it("patches topic-session sidebar cache immediately when title updates", () => {
+    queryCache.set(
+      JSON.stringify(["topic-sessions-grouped", "workspace-1", 5]),
+      [
+        {
+          agentUserId: "bot-1",
+          agentId: "agent-1",
+          agentDisplayName: "Agent",
+          agentAvatarUrl: null,
+          legacyDirectChannelId: null,
+          totalCount: 1,
+          recentSessions: [
+            {
+              channelId: "channel-1",
+              sessionId: "session-1",
+              title: "临时标题",
+              lastMessageAt: null,
+              unreadCount: 0,
+              createdAt: "2026-04-01T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    );
+
+    renderHook(() => useWebSocketEvents());
+
+    const callback = listeners.get("topic_session_updated")?.[0];
+    expect(callback).toBeDefined();
+
+    callback?.({ channelId: "channel-1", title: "AI总结标题" });
+
+    const cached = queryCache.get(
+      JSON.stringify(["topic-sessions-grouped", "workspace-1", 5]),
+    ) as Array<{ recentSessions: Array<{ title: string | null }> }>;
+
+    expect(cached[0].recentSessions[0].title).toBe("AI总结标题");
   });
 
   // ==================== Routine Updated ====================

--- a/apps/client/src/hooks/useBrowserRuntime.ts
+++ b/apps/client/src/hooks/useBrowserRuntime.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { isTauriApp } from "@/lib/tauri";
+import type { DaemonStatus } from "@/types/tauri-ahand";
 
 // ---------------------------------------------------------------------------
 // Wire types — MUST match apps/client/src-tauri/src/ahand/browser_runtime.rs.
@@ -347,6 +349,40 @@ export function useBrowserRuntime(): UseBrowserRuntimeResult {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  // Re-fetch status whenever the embedded ahandd daemon transitions to
+  // "online". Without this, the renderer would keep the stale
+  // `agentVisible: false` snapshot captured the moment `browser_install` /
+  // `browser_set_enabled` resolved — at that point the respawned daemon is
+  // typically still mid-handshake, so the warning indicator would never
+  // clear without a manual reload. Listens to the same event channel as
+  // `useAhandLocalStatus`.
+  useEffect(() => {
+    if (!isTauriApp()) return;
+    let unlisten: (() => void) | null = null;
+    listen<DaemonStatus>("ahand-daemon-status", (ev) => {
+      // Skip while a command is in flight — install/setEnabled return
+      // fresh status when they resolve, so we'd just race them.
+      if (
+        stateRef.current.kind === "installing" ||
+        stateRef.current.kind === "reloading"
+      ) {
+        return;
+      }
+      // Only refresh on online transitions — that's the case where
+      // agentVisible would flip from false → true.
+      if (ev.payload.state === "online") {
+        void refresh();
+      }
+    })
+      .then((u) => {
+        unlisten = u;
+      })
+      .catch(() => {});
+    return () => {
+      unlisten?.();
+    };
   }, [refresh]);
 
   const install = useCallback(async (force: boolean) => {

--- a/apps/client/src/hooks/useWebSocketEvents.ts
+++ b/apps/client/src/hooks/useWebSocketEvents.ts
@@ -20,6 +20,7 @@ import type {
   MessagePropertyChangedEvent,
   MessageRelationChangedEvent,
   MessageRelationsPurgedEvent,
+  TopicSessionUpdatedEvent,
 } from "@/types/ws-events";
 import { relationKeys } from "@/lib/query-client";
 import { useAppStore, useSelectedWorkspaceId, useUser } from "@/stores";
@@ -102,6 +103,49 @@ export function useWebSocketEvents() {
         });
         queryClient.invalidateQueries({ queryKey: ["channels", workspaceId] });
       }, 500);
+    };
+
+    const handleTopicSessionUpdated = (event: TopicSessionUpdatedEvent) => {
+      queryClient.setQueriesData<TopicSessionGroup[]>(
+        { queryKey: ["topic-sessions-grouped", workspaceId] },
+        (old) => {
+          if (!old) return old;
+          let changed = false;
+          const next = old.map((group) => {
+            if (
+              !group.recentSessions.some((s) => s.channelId === event.channelId)
+            ) {
+              return group;
+            }
+            changed = true;
+            return {
+              ...group,
+              recentSessions: group.recentSessions.map((s) =>
+                s.channelId === event.channelId
+                  ? { ...s, title: event.title }
+                  : s,
+              ),
+            };
+          });
+          return changed ? next : old;
+        },
+      );
+
+      queryClient.setQueryData(
+        ["channels", workspaceId],
+        (old: ChannelWithUnread[] | undefined) => {
+          if (!old) return old;
+          let changed = false;
+          const next = old.map((channel) => {
+            if (channel.id !== event.channelId) return channel;
+            changed = true;
+            return { ...channel, name: event.title };
+          });
+          return changed ? next : old;
+        },
+      );
+
+      invalidateTopicSessions();
     };
 
     // Handle new message - immediately increment unread count
@@ -481,7 +525,7 @@ export function useWebSocketEvents() {
 
     // Topic-session lifecycle events
     wsService.on("topic_session_created", invalidateTopicSessions);
-    wsService.on("topic_session_updated", invalidateTopicSessions);
+    wsService.on("topic_session_updated", handleTopicSessionUpdated);
     wsService.on("topic_session_deleted", invalidateTopicSessions);
 
     // Message events for unread counts
@@ -538,7 +582,7 @@ export function useWebSocketEvents() {
 
       // Topic-session events
       wsService.off("topic_session_created", invalidateTopicSessions);
-      wsService.off("topic_session_updated", invalidateTopicSessions);
+      wsService.off("topic_session_updated", handleTopicSessionUpdated);
       wsService.off("topic_session_deleted", invalidateTopicSessions);
 
       // Message events

--- a/apps/client/src/i18n/locales/en/ahand.json
+++ b/apps/client/src/i18n/locales/en/ahand.json
@@ -175,7 +175,10 @@
       "operationInProgress": "Another browser operation is running. Please wait for it to finish.",
       "browserNotInstalled": "Finish installing the browser runtime before enabling agent access.",
       "runtimeNotStarted": "The ahand runtime isn't running yet. Please try again shortly.",
-      "unavailableInWeb": "This setting is only available in the desktop app."
+      "unavailableInWeb": "This setting is only available in the desktop app.",
+      "configLoadFailed": "Failed to read the ahand config file. See logs for details.",
+      "configWriteFailed": "Failed to write the ahand config file (may be a permissions issue). See logs for details.",
+      "configFinalLoadFailed": "Couldn't re-read the config after the operation; the displayed state may be stale. See logs for details."
     }
   },
   "overview": {

--- a/apps/client/src/i18n/locales/zh-CN/ahand.json
+++ b/apps/client/src/i18n/locales/zh-CN/ahand.json
@@ -172,7 +172,10 @@
       "operationInProgress": "已有一项浏览器操作在运行，请稍候。",
       "browserNotInstalled": "请先完成浏览器组件安装，再启用 Agent 可用。",
       "runtimeNotStarted": "ahand 运行时未启动，请稍后再试。",
-      "unavailableInWeb": "此功能仅在桌面应用中可用。"
+      "unavailableInWeb": "此功能仅在桌面应用中可用。",
+      "configLoadFailed": "读取 ahand 配置文件失败。详情见日志。",
+      "configWriteFailed": "写入 ahand 配置文件失败（可能是权限问题）。详情见日志。",
+      "configFinalLoadFailed": "操作完成后读取配置失败，状态可能不准确。详情见日志。"
     }
   },
   "overview": {

--- a/apps/client/src/stores/useStreamingStore.test.ts
+++ b/apps/client/src/stores/useStreamingStore.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useStreamingStore } from "./useStreamingStore";
+
+describe("useStreamingStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useStreamingStore.setState({ streams: new Map() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps thinking and text as ordered parts when they alternate in one stream", () => {
+    useStreamingStore.getState().startStream({
+      streamId: "stream-1",
+      channelId: "channel-1",
+      senderId: "bot-1",
+      startedAt: 1000,
+    });
+
+    useStreamingStore
+      .getState()
+      .setThinkingContent("stream-1", "first thinking");
+    useStreamingStore.getState().setStreamContent("stream-1", "first reply");
+    useStreamingStore
+      .getState()
+      .setThinkingContent("stream-1", "first thinkingsecond thinking");
+    useStreamingStore
+      .getState()
+      .setStreamContent("stream-1", "first replysecond reply");
+
+    const stream = useStreamingStore.getState().streams.get("stream-1");
+    expect(stream?.parts.map((part) => [part.type, part.content])).toEqual([
+      ["thinking", "first thinking"],
+      ["content", "first reply"],
+      ["thinking", "second thinking"],
+      ["content", "second reply"],
+    ]);
+  });
+
+  it("updates the active part instead of creating duplicates for same-phase deltas", () => {
+    useStreamingStore.getState().startStream({
+      streamId: "stream-1",
+      channelId: "channel-1",
+      senderId: "bot-1",
+      startedAt: 1000,
+    });
+
+    useStreamingStore.getState().setThinkingContent("stream-1", "think");
+    useStreamingStore.getState().setThinkingContent("stream-1", "thinking");
+    useStreamingStore.getState().setStreamContent("stream-1", "hel");
+    useStreamingStore.getState().setStreamContent("stream-1", "hello");
+
+    const stream = useStreamingStore.getState().streams.get("stream-1");
+    expect(stream?.parts.map((part) => [part.type, part.content])).toEqual([
+      ["thinking", "thinking"],
+      ["content", "hello"],
+    ]);
+  });
+});

--- a/apps/client/src/stores/useStreamingStore.ts
+++ b/apps/client/src/stores/useStreamingStore.ts
@@ -15,6 +15,17 @@ export interface StreamingMessage {
   isStreaming: boolean;
   /** Timestamp when streaming started */
   startedAt: number;
+  /** Ordered thinking/text parts as they arrive within this response */
+  parts: StreamingPart[];
+}
+
+export interface StreamingPart {
+  id: string;
+  type: "thinking" | "content";
+  content: string;
+  startedAt: number;
+  isStreaming: boolean;
+  durationMs?: number;
 }
 
 interface StreamingState {
@@ -50,6 +61,71 @@ interface StreamingState {
 const STREAM_TIMEOUT_MS = 120_000;
 const streamTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
+function closeActiveParts(
+  parts: StreamingPart[],
+  activeType: StreamingPart["type"],
+  now: number,
+): StreamingPart[] {
+  return parts.map((part) => {
+    if (!part.isStreaming || part.type === activeType) return part;
+    return {
+      ...part,
+      isStreaming: false,
+      durationMs: Math.max(0, now - part.startedAt),
+    };
+  });
+}
+
+function aggregateParts(
+  parts: StreamingPart[],
+  type: StreamingPart["type"],
+): string {
+  return parts
+    .filter((part) => part.type === type)
+    .map((part) => part.content)
+    .join("");
+}
+
+function updateStreamingParts(
+  stream: StreamingMessage,
+  type: StreamingPart["type"],
+  incomingContent: string,
+  previousAggregate: string,
+): StreamingPart[] {
+  const now = Date.now();
+  const parts = closeActiveParts(stream.parts, type, now);
+  const lastPart = parts[parts.length - 1];
+  const isAggregateDelta = incomingContent.startsWith(previousAggregate);
+  const nextContent = isAggregateDelta
+    ? incomingContent.slice(previousAggregate.length)
+    : incomingContent;
+
+  if (!nextContent && isAggregateDelta) {
+    return parts;
+  }
+
+  if (lastPart?.type === type) {
+    const updatedPart: StreamingPart = {
+      ...lastPart,
+      content: isAggregateDelta ? lastPart.content + nextContent : nextContent,
+      isStreaming: true,
+      durationMs: undefined,
+    };
+    return [...parts.slice(0, -1), updatedPart];
+  }
+
+  return [
+    ...parts,
+    {
+      id: `${stream.streamId}-${parts.length}`,
+      type,
+      content: nextContent,
+      startedAt: now,
+      isStreaming: true,
+    },
+  ];
+}
+
 export const useStreamingStore = create<StreamingState>((set, get) => ({
   streams: new Map(),
 
@@ -76,6 +152,7 @@ export const useStreamingStore = create<StreamingState>((set, get) => ({
         thinking: "",
         isThinking: false,
         isStreaming: true,
+        parts: [],
       });
       return { streams: newStreams };
     });
@@ -85,11 +162,18 @@ export const useStreamingStore = create<StreamingState>((set, get) => ({
     set((state) => {
       const stream = state.streams.get(streamId);
       if (!stream) return state;
+      const parts = updateStreamingParts(
+        stream,
+        "content",
+        content,
+        stream.content,
+      );
       const newStreams = new Map(state.streams);
       newStreams.set(streamId, {
         ...stream,
-        content,
+        content: aggregateParts(parts, "content"),
         isThinking: false,
+        parts,
       });
       return { streams: newStreams };
     });
@@ -99,11 +183,18 @@ export const useStreamingStore = create<StreamingState>((set, get) => ({
     set((state) => {
       const stream = state.streams.get(streamId);
       if (!stream) return state;
+      const parts = updateStreamingParts(
+        stream,
+        "thinking",
+        content,
+        stream.thinking,
+      );
       const newStreams = new Map(state.streams);
       newStreams.set(streamId, {
         ...stream,
-        thinking: content,
+        thinking: aggregateParts(parts, "thinking"),
         isThinking: true,
+        parts,
       });
       return { streams: newStreams };
     });

--- a/apps/client/src/types/ws-events.ts
+++ b/apps/client/src/types/ws-events.ts
@@ -252,6 +252,12 @@ export interface ChannelModelChangedEvent {
   changedAt: string;
 }
 
+/** Topic-session title updated event */
+export interface TopicSessionUpdatedEvent {
+  channelId: string;
+  title: string;
+}
+
 // ==================== Message Event Types ====================
 
 import type { Message } from "./im";

--- a/apps/server/apps/gateway/src/folder9/dto/folder-token-request.dto.ts
+++ b/apps/server/apps/gateway/src/folder9/dto/folder-token-request.dto.ts
@@ -37,11 +37,10 @@ export class FolderTokenRequestDto {
   userId?: string;
 
   /**
-   * One of the `Team9LogicalMountKey` union values. v1 only accepts
-   * `routine.document`; other values are rejected with 403 at the
-   * service layer (see {@link FolderTokenService}). Kept as
+   * One of the `Team9LogicalMountKey` union values. Kept as
    * loosely-validated string here so the wire format stays stable as
-   * we incrementally expand the allow-list.
+   * we incrementally expand the allow-list, with semantic acceptance
+   * enforced by `FolderTokenService`.
    */
   @IsString()
   @MaxLength(64)

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.spec.ts
@@ -445,16 +445,10 @@ describe('FolderTokenService', () => {
     });
   });
 
-  // ── I7: stub-authz scopes are read-only ────────────────────────────────
-  //
-  // session.{tmp,home}, agent.{tmp,home}, user.{tmp,home},
-  // routine.{tmp,home} ride a stub authz path until real RBAC lands.
-  // Until then, write/propose tokens through this endpoint would
-  // silently widen the trust boundary, so the v1 endpoint caps the
-  // permitted action at `read`. routine.document keeps its own real
-  // authz and is unaffected.
-  describe('I7 — stub-authz scopes are read-only', () => {
-    const STUB_KEYS = [
+  // ── Non-document scopes may issue write tokens after real authz ─────────
+
+  describe('non-document scopes — write tokens after real authz', () => {
+    const WRITABLE_KEYS = [
       'session.tmp',
       'session.home',
       'agent.tmp',
@@ -465,56 +459,48 @@ describe('FolderTokenService', () => {
       'routine.home',
     ] as const;
 
-    for (const logicalKey of STUB_KEYS) {
-      it(`403: ${logicalKey} rejects permission=write before any token mint`, async () => {
-        // The I7 gate runs after the bot identity lookup but before
-        // any logical-key authz (mount row check, ownership, etc).
-        // Each `await ... rejects` consumes one full call, so we
-        // queue a bot row per call here (two assertions = two calls).
-        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
-        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
-        const dto = makeDto({
-          logicalKey,
-          permission: 'write',
-        });
-        await expect(
-          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
-        ).rejects.toThrow(ForbiddenException);
-        await expect(
-          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
-        ).rejects.toThrow(/stub authz; only read permitted/);
-        expect(folder9Client.createToken).not.toHaveBeenCalled();
-      });
+    function queueAuthorizedPath(
+      logicalKey: (typeof WRITABLE_KEYS)[number],
+    ): Partial<FolderTokenRequestDto> {
+      queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
 
-      it(`403: ${logicalKey} rejects permission=propose`, async () => {
-        queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
-        const dto = makeDto({
-          logicalKey,
-          permission: 'propose',
-        });
-        await expect(
-          service.issueToken(dto, BOT_USER_ID, TENANT_ID),
-        ).rejects.toThrow(/stub authz; only read permitted/);
-        expect(folder9Client.createToken).not.toHaveBeenCalled();
-      });
+      if (logicalKey.startsWith('agent.')) {
+        queueMount({ scopeId: AGENT_ID });
+        return { logicalKey };
+      }
+
+      if (logicalKey.startsWith('session.')) {
+        queueMount({ scopeId: DM_SESSION_ID });
+        return { logicalKey, sessionId: DM_SESSION_ID };
+      }
+
+      if (logicalKey.startsWith('user.')) {
+        queueMount({ scopeId: USER_ID });
+        queueChannelMember(true);
+        return { logicalKey, sessionId: DM_SESSION_ID, userId: USER_ID };
+      }
+
+      queueMount({ scopeId: ROUTINE_ID });
+      queueRoutineForBot({ id: ROUTINE_ID });
+      return { logicalKey, routineId: ROUTINE_ID };
     }
 
-    it('routine.document is NOT a stub-authz scope: write is still allowed', async () => {
-      // I7 must not regress routine.document, which has real authz.
-      queueBot({ userId: BOT_USER_ID });
-      queueRoutine({
-        id: ROUTINE_ID,
-        tenantId: TENANT_ID,
-        folderId: FOLDER_ID,
-      });
+    for (const logicalKey of WRITABLE_KEYS) {
+      it(`200: ${logicalKey} mints permission=write after mount + ownership checks`, async () => {
+        const dto = makeDto({
+          ...queueAuthorizedPath(logicalKey),
+          permission: 'write',
+        });
 
-      const dto = makeDto({
-        logicalKey: 'routine.document',
-        permission: 'write',
+        const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
+
+        expect(result.token).toBe('opaque-token');
+        expect(folder9Client.createToken).toHaveBeenCalledTimes(1);
+        expect(folder9Client.createToken.mock.calls[0][0].permission).toBe(
+          'write',
+        );
       });
-      const result = await service.issueToken(dto, BOT_USER_ID, TENANT_ID);
-      expect(result.token).toBe('opaque-token');
-    });
+    }
   });
 
   // ── Admin permission rejection ────────────────────────────────────────────
@@ -554,9 +540,6 @@ describe('FolderTokenService', () => {
     it('rejects when caller bot is not active or not found', async () => {
       queueBot(null);
 
-      // Use `permission: 'read'` so the request bypasses the I7
-      // stub-authz read-only gate and actually exercises the bot
-      // identity lookup (the next gate after the early checks).
       await expect(
         service.issueToken(
           makeDto({ logicalKey: 'session.tmp', permission: 'read' }),
@@ -592,11 +575,6 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        // Use `permission: 'read'` here so the rejection path runs the
-        // real authz logic (mount row absent → 403). I7 caps stub-authz
-        // scopes at read; with the default 'write' the test would
-        // short-circuit at the I7 gate and never exercise the mount
-        // check we're trying to verify.
         const dto = makeDto({ logicalKey, permission: 'read' });
         await expect(
           service.issueToken(dto, BOT_USER_ID, TENANT_ID),
@@ -654,7 +632,6 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        // permission: 'read' — see the agent.* tests above for rationale.
         const dto = makeDto({
           logicalKey,
           sessionId: DM_SESSION_ID,
@@ -741,7 +718,6 @@ describe('FolderTokenService', () => {
         queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });
         queueMount(null);
 
-        // permission: 'read' required by I7 — see agent.* tests.
         const dto = makeDto({
           logicalKey,
           sessionId: DM_SESSION_ID,
@@ -824,10 +800,8 @@ describe('FolderTokenService', () => {
 
   // ── TTL on real authz path ────────────────────────────────────────────────
   //
-  // After I7, stub-authz logical keys (agent.*, session.*, user.*,
-  // routine.{tmp,home}) are read-only. Read tokens use a 6h TTL on
-  // those scopes. (The `propose` 1h-TTL path remains exercised
-  // indirectly via routine.document tests above.)
+  // Read tokens use a 6h TTL on non-document scopes. Write and
+  // propose tokens use the shorter 1h window.
   describe('TTL on real authz path', () => {
     it('uses 6h read TTL on agent.home with permission=read', async () => {
       queueBot({ id: BOT_ID, managedMeta: { agentId: AGENT_ID } });

--- a/apps/server/apps/gateway/src/folder9/folder-token.service.ts
+++ b/apps/server/apps/gateway/src/folder9/folder-token.service.ts
@@ -186,31 +186,6 @@ export class FolderTokenService {
       throw new ForbiddenException('Caller is not a known bot user');
     }
 
-    // I7: stub authz scopes are read-only.
-    //
-    // session.{tmp,home}, agent.{tmp,home}, user.{tmp,home},
-    // routine.{tmp,home} ride a stub authz path until real RBAC lands
-    // (per design spec). Until then, write/propose access through this
-    // endpoint would silently widen the trust boundary, so we cap the
-    // permitted action at `read`. routine.document keeps its own real
-    // authz (already gated above) and is unaffected.
-    const STUB_AUTHZ_LOGICAL_KEYS = new Set([
-      'session.tmp',
-      'session.home',
-      'agent.tmp',
-      'agent.home',
-      'user.tmp',
-      'user.home',
-      'routine.tmp',
-      'routine.home',
-    ]);
-    if (
-      STUB_AUTHZ_LOGICAL_KEYS.has(req.logicalKey) &&
-      req.permission !== 'read'
-    ) {
-      throw new ForbiddenException('stub authz; only read permitted');
-    }
-
     // Resolve the audit `scopeId` and run logical-key-specific authz.
     let scopeId: string;
     if (req.logicalKey === 'routine.document') {

--- a/apps/server/apps/gateway/src/im/channels/channels.service.ts
+++ b/apps/server/apps/gateway/src/im/channels/channels.service.ts
@@ -574,7 +574,8 @@ export class ChannelsService {
    * contract between team9 and agent-pi observable at construction time
    * and keeps compensation logic on the caller where the saga lives.
    *
-   * propertySettings.topicSession caches `{ agentId, sessionId, title }`
+   * propertySettings.topicSession caches `{ agentId, sessionId, title,
+   * titleSource }`
    * for cheap sidebar/search reads; title is eventually consistent with
    * agent-pi (the source of truth) via the `topic_session_updated` WS
    * event. Membership: creator + bot shadow user, both 'member'.
@@ -586,14 +587,22 @@ export class ChannelsService {
     agentId: string;
     sessionId: string;
     title: string | null;
+    titleSource?: 'temporary' | 'manual' | 'generated';
     channelId?: string;
   }): Promise<ChannelResponse> {
-    const { creatorId, botUserId, tenantId, agentId, sessionId, title } =
-      params;
+    const {
+      creatorId,
+      botUserId,
+      tenantId,
+      agentId,
+      sessionId,
+      title,
+      titleSource,
+    } = params;
     const channelId = params.channelId ?? uuidv7();
 
     const propertySettings: unknown = {
-      topicSession: { agentId, sessionId, title },
+      topicSession: { agentId, sessionId, title, titleSource },
     };
 
     const channel = await this.db.transaction(async (tx) => {
@@ -603,7 +612,7 @@ export class ChannelsService {
           id: channelId,
           tenantId: tenantId ?? null,
           type: 'topic-session',
-          name: null,
+          name: title,
           createdBy: creatorId,
           propertySettings,
         })
@@ -651,14 +660,19 @@ export class ChannelsService {
    * fan out `channel.updated` (for search re-index) and `topic_session_updated`
    * (for sidebar live refresh) with consistent payloads.
    *
-   * Uses an atomic guard (`WHERE title IS NULL`) when `expectCurrentTitleNull`
-   * is set so concurrent callers racing on the same channel can't double-write.
+   * Uses a guard when `expectCurrentTitleNull` is set so concurrent callers
+   * racing on the same channel can't double-write. A temporary title may be
+   * overwritten only when `allowTemporaryTitle` is also set.
    * Returns `null` when the guard rejects the write.
    */
   async updateTopicSessionTitle(
     channelId: string,
     title: string | null,
-    options: { expectCurrentTitleNull?: boolean } = {},
+    options: {
+      expectCurrentTitleNull?: boolean;
+      allowTemporaryTitle?: boolean;
+      titleSource?: 'temporary' | 'manual' | 'generated';
+    } = {},
   ): Promise<schema.Channel | null> {
     const [row] = await this.db
       .select()
@@ -674,18 +688,27 @@ export class ChannelsService {
           agentId?: string;
           sessionId?: string;
           title?: string | null;
+          titleSource?: 'temporary' | 'manual' | 'generated';
         };
       } | null) ?? {};
     const ts = existing.topicSession ?? {};
 
-    if (options.expectCurrentTitleNull && ts.title) {
+    if (
+      options.expectCurrentTitleNull &&
+      ts.title &&
+      !(options.allowTemporaryTitle && ts.titleSource === 'temporary')
+    ) {
       // Another writer beat us to it — bail without overwriting.
       return null;
     }
 
     const next = {
       ...existing,
-      topicSession: { ...ts, title },
+      topicSession: {
+        ...ts,
+        title,
+        titleSource: options.titleSource ?? ts.titleSource,
+      },
     };
 
     await this.db

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
@@ -201,7 +201,7 @@ describe('TopicSessionsService', () => {
       expect(result.sessionId).toBe(
         `team9/${TENANT_ID}/${AGENT_ID}/dm/${result.channelId}`,
       );
-      expect(result.title).toBeNull();
+      expect(result.title).toBe('Hello agent, help me kick off');
 
       // Ordering invariants:
       expect(channels.assertDirectMessageAllowed).toHaveBeenCalledWith(
@@ -227,6 +227,8 @@ describe('TopicSessionsService', () => {
           agentId: AGENT_ID,
           sessionId: result.sessionId,
           channelId: result.channelId,
+          title: 'Hello agent, help me kick off',
+          titleSource: 'temporary',
         }),
       );
       expect(imWorkerGrpc.createMessage).toHaveBeenCalledWith(
@@ -243,6 +245,29 @@ describe('TopicSessionsService', () => {
         expect.objectContaining({
           channelId: result.channelId,
           sessionId: result.sessionId,
+        }),
+      );
+    });
+
+    it('derives a short temporary CJK title from the initial message', async () => {
+      db.limit.mockResolvedValueOnce([makeHiveBotRow()]);
+      channels.createTopicSessionChannel.mockImplementationOnce(
+        async ({ channelId }: any) =>
+          makeTopicChannelRow(channelId ?? 'generated'),
+      );
+
+      const result = await service.create({
+        creatorId: CREATOR_ID,
+        tenantId: TENANT_ID,
+        botUserId: BOT_USER_ID,
+        initialMessage: '  新话题默认的标题在AI智能总结标题之前显示  ',
+      });
+
+      expect(result.title).toBe('新话题默认的标题在AI智');
+      expect(channels.createTopicSessionChannel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '新话题默认的标题在AI智',
+          titleSource: 'temporary',
         }),
       );
     });

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -87,7 +87,9 @@ export class TopicSessionsService {
     title?: string | null;
   }): Promise<TopicSessionResponse> {
     const { creatorId, tenantId, botUserId, initialMessage, model } = params;
-    const title = params.title ?? null;
+    const explicitTitle = params.title?.trim();
+    const title = explicitTitle || this.deriveTemporaryTitle(initialMessage);
+    const titleSource = explicitTitle ? 'manual' : 'temporary';
 
     // --- Step 1: resolve agentId from bot ---
     const [botRow] = await this.db
@@ -168,6 +170,7 @@ export class TopicSessionsService {
         agentId,
         sessionId,
         title,
+        titleSource,
         channelId,
       });
     } catch (err) {
@@ -603,6 +606,21 @@ export class TopicSessionsService {
     // there's no collision with legacy direct / routine-session ids
     // that also live under the dm/ scope.
     return `team9/${tenantId ?? ''}/${agentId}/dm/${channelId}`;
+  }
+
+  private deriveTemporaryTitle(initialMessage: string): string {
+    const normalized = initialMessage.replace(/\s+/g, ' ').trim();
+    const hasCjk =
+      /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
+        normalized,
+      );
+
+    if (hasCjk) {
+      return Array.from(normalized).slice(0, 12).join('');
+    }
+
+    const firstWords = normalized.split(' ').slice(0, 6).join(' ');
+    return Array.from(firstWords).slice(0, 40).join('');
   }
 
   /**

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.spec.ts
@@ -1,0 +1,111 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+const { TopicTitleGeneratorService } =
+  await import('./topic-title-generator.service.js');
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+function mockDb() {
+  const chain: Record<string, MockFn> = {};
+  for (const method of [
+    'select',
+    'from',
+    'where',
+    'limit',
+    'innerJoin',
+    'orderBy',
+  ]) {
+    chain[method] = jest.fn<any>().mockReturnValue(chain);
+  }
+  return chain;
+}
+
+describe('TopicTitleGeneratorService', () => {
+  let db: ReturnType<typeof mockDb>;
+  let hub: { request: MockFn; serviceHeaders: MockFn };
+  let channels: { updateTopicSessionTitle: MockFn };
+  let ws: { sendToUser: MockFn };
+  let eventEmitter: { emit: MockFn };
+  let service: InstanceType<typeof TopicTitleGeneratorService>;
+
+  beforeEach(() => {
+    db = mockDb();
+    hub = {
+      request: jest.fn<any>().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'AI总结标题' } }],
+        }),
+      }),
+      serviceHeaders: jest.fn<any>().mockReturnValue({
+        authorization: 'Bearer test',
+      }),
+    };
+    channels = {
+      updateTopicSessionTitle: jest.fn<any>().mockResolvedValue({
+        id: 'channel-1',
+        type: 'topic-session',
+        name: 'AI总结标题',
+      }),
+    };
+    ws = { sendToUser: jest.fn<any>().mockResolvedValue(undefined) };
+    eventEmitter = { emit: jest.fn<any>() };
+    service = new TopicTitleGeneratorService(
+      db as any,
+      hub as any,
+      channels as any,
+      ws as any,
+      eventEmitter as any,
+    );
+  });
+
+  it('replaces a temporary title when the bot reply triggers AI title generation', async () => {
+    db.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'channel-1',
+          type: 'topic-session',
+          createdBy: 'user-1',
+          tenantId: 'tenant-1',
+          propertySettings: {
+            topicSession: {
+              title: '临时标题',
+              titleSource: 'temporary',
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          content: '用户第一句话',
+          senderId: 'user-1',
+        },
+      ]);
+
+    await service.onMessageCreated({
+      message: {
+        id: 'msg-2',
+        channelId: 'channel-1',
+        senderId: 'bot-1',
+        content: 'bot reply',
+        type: 'text',
+      },
+      sender: { id: 'bot-1', userType: 'bot' },
+    });
+
+    expect(channels.updateTopicSessionTitle).toHaveBeenCalledWith(
+      'channel-1',
+      'AI总结标题',
+      {
+        expectCurrentTitleNull: true,
+        allowTemporaryTitle: true,
+        titleSource: 'generated',
+      },
+    );
+    expect(ws.sendToUser).toHaveBeenCalledWith(
+      'user-1',
+      'topic_session_updated',
+      { channelId: 'channel-1', title: 'AI总结标题' },
+    );
+  });
+});

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.spec.ts
@@ -1,3 +1,7 @@
+// Required env vars must be set before importing the service, since some
+// transitively-imported modules (e.g. websocket.gateway) read env at load time.
+process.env.CORS_ORIGIN ??= 'http://localhost:3000';
+
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 const { TopicTitleGeneratorService } =

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-title-generator.service.ts
@@ -71,7 +71,8 @@ export class TopicTitleGeneratorService {
    * Listen for any freshly persisted message (human, bot, streaming end…)
    * and decide whether to generate a title for the channel it landed in.
    * The decision is "bot just replied in a topic-session channel whose
-   * title is still null" — exactly the first-turn-done signal we want.
+   * title is missing or still temporary" — exactly the first-turn-done
+   * signal we want.
    */
   @OnEvent('message.created')
   async onMessageCreated(payload: MessageCreatedPayload): Promise<void> {
@@ -104,7 +105,8 @@ export class TopicTitleGeneratorService {
     }
     if (senderUserType !== 'bot') return;
 
-    // Channel must be a topic session and its title must still be null.
+    // Channel must be a topic session and its title must either be empty
+    // or the first-message placeholder created before the AI summary.
     const [channel] = await this.db
       .select()
       .from(schema.channels)
@@ -115,10 +117,13 @@ export class TopicTitleGeneratorService {
     const ts =
       (
         channel.propertySettings as {
-          topicSession?: { title?: string | null };
+          topicSession?: {
+            title?: string | null;
+            titleSource?: 'temporary' | 'manual' | 'generated';
+          };
         } | null
       )?.topicSession ?? {};
-    if (ts.title) return;
+    if (ts.title && ts.titleSource !== 'temporary') return;
 
     // capability-hub needs a billable identity (userId + tenantId) on
     // every LLM call so it can pre-authorize and then record usage
@@ -150,7 +155,11 @@ export class TopicTitleGeneratorService {
       const updated = await this.channels.updateTopicSessionTitle(
         channelId,
         title,
-        { expectCurrentTitleNull: true },
+        {
+          expectCurrentTitleNull: true,
+          allowTemporaryTitle: true,
+          titleSource: 'generated',
+        },
       );
       if (!updated) return;
 

--- a/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
+++ b/apps/server/apps/gateway/src/routines/__tests__/routines-creation-flow.integration.spec.ts
@@ -633,13 +633,24 @@ describe('Routine Creation Flow — integration', () => {
           creationChannelId: CHANNEL_ID,
           title: DRAFT_ROUTINE.title,
           description: null,
-          documentContent: null,
+          // documentContent dropped post-folder9 migration: SKILL.md is the
+          // source of truth for runbook body content. The agent reads it
+          // from /workspace/routine/document/SKILL.md, not from this field.
           botId: DRAFT_ROUTINE.botId,
           triggers: [],
         }),
       }),
       TENANT_ID,
     );
+    const sendCall = (clawHiveService.sendInput as jest.Mock).mock.calls.find(
+      (c) =>
+        (c[1] as { type?: string } | undefined)?.type ===
+        'team9:routine-creation.start',
+    );
+    expect(sendCall).toBeDefined();
+    expect(
+      (sendCall![1] as { payload: Record<string, unknown> }).payload,
+    ).not.toHaveProperty('documentContent');
   });
 
   it('hard-deletes the creation channel when deleting a draft', async () => {

--- a/apps/server/apps/gateway/src/routines/routine-bot.controller.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routine-bot.controller.spec.ts
@@ -30,7 +30,6 @@ describe('RoutineBotController', () => {
         .mockResolvedValue({ id: 'routine-1', status: 'draft' }),
       getRoutineById: jest.fn<any>().mockResolvedValue({
         id: 'routine-1',
-        documentContent: '',
         triggers: [],
       }),
       updateRoutine: jest
@@ -74,7 +73,7 @@ describe('RoutineBotController', () => {
   it('delegates getRoutineById with routineId, bot user, and tenant', async () => {
     await expect(
       controller.getById('routine-1', 'bot-user-1', 'tenant-1'),
-    ).resolves.toEqual({ id: 'routine-1', documentContent: '', triggers: [] });
+    ).resolves.toEqual({ id: 'routine-1', triggers: [] });
 
     expect(routineBotService.getRoutineById).toHaveBeenCalledWith(
       'routine-1',

--- a/apps/server/apps/gateway/src/routines/routine-bot.service.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routine-bot.service.spec.ts
@@ -117,7 +117,6 @@ describe('RoutineBotService — TaskCast integration', () => {
       db as never,
       wsGateway as never,
       taskCastService as never,
-      {} as never, // documentsService — not used in TaskCast tests
       {} as never, // routineTriggersService — not used in TaskCast tests
       {} as never, // routinesService — not used in TaskCast tests
     );
@@ -543,7 +542,6 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
   let db: ReturnType<typeof mockDb>;
   let wsGateway: { broadcastToWorkspace: MockFn };
   let taskCastService: { publishEvent: MockFn; transitionStatus: MockFn };
-  let documentsService: { create: MockFn; getById: MockFn; update: MockFn };
   let routineTriggersService: {
     listByRoutine: MockFn;
     replaceAllForRoutine: MockFn;
@@ -575,11 +573,6 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
       publishEvent: jest.fn<any>().mockResolvedValue(undefined),
       transitionStatus: jest.fn<any>().mockResolvedValue(undefined),
     };
-    documentsService = {
-      create: jest.fn<any>().mockResolvedValue({ id: 'doc-1' }),
-      getById: jest.fn<any>().mockResolvedValue({ content: 'doc content' }),
-      update: jest.fn<any>().mockResolvedValue(undefined),
-    };
     routineTriggersService = {
       listByRoutine: jest.fn<any>().mockResolvedValue([]),
       replaceAllForRoutine: jest.fn<any>().mockResolvedValue(undefined),
@@ -596,7 +589,6 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
       db as never,
       wsGateway as never,
       taskCastService as never,
-      documentsService as never,
       routineTriggersService as never,
       routinesService as never,
     );
@@ -766,16 +758,13 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
   // ── getRoutineById ────────────────────────────────────────────────
 
   describe('getRoutineById', () => {
-    it('returns routine enriched with documentContent and triggers', async () => {
+    it('returns routine enriched with triggers (no documentContent — deprecated)', async () => {
       // getRoutineOrThrow: routine lookup
       db.limit
         .mockResolvedValueOnce([ROUTINE_ROW] as any)
         // verifyBotOwnership: bot lookup
         .mockResolvedValueOnce([BOT_ROW] as any);
 
-      documentsService.getById.mockResolvedValueOnce({
-        content: 'my content',
-      } as any);
       routineTriggersService.listByRoutine.mockResolvedValueOnce([
         { id: 'trigger-1' },
       ] as any);
@@ -788,9 +777,14 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
 
       expect(result).toMatchObject({
         id: 'routine-1',
-        documentContent: 'my content',
         triggers: [{ id: 'trigger-1' }],
       });
+      // documentContent must NOT be enriched onto the response — the field is
+      // a deprecated legacy column and was misleading the agent into thinking
+      // SKILL.md was unwritten when it was actually present in folder9.
+      expect(
+        (result as Record<string, unknown>).documentContent,
+      ).toBeUndefined();
     });
 
     it('throws NotFoundException when routine not found', async () => {
@@ -810,25 +804,6 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
       await expect(
         service.getRoutineById('routine-1', 'bot-user-1', 'tenant-1'),
       ).rejects.toThrow(ForbiddenException);
-    });
-
-    it('returns empty documentContent when documentsService throws', async () => {
-      db.limit
-        .mockResolvedValueOnce([ROUTINE_ROW] as any)
-        .mockResolvedValueOnce([BOT_ROW] as any);
-
-      documentsService.getById.mockRejectedValueOnce(
-        new Error('not found') as any,
-      );
-      routineTriggersService.listByRoutine.mockResolvedValueOnce([] as any);
-
-      const result = await service.getRoutineById(
-        'routine-1',
-        'bot-user-1',
-        'tenant-1',
-      );
-
-      expect(result.documentContent).toBe('');
     });
   });
 
@@ -856,25 +831,17 @@ describe('RoutineBotService — Routine CRUD (bot-scoped)', () => {
     // The bot-side bridge `(dto as ...).documentContent` was removed in
     // A.4 along with its create-side counterpart. Bots no longer write
     // routine body via PATCH — that path moves to the folder9 SKILL.md
-    // proxy (A.6). The legacy assertion that updateRoutine called
-    // documentsService.update with a documentContent literal is replaced
-    // by a regression check that documentsService is NOT touched at all
-    // on a body-less update.
-    it('does NOT touch documentsService on a routine PATCH', async () => {
-      db.limit
-        .mockResolvedValueOnce([ROUTINE_ROW] as any)
-        .mockResolvedValueOnce([BOT_ROW] as any);
-
-      db.returning.mockResolvedValueOnce([ROUTINE_ROW] as any);
-
-      await service.updateRoutine(
-        'routine-1',
-        { title: 'Updated' } as never,
-        'bot-user-1',
-        'tenant-1',
-      );
-
-      expect(documentsService.update).not.toHaveBeenCalled();
+    // proxy (A.6). After the routine→folder9 skill migration the
+    // `documentsService` injection itself was dropped from
+    // `RoutineBotService` (no remaining call site), so a structural guard
+    // is more honest than asserting on a now-unwired mock: the constructor
+    // must not list DocumentsService as a parameter.
+    it('does NOT take DocumentsService as a constructor dependency', () => {
+      // RoutineBotService's constructor takes (db, wsGateway, taskCastService,
+      // routineTriggersService, routinesService) — 5 args, no documentsService.
+      // If a future contributor re-adds the injection without re-introducing a
+      // real call site, this length check will flag it.
+      expect(RoutineBotService.length).toBe(5);
     });
 
     it('replaces triggers when provided', async () => {

--- a/apps/server/apps/gateway/src/routines/routine-bot.service.ts
+++ b/apps/server/apps/gateway/src/routines/routine-bot.service.ts
@@ -24,7 +24,6 @@ import type { UpdateRoutineDto } from './dto/update-routine.dto.js';
 import type { CreateRoutineDto } from './dto/create-routine.dto.js';
 import type { CompleteCreationDto } from './dto/complete-creation.dto.js';
 import { TaskCastService } from './taskcast.service.js';
-import { DocumentsService } from '../documents/documents.service.js';
 import { RoutineTriggersService } from './routine-triggers.service.js';
 import { RoutinesService } from './routines.service.js';
 
@@ -32,13 +31,17 @@ import { RoutinesService } from './routines.service.js';
 
 @Injectable()
 export class RoutineBotService {
+  // `DocumentsService` is intentionally NOT injected here. It used to enrich
+  // `getRoutineById` with the legacy `documentContent` column; that
+  // enrichment was removed in the routine→folder9 skill migration (SKILL.md
+  // is now the source of truth, mounted via folder9). Re-introducing the
+  // injection without a real call site would resurrect dead DI wiring.
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
     @Inject(WEBSOCKET_GATEWAY)
     private readonly wsGateway: WebsocketGateway,
     private readonly taskCastService: TaskCastService,
-    private readonly documentsService: DocumentsService,
     private readonly routineTriggersService: RoutineTriggersService,
     private readonly routinesService: RoutinesService,
   ) {}
@@ -469,7 +472,17 @@ export class RoutineBotService {
 
   /**
    * Fetch a routine by ID, verifying the calling bot is the assigned bot.
-   * Returns routine enriched with documentContent and triggers.
+   * Returns routine enriched with triggers.
+   *
+   * `documentContent` is no longer enriched onto the response — the field is
+   * a deprecated legacy column from before the folder9 migration and always
+   * read empty for routines created on the new path. Bots should read the
+   * runbook from the folder9-backed SKILL.md (mounted at
+   * `/workspace/routine/document/SKILL.md` in the agent session) and never
+   * derive runbook state from `documentContent`. Removed in the
+   * routine→folder9 skill migration to stop the field from misleading the
+   * agent into "documentContent is empty therefore SKILL.md is missing"
+   * loops.
    */
   async getRoutineById(routineId: string, botUserId: string, tenantId: string) {
     const routine = await this.getRoutineOrThrow(routineId, tenantId);
@@ -480,24 +493,13 @@ export class RoutineBotService {
     }
     await this.verifyBotOwnership(routine.botId, botUserId);
 
-    // Enrich with document content
-    let documentContent = '';
-    if (routine.documentId) {
-      try {
-        const doc = await this.documentsService.getById(routine.documentId);
-        documentContent = (doc as { content?: string | null }).content ?? '';
-      } catch {
-        documentContent = '';
-      }
-    }
-
     // Enrich with triggers
     const triggers = await this.routineTriggersService.listByRoutine(
       routineId,
       tenantId,
     );
 
-    return { ...routine, documentContent, triggers };
+    return { ...routine, triggers };
   }
 
   /**

--- a/apps/server/apps/gateway/src/routines/routines.service.spec.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.spec.ts
@@ -4717,17 +4717,15 @@ describe('RoutinesService — TaskCast integration', () => {
       });
     });
 
-    it('kickoff payload includes the enriched draft fields when doc is present', async () => {
-      const DOCUMENT_ID = 'doc-42';
+    it('kickoff payload includes the enriched draft fields (no documentContent — it is deprecated)', async () => {
+      // After the routine→folder9 skill migration the kickoff payload no
+      // longer carries a `documentContent` enrichment. The runbook lives
+      // in the folder9-mounted SKILL.md; legacy `documents` table reads
+      // would always return empty for new routines and only ever served
+      // to confuse the agent into "SKILL.md unwritten" loops.
       mockGetRoutine({
         description: 'My routine description',
-        documentId: DOCUMENT_ID,
         botId: BOT_ID,
-      });
-      documentsService.getById.mockResolvedValueOnce({
-        id: DOCUMENT_ID,
-        tenantId: TENANT_ID,
-        currentVersion: { versionIndex: 1, content: 'draft doc content' },
       });
 
       await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
@@ -4741,13 +4739,14 @@ describe('RoutinesService — TaskCast integration', () => {
       expect(payload.creationChannelId).toBe(CHANNEL_ID);
       expect(payload.title).toBe('Test Draft');
       expect(payload.description).toBe('My routine description');
-      expect(payload.documentContent).toBe('draft doc content');
+      expect(payload).not.toHaveProperty('documentContent');
       expect(payload.botId).toBe(BOT_ID);
       expect(payload.triggers).toEqual([]);
     });
 
     it('payload uses null for missing optional fields when draft has none', async () => {
-      // Default mockGetRoutine has no description and no documentId
+      // Default mockGetRoutine has no description; documentId is also null
+      // but the field is no longer carried on the kickoff payload either way.
       mockGetRoutine({ description: null, documentId: null });
 
       await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
@@ -4756,7 +4755,7 @@ describe('RoutinesService — TaskCast integration', () => {
         .calls[0] as [string, { payload: Record<string, unknown> }, string];
       const payload = sendInputCall[1].payload;
       expect(payload.description).toBeNull();
-      expect(payload.documentContent).toBeNull();
+      expect(payload).not.toHaveProperty('documentContent');
       expect(payload.triggers).toEqual([]);
     });
 
@@ -4840,24 +4839,20 @@ describe('RoutinesService — TaskCast integration', () => {
       );
     });
 
-    it('logs warn and uses null documentContent when documentsService.getById throws', async () => {
-      const DOCUMENT_ID = 'doc-fail';
+    it('startCreationSession: kickoff payload omits the deprecated documentContent field entirely', async () => {
+      // Routine→folder9 skill migration: the kickoff event used to carry a
+      // best-effort `documentContent` enrichment fetched from the legacy
+      // `documents` table. Routines created on the new path have
+      // documentId=null, so the field was always null for new routines and
+      // always misleading for the agent (it would interpret an empty
+      // documentContent as "SKILL.md unwritten" and start re-authoring on
+      // top of the actual SKILL.md living in folder9). The enrichment was
+      // removed; this test guards against re-introduction.
+      const DOCUMENT_ID = 'doc-legacy';
       mockGetRoutine({ documentId: DOCUMENT_ID });
-      documentsService.getById.mockRejectedValueOnce(
-        new Error('doc fetch boom'),
-      );
-      const loggerWarn = jest
-        .spyOn((service as any).logger, 'warn')
-        .mockImplementation(() => undefined);
 
-      // Should resolve successfully despite getById failure
       await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
 
-      expect(loggerWarn).toHaveBeenCalledWith(
-        expect.stringContaining('failed to fetch draft documentContent'),
-      );
-
-      // documentContent in the payload should be null
       const payload = (
         (clawHiveService.sendInput as jest.Mock).mock.calls[0] as [
           string,
@@ -4865,9 +4860,11 @@ describe('RoutinesService — TaskCast integration', () => {
           string,
         ]
       )[1].payload;
-      expect(payload.documentContent).toBeNull();
-
-      loggerWarn.mockRestore();
+      expect(payload).not.toHaveProperty('documentContent');
+      // The kickoff path must NOT touch documentsService — leaning on it
+      // brought tenant-mismatch / fetch-failure handling that is no longer
+      // relevant once SKILL.md is the source of truth.
+      expect(documentsService.getById).not.toHaveBeenCalled();
     });
 
     it('kickoff payload includes draft triggers from inline DB select', async () => {
@@ -4977,60 +4974,12 @@ describe('RoutinesService — TaskCast integration', () => {
       loggerWarn.mockRestore();
     });
 
-    // ── documentContent enrichment tests ──────────────────────────────
-
-    it('startCreationSession: kickoff payload includes documentContent from doc.currentVersion.content', async () => {
-      const DOCUMENT_ID = 'doc-1';
-      mockGetRoutine({ documentId: DOCUMENT_ID });
-      documentsService.getById.mockResolvedValueOnce({
-        id: DOCUMENT_ID,
-        tenantId: TENANT_ID,
-        currentVersion: { versionIndex: 1, content: 'doc body' },
-      } as any);
-
-      await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
-
-      const payload = (clawHiveService.sendInput as jest.Mock).mock
-        .calls[0] as [string, { payload: Record<string, unknown> }, string];
-      expect(payload[1].payload.documentContent).toBe('doc body');
-    });
-
-    it('startCreationSession: documentContent stays null when doc tenantId mismatches', async () => {
-      const DOCUMENT_ID = 'doc-1';
-      mockGetRoutine({ documentId: DOCUMENT_ID });
-      documentsService.getById.mockResolvedValueOnce({
-        id: DOCUMENT_ID,
-        tenantId: 'other-tenant',
-        currentVersion: { versionIndex: 1, content: 'leaked' },
-      } as any);
-      const loggerWarn = jest.spyOn((service as any).logger, 'warn');
-
-      await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
-
-      const payload = (clawHiveService.sendInput as jest.Mock).mock
-        .calls[0] as [string, { payload: Record<string, unknown> }, string];
-      expect(payload[1].payload.documentContent).toBeNull();
-      expect(loggerWarn).toHaveBeenCalledWith(
-        expect.stringContaining('tenant mismatch'),
-      );
-      loggerWarn.mockRestore();
-    });
-
-    it('startCreationSession: documentContent stays null when currentVersion is null', async () => {
-      const DOCUMENT_ID = 'doc-1';
-      mockGetRoutine({ documentId: DOCUMENT_ID });
-      documentsService.getById.mockResolvedValueOnce({
-        id: DOCUMENT_ID,
-        tenantId: TENANT_ID,
-        currentVersion: null,
-      } as any);
-
-      await service.startCreationSession(ROUTINE_ID, USER_ID, TENANT_ID);
-
-      const payload = (clawHiveService.sendInput as jest.Mock).mock
-        .calls[0] as [string, { payload: Record<string, unknown> }, string];
-      expect(payload[1].payload.documentContent).toBeNull();
-    });
+    // documentContent enrichment was removed in the routine→folder9 skill
+    // migration — see the regression test above
+    // ("kickoff payload omits the deprecated documentContent field entirely").
+    // The previous tenant-mismatch / fetch-failure / currentVersion=null
+    // sub-cases all collapsed into "the field is not present and getById
+    // is never called", which is what the regression test asserts.
 
     describe('creator language propagation', () => {
       it("includes creator's language + timeZone in team9Context when both are set", async () => {

--- a/apps/server/apps/gateway/src/routines/routines.service.ts
+++ b/apps/server/apps/gateway/src/routines/routines.service.ts
@@ -33,10 +33,7 @@ import {
 import { WS_EVENTS } from '@team9/shared';
 import { WEBSOCKET_GATEWAY } from '../shared/constants/injection-tokens.js';
 import type { WebsocketGateway } from '../im/websocket/websocket.gateway.js';
-import {
-  DocumentsService,
-  type DocumentResponse,
-} from '../documents/documents.service.js';
+import { DocumentsService } from '../documents/documents.service.js';
 import { ChannelsService } from '../im/channels/channels.service.js';
 import { ClawHiveService } from '@team9/claw-hive';
 import { appMetrics } from '@team9/observability';
@@ -1431,34 +1428,13 @@ export class RoutinesService {
       );
     }
 
-    // Fetch document content as best-effort enrichment for the kickoff payload.
-    let draftDocumentContent: string | null = null;
-    if (routine.documentId) {
-      try {
-        const doc: DocumentResponse = await this.documentsService.getById(
-          routine.documentId,
-        );
-        if (doc.tenantId !== tenantId) {
-          this.logger.warn(
-            `startCreationSession: routine ${routineId} document ${routine.documentId} tenant mismatch (got ${doc.tenantId}, expected ${tenantId}); skipping enrichment`,
-          );
-          // leave draftDocumentContent as null
-        } else {
-          const content = doc.currentVersion?.content;
-          if (typeof content === 'string') {
-            const trimmed = content.trim();
-            if (trimmed.length > 0) {
-              draftDocumentContent = trimmed;
-            }
-          }
-        }
-      } catch (err) {
-        // Best-effort enrichment; if the document fetch fails, leave null.
-        this.logger.warn(
-          `startCreationSession: failed to fetch draft documentContent for routine ${routineId}: ${err}`,
-        );
-      }
-    }
+    // documentContent is no longer enriched onto the kickoff payload — the
+    // routine→folder9 skill migration moved runbook body content to a
+    // managed folder9 SKILL.md, and the agent now reads it via the
+    // filesystem-backed mount at `/workspace/routine/document/SKILL.md`.
+    // Carrying the deprecated legacy column on the kickoff event misled the
+    // agent into "documentContent is empty therefore SKILL.md is missing"
+    // loops when the actual source of truth lives in folder9.
 
     // Fetch existing triggers as best-effort enrichment so the agent can
     // render an accurate state (e.g. "1 trigger configured") instead of
@@ -1636,7 +1612,6 @@ export class RoutinesService {
             creationChannelId: channel.id,
             title: routine.title,
             description: routine.description ?? null,
-            documentContent: draftDocumentContent,
             botId: routine.botId,
             triggers: draftTriggers,
           },

--- a/apps/server/libs/database/migrations/0057_yielding_radioactive_man.sql
+++ b/apps/server/libs/database/migrations/0057_yielding_radioactive_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workspace_folder_mounts" ALTER COLUMN "scope_id" SET DATA TYPE varchar(256);

--- a/apps/server/libs/database/migrations/meta/0057_snapshot.json
+++ b/apps/server/libs/database/migrations/meta/0057_snapshot.json
@@ -1,0 +1,8192 @@
+{
+  "id": "a92e98bf-510d-4f72-9cb8-da2ede0fb12b",
+  "prevId": "4fd8fdab-b03e-47c6-8fc3-71c67ed2a457",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_suggestions": {
+      "name": "document_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "document_suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_version_id": {
+          "name": "result_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_document_suggestions_document_id": {
+          "name": "idx_document_suggestions_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_suggestions_status": {
+          "name": "idx_document_suggestions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_suggestions_document_id_documents_id_fk": {
+          "name": "document_suggestions_document_id_documents_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_suggestions_from_version_id_document_versions_id_fk": {
+          "name": "document_suggestions_from_version_id_document_versions_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["from_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_suggestions_result_version_id_document_versions_id_fk": {
+          "name": "document_suggestions_result_version_id_document_versions_id_fk",
+          "tableFrom": "document_suggestions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["result_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_versions": {
+      "name": "document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_index": {
+          "name": "version_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_document_versions_document_id": {
+          "name": "idx_document_versions_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_document_id_documents_id_fk": {
+          "name": "document_versions_document_id_documents_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_document_versions_doc_version": {
+          "name": "uq_document_versions_doc_version",
+          "nullsNotDistinct": false,
+          "columns": ["document_id", "version_index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privileges": {
+          "name": "privileges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_documents_tenant_id": {
+          "name": "idx_documents_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_document_type": {
+          "name": "idx_documents_document_type",
+          "columns": [
+            {
+              "expression": "document_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_tenant_id_tenants_id_fk": {
+          "name": "documents_tenant_id_tenants_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_folder_mounts": {
+      "name": "workspace_folder_mounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_key": {
+          "name": "mount_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_type": {
+          "name": "folder_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder9_folder_id": {
+          "name": "folder9_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_folder_mounts_unique": {
+          "name": "workspace_folder_mounts_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_folder_mounts_workspace_id_tenants_id_fk": {
+          "name": "workspace_folder_mounts_workspace_id_tenants_id_fk",
+          "tableFrom": "workspace_folder_mounts",
+          "tableTo": "tenants",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_ahand_devices": {
+      "name": "im_ahand_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hub_device_id": {
+          "name": "hub_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ahand_devices_owner_idx": {
+          "name": "ahand_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ahand_devices_status_idx": {
+          "name": "ahand_devices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_ahand_devices_hub_device_id_unique": {
+          "name": "im_ahand_devices_hub_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hub_device_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_audit_logs": {
+      "name": "im_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_channel_created": {
+          "name": "idx_audit_logs_channel_created",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_entity": {
+          "name": "idx_audit_logs_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_performer": {
+          "name": "idx_audit_logs_performer",
+          "columns": [
+            {
+              "expression": "performed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_audit_logs_channel_id_im_channels_id_fk": {
+          "name": "im_audit_logs_channel_id_im_channels_id_fk",
+          "tableFrom": "im_audit_logs",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_audit_logs_performed_by_im_users_id_fk": {
+          "name": "im_audit_logs_performed_by_im_users_id_fk",
+          "tableFrom": "im_audit_logs",
+          "tableTo": "im_users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_bots": {
+      "name": "im_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "bot_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_application_id": {
+          "name": "installed_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_headers": {
+          "name": "webhook_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "managed_provider": {
+          "name": "managed_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_meta": {
+          "name": "managed_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bots_user_id": {
+          "name": "idx_bots_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_type": {
+          "name": "idx_bots_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_owner_id": {
+          "name": "idx_bots_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_mentor_id": {
+          "name": "idx_bots_mentor_id",
+          "columns": [
+            {
+              "expression": "mentor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_installed_application_id": {
+          "name": "idx_bots_installed_application_id",
+          "columns": [
+            {
+              "expression": "installed_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bots_access_token": {
+          "name": "idx_bots_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bots_owner_app_unique": {
+          "name": "bots_owner_app_unique",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installed_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bots\".\"owner_id\" IS NOT NULL AND \"im_bots\".\"installed_application_id\" IS NOT NULL AND \"im_bots\".\"extra\"->>'personalStaff' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bots_user_id_im_users_id_fk": {
+          "name": "im_bots_user_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_bots_owner_id_im_users_id_fk": {
+          "name": "im_bots_owner_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bots_mentor_id_im_users_id_fk": {
+          "name": "im_bots_mentor_id_im_users_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_users",
+          "columnsFrom": ["mentor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bots_installed_application_id_im_installed_applications_id_fk": {
+          "name": "im_bots_installed_application_id_im_installed_applications_id_fk",
+          "tableFrom": "im_bots",
+          "tableTo": "im_installed_applications",
+          "columnsFrom": ["installed_application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_bots_user_id_unique": {
+          "name": "im_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_members": {
+      "name": "im_channel_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_dm_sidebar": {
+          "name": "show_in_dm_sidebar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_channel_members_user_id": {
+          "name": "idx_channel_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_members_channel_id_im_channels_id_fk": {
+          "name": "im_channel_members_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_members",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_members_user_id_im_users_id_fk": {
+          "name": "im_channel_members_user_id_im_users_id_fk",
+          "tableFrom": "im_channel_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_channel_user": {
+          "name": "unique_channel_user",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_property_definitions": {
+      "name": "im_channel_property_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "property_value_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_native": {
+          "name": "is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_auto_fill": {
+          "name": "ai_auto_fill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ai_auto_fill_prompt": {
+          "name": "ai_auto_fill_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_chat_policy": {
+          "name": "show_in_chat_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "allow_new_options": {
+          "name": "allow_new_options",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_property_def_order": {
+          "name": "idx_channel_property_def_order",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_property_definitions_channel_id_im_channels_id_fk": {
+          "name": "im_channel_property_definitions_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_property_definitions",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_property_definitions_created_by_im_users_id_fk": {
+          "name": "im_channel_property_definitions_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_property_definitions",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_channel_property_def_key": {
+          "name": "uq_channel_property_def_key",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_sections": {
+      "name": "im_channel_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_sections_tenant": {
+          "name": "idx_channel_sections_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_sections_tenant_id_tenants_id_fk": {
+          "name": "im_channel_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "im_channel_sections",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_sections_created_by_im_users_id_fk": {
+          "name": "im_channel_sections_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_sections",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_tabs": {
+      "name": "im_channel_tabs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_id": {
+          "name": "view_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_tabs_channel": {
+          "name": "idx_channel_tabs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_tabs_channel_id_im_channels_id_fk": {
+          "name": "im_channel_tabs_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_tabs_view_id_im_channel_views_id_fk": {
+          "name": "im_channel_tabs_view_id_im_channel_views_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_channel_views",
+          "columnsFrom": ["view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_channel_tabs_created_by_im_users_id_fk": {
+          "name": "im_channel_tabs_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_tabs",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_views": {
+      "name": "im_channel_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_views_channel": {
+          "name": "idx_channel_views_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_views_channel_id_im_channels_id_fk": {
+          "name": "im_channel_views_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_views",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_views_created_by_im_users_id_fk": {
+          "name": "im_channel_views_created_by_im_users_id_fk",
+          "tableFrom": "im_channel_views",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channels": {
+      "name": "im_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_activated": {
+          "name": "is_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_settings": {
+          "name": "property_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channels_tenant": {
+          "name": "idx_channels_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channels_tenant_id_tenants_id_fk": {
+          "name": "im_channels_tenant_id_tenants_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channels_created_by_im_users_id_fk": {
+          "name": "im_channels_created_by_im_users_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_channels_section_id_im_channel_sections_id_fk": {
+          "name": "im_channels_section_id_im_channel_sections_id_fk",
+          "tableFrom": "im_channels",
+          "tableTo": "im_channel_sections",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_email_verification_tokens": {
+      "name": "im_email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_verification_tokens_user_id": {
+          "name": "idx_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verification_tokens_token": {
+          "name": "idx_verification_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verification_tokens_expires_at": {
+          "name": "idx_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_email_verification_tokens_user_id_im_users_id_fk": {
+          "name": "im_email_verification_tokens_user_id_im_users_id_fk",
+          "tableFrom": "im_email_verification_tokens",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_email_verification_tokens_token_unique": {
+          "name": "im_email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_files": {
+      "name": "im_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "file_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_files_key": {
+          "name": "idx_files_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_tenant": {
+          "name": "idx_files_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_channel": {
+          "name": "idx_files_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_uploader": {
+          "name": "idx_files_uploader",
+          "columns": [
+            {
+              "expression": "uploader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_files_tenant_id_tenants_id_fk": {
+          "name": "im_files_tenant_id_tenants_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_files_channel_id_im_channels_id_fk": {
+          "name": "im_files_channel_id_im_channels_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_files_uploader_id_im_users_id_fk": {
+          "name": "im_files_uploader_id_im_users_id_fk",
+          "tableFrom": "im_files",
+          "tableTo": "im_users",
+          "columnsFrom": ["uploader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_hive_send_failures": {
+      "name": "im_hive_send_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_channel_id": {
+          "name": "tracking_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hive_send_failures_msg_bot_unique": {
+          "name": "hive_send_failures_msg_bot_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_agent_idx": {
+          "name": "hive_send_failures_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_tenant_idx": {
+          "name": "hive_send_failures_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hive_send_failures_last_seen_idx": {
+          "name": "hive_send_failures_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_hive_send_failures_message_id_im_messages_id_fk": {
+          "name": "im_hive_send_failures_message_id_im_messages_id_fk",
+          "tableFrom": "im_hive_send_failures",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_hive_send_failures_bot_id_im_bots_id_fk": {
+          "name": "im_hive_send_failures_bot_id_im_bots_id_fk",
+          "tableFrom": "im_hive_send_failures",
+          "tableTo": "im_bots",
+          "columnsFrom": ["bot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_users": {
+      "name": "im_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'human'"
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_users_email_unique": {
+          "name": "im_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "im_users_username_unique": {
+          "name": "im_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_email_change_requests": {
+      "name": "im_user_email_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_email": {
+          "name": "current_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_email_change_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_email_change_requests_user_id": {
+          "name": "idx_user_email_change_requests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_email_change_requests_status": {
+          "name": "idx_user_email_change_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_email_change_requests_expires_at": {
+          "name": "idx_user_email_change_requests_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_user_email_change_requests_pending_user": {
+          "name": "uq_user_email_change_requests_pending_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_user_email_change_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_user_email_change_requests_pending_new_email": {
+          "name": "uq_user_email_change_requests_pending_new_email",
+          "columns": [
+            {
+              "expression": "new_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_user_email_change_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_email_change_requests_user_id_im_users_id_fk": {
+          "name": "im_user_email_change_requests_user_id_im_users_id_fk",
+          "tableFrom": "im_user_email_change_requests",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_user_email_change_requests_token_hash_unique": {
+          "name": "im_user_email_change_requests_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_id": {
+          "name": "root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_ast": {
+          "name": "content_ast",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_msg_id": {
+          "name": "client_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_messages_channel_id": {
+          "name": "idx_messages_channel_id",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_parent_id": {
+          "name": "idx_messages_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_root_id": {
+          "name": "idx_messages_root_id",
+          "columns": [
+            {
+              "expression": "root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_seq_id": {
+          "name": "idx_messages_seq_id",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_client_msg_id": {
+          "name": "idx_messages_client_msg_id",
+          "columns": [
+            {
+              "expression": "client_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_channel_id_im_channels_id_fk": {
+          "name": "im_messages_channel_id_im_channels_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_messages_sender_id_im_users_id_fk": {
+          "name": "im_messages_sender_id_im_users_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_users",
+          "columnsFrom": ["sender_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_attachments": {
+      "name": "im_message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_attachments_message_id": {
+          "name": "idx_message_attachments_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_attachments_message_id_im_messages_id_fk": {
+          "name": "im_message_attachments_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_attachments",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_reactions": {
+      "name": "im_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_message_reactions_message_id_im_messages_id_fk": {
+          "name": "im_message_reactions_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_reactions",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_reactions_user_id_im_users_id_fk": {
+          "name": "im_message_reactions_user_id_im_users_id_fk",
+          "tableFrom": "im_message_reactions",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "user_id", "emoji"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_acks": {
+      "name": "im_message_acks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ack_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_acks_message_id": {
+          "name": "idx_message_acks_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_user_id": {
+          "name": "idx_message_acks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_status": {
+          "name": "idx_message_acks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_acks_retry": {
+          "name": "idx_message_acks_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_acks_message_id_im_messages_id_fk": {
+          "name": "im_message_acks_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_acks",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_acks_user_id_im_users_id_fk": {
+          "name": "im_message_acks_user_id_im_users_id_fk",
+          "tableFrom": "im_message_acks",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_message_user_ack": {
+          "name": "unique_message_user_ack",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_outbox": {
+      "name": "im_message_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "outbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_outbox_status": {
+          "name": "idx_outbox_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_created": {
+          "name": "idx_outbox_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_message_id": {
+          "name": "idx_outbox_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_status_created": {
+          "name": "idx_outbox_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_outbox_message_id_im_messages_id_fk": {
+          "name": "im_message_outbox_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_outbox",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_channel_read_status": {
+      "name": "im_user_channel_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_seq_id": {
+          "name": "last_sync_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_user_channel_read_status_user_id_im_users_id_fk": {
+          "name": "im_user_channel_read_status_user_id_im_users_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_user_channel_read_status_channel_id_im_channels_id_fk": {
+          "name": "im_user_channel_read_status_channel_id_im_channels_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_user_channel_read_status_last_read_message_id_im_messages_id_fk": {
+          "name": "im_user_channel_read_status_last_read_message_id_im_messages_id_fk",
+          "tableFrom": "im_user_channel_read_status",
+          "tableTo": "im_messages",
+          "columnsFrom": ["last_read_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_channel_read": {
+          "name": "unique_user_channel_read",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_notifications": {
+      "name": "im_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "notification_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_category": {
+          "name": "idx_notifications_user_category",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_type": {
+          "name": "idx_notifications_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires": {
+          "name": "idx_notifications_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_reference": {
+          "name": "idx_notifications_reference",
+          "columns": [
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_message": {
+          "name": "idx_notifications_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_channel": {
+          "name": "idx_notifications_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_notifications_user_id_im_users_id_fk": {
+          "name": "im_notifications_user_id_im_users_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_actor_id_im_users_id_fk": {
+          "name": "im_notifications_actor_id_im_users_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_notifications_tenant_id_tenants_id_fk": {
+          "name": "im_notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_channel_id_im_channels_id_fk": {
+          "name": "im_notifications_channel_id_im_channels_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_notifications_message_id_im_messages_id_fk": {
+          "name": "im_notifications_message_id_im_messages_id_fk",
+          "tableFrom": "im_notifications",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_notification_mutes": {
+      "name": "im_channel_notification_mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_mutes_user": {
+          "name": "idx_channel_mutes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_mutes_channel": {
+          "name": "idx_channel_mutes_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_notification_mutes_user_id_im_users_id_fk": {
+          "name": "im_channel_notification_mutes_user_id_im_users_id_fk",
+          "tableFrom": "im_channel_notification_mutes",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_channel_notification_mutes_channel_id_im_channels_id_fk": {
+          "name": "im_channel_notification_mutes_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_notification_mutes",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_channel_notification_mute": {
+          "name": "unique_channel_notification_mute",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_notification_preferences": {
+      "name": "im_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions_enabled": {
+          "name": "mentions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "replies_enabled": {
+          "name": "replies_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dms_enabled": {
+          "name": "dms_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "system_enabled": {
+          "name": "system_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "workspace_enabled": {
+          "name": "workspace_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "desktop_enabled": {
+          "name": "desktop_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sound_enabled": {
+          "name": "sound_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dnd_enabled": {
+          "name": "dnd_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dnd_start": {
+          "name": "dnd_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dnd_end": {
+          "name": "dnd_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "im_notification_preferences_user_id_im_users_id_fk": {
+          "name": "im_notification_preferences_user_id_im_users_id_fk",
+          "tableFrom": "im_notification_preferences",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_notification_preferences": {
+          "name": "unique_user_notification_preferences",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_channel_search": {
+      "name": "im_channel_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_created_at": {
+          "name": "channel_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_search_vector": {
+          "name": "idx_channel_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_channel_search_tenant": {
+          "name": "idx_channel_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_search_type": {
+          "name": "idx_channel_search_type",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_channel_search_channel_id_im_channels_id_fk": {
+          "name": "im_channel_search_channel_id_im_channels_id_fk",
+          "tableFrom": "im_channel_search",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_channel_search_channel_id_unique": {
+          "name": "im_channel_search_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_file_search": {
+      "name": "im_file_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_username": {
+          "name": "uploader_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_file_search_vector": {
+          "name": "idx_file_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_file_search_channel": {
+          "name": "idx_file_search_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_file_search_tenant": {
+          "name": "idx_file_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_file_search_mime": {
+          "name": "idx_file_search_mime",
+          "columns": [
+            {
+              "expression": "mime_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_file_search_file_id_im_files_id_fk": {
+          "name": "im_file_search_file_id_im_files_id_fk",
+          "tableFrom": "im_file_search",
+          "tableTo": "im_files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_file_search_file_id_unique": {
+          "name": "im_file_search_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_search": {
+      "name": "im_message_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_username": {
+          "name": "sender_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_attachment": {
+          "name": "has_attachment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_thread_reply": {
+          "name": "is_thread_reply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_created_at": {
+          "name": "message_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_search_vector": {
+          "name": "idx_message_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_message_search_channel": {
+          "name": "idx_message_search_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_sender": {
+          "name": "idx_message_search_sender",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_tenant": {
+          "name": "idx_message_search_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_created": {
+          "name": "idx_message_search_created",
+          "columns": [
+            {
+              "expression": "message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_search_tenant_created": {
+          "name": "idx_message_search_tenant_created",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_search_message_id_im_messages_id_fk": {
+          "name": "im_message_search_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_search",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_message_search_message_id_unique": {
+          "name": "im_message_search_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["message_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_search": {
+      "name": "im_user_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_created_at": {
+          "name": "user_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_search_vector": {
+          "name": "idx_user_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_search_status": {
+          "name": "idx_user_search_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_search_user_id_im_users_id_fk": {
+          "name": "im_user_search_user_id_im_users_id_fk",
+          "tableFrom": "im_user_search",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "im_user_search_user_id_unique": {
+          "name": "im_user_search_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_installed_applications": {
+      "name": "im_installed_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "installed_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_installed_applications_tenant_id": {
+          "name": "idx_installed_applications_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_installed_applications_application_id": {
+          "name": "idx_installed_applications_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_installed_applications_status": {
+          "name": "idx_installed_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_installed_applications_installed_by_im_users_id_fk": {
+          "name": "im_installed_applications_installed_by_im_users_id_fk",
+          "tableFrom": "im_installed_applications",
+          "tableTo": "im_users",
+          "columnsFrom": ["installed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_push_subscriptions": {
+      "name": "im_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_push_sub_user": {
+          "name": "idx_push_sub_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_push_subscriptions_user_id_im_users_id_fk": {
+          "name": "im_push_subscriptions_user_id_im_users_id_fk",
+          "tableFrom": "im_push_subscriptions",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_push_endpoint": {
+          "name": "unique_push_endpoint",
+          "nullsNotDistinct": false,
+          "columns": ["endpoint"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_user_push_tokens": {
+      "name": "im_user_push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "push_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_push_tokens_user_id": {
+          "name": "idx_user_push_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_user_push_tokens_user_id_im_users_id_fk": {
+          "name": "im_user_push_tokens_user_id_im_users_id_fk",
+          "tableFrom": "im_user_push_tokens",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_push_token": {
+          "name": "uq_user_push_token",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_properties": {
+      "name": "im_message_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_definition_id": {
+          "name": "property_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_value": {
+          "name": "number_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean_value": {
+          "name": "boolean_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_value": {
+          "name": "date_value",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "json_value": {
+          "name": "json_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_props_message": {
+          "name": "idx_message_props_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_text": {
+          "name": "idx_message_props_def_text",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_number": {
+          "name": "idx_message_props_def_number",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_date": {
+          "name": "idx_message_props_def_date",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_props_def_boolean": {
+          "name": "idx_message_props_def_boolean",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "boolean_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_properties_message_id_im_messages_id_fk": {
+          "name": "im_message_properties_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_property_definition_id_im_channel_property_definitions_id_fk": {
+          "name": "im_message_properties_property_definition_id_im_channel_property_definitions_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_channel_property_definitions",
+          "columnsFrom": ["property_definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_created_by_im_users_id_fk": {
+          "name": "im_message_properties_created_by_im_users_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "im_message_properties_updated_by_im_users_id_fk": {
+          "name": "im_message_properties_updated_by_im_users_id_fk",
+          "tableFrom": "im_message_properties",
+          "tableTo": "im_users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_message_property": {
+          "name": "uq_message_property",
+          "nullsNotDistinct": false,
+          "columns": ["message_id", "property_definition_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.im_message_relations": {
+      "name": "im_message_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_message_id": {
+          "name": "target_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_definition_id": {
+          "name": "property_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_kind": {
+          "name": "relation_kind",
+          "type": "relation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mr_source_kind": {
+          "name": "idx_mr_source_kind",
+          "columns": [
+            {
+              "expression": "source_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_target_kind": {
+          "name": "idx_mr_target_kind",
+          "columns": [
+            {
+              "expression": "target_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_channel_kind": {
+          "name": "idx_mr_channel_kind",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mr_propdef": {
+          "name": "idx_mr_propdef",
+          "columns": [
+            {
+              "expression": "property_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_relations_tenant_id_tenants_id_fk": {
+          "name": "im_message_relations_tenant_id_tenants_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_channel_id_im_channels_id_fk": {
+          "name": "im_message_relations_channel_id_im_channels_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_source_message_id_im_messages_id_fk": {
+          "name": "im_message_relations_source_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_messages",
+          "columnsFrom": ["source_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_target_message_id_im_messages_id_fk": {
+          "name": "im_message_relations_target_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_messages",
+          "columnsFrom": ["target_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_property_definition_id_im_channel_property_definitions_id_fk": {
+          "name": "im_message_relations_property_definition_id_im_channel_property_definitions_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_channel_property_definitions",
+          "columnsFrom": ["property_definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_message_relations_created_by_im_users_id_fk": {
+          "name": "im_message_relations_created_by_im_users_id_fk",
+          "tableFrom": "im_message_relations",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_message_relation_edge": {
+          "name": "uq_message_relation_edge",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_message_id",
+            "property_definition_id",
+            "target_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_message_relation_no_self": {
+          "name": "chk_message_relation_no_self",
+          "value": "\"im_message_relations\".\"source_message_id\" <> \"im_message_relations\".\"target_message_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "tenant_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenants_domain_unique": {
+          "name": "tenants_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_members": {
+      "name": "tenant_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_tenant_members_user_id": {
+          "name": "idx_tenant_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_members_tenant_id_tenants_id_fk": {
+          "name": "tenant_members_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_members_user_id_im_users_id_fk": {
+          "name": "tenant_members_user_id_im_users_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_members_invited_by_im_users_id_fk": {
+          "name": "tenant_members_invited_by_im_users_id_fk",
+          "tableFrom": "tenant_members",
+          "tableTo": "im_users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_tenant_user": {
+          "name": "unique_tenant_user",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_usage": {
+      "name": "invitation_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_usage_invitation_id_workspace_invitations_id_fk": {
+          "name": "invitation_usage_invitation_id_workspace_invitations_id_fk",
+          "tableFrom": "invitation_usage",
+          "tableTo": "workspace_invitations",
+          "columnsFrom": ["invitation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_usage_user_id_im_users_id_fk": {
+          "name": "invitation_usage_user_id_im_users_id_fk",
+          "tableFrom": "invitation_usage",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_tenant_id": {
+          "name": "idx_workspace_invitations_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_tenant_id_tenants_id_fk": {
+          "name": "workspace_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_created_by_im_users_id_fk": {
+          "name": "workspace_invitations_created_by_im_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "im_users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_code_unique": {
+          "name": "workspace_invitations_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_roles": {
+      "name": "onboarding_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_key": {
+          "name": "category_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_roles_category_idx": {
+          "name": "onboarding_roles_category_idx",
+          "columns": [
+            {
+              "expression": "category_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_roles_active_idx": {
+          "name": "onboarding_roles_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "onboarding_roles_slug_unique": {
+          "name": "onboarding_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_onboarding": {
+      "name": "workspace_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "step_data": {
+          "name": "step_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_onboarding_tenant_idx": {
+          "name": "workspace_onboarding_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_onboarding_user_idx": {
+          "name": "workspace_onboarding_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_onboarding_tenant_id_tenants_id_fk": {
+          "name": "workspace_onboarding_tenant_id_tenants_id_fk",
+          "tableFrom": "workspace_onboarding",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_onboarding_user_id_im_users_id_fk": {
+          "name": "workspace_onboarding_user_id_im_users_id_fk",
+          "tableFrom": "workspace_onboarding",
+          "tableTo": "im_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_onboarding_tenant_user_unique": {
+          "name": "workspace_onboarding_tenant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__routines": {
+      "name": "routine__routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "routine__schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'once'"
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_execution_id": {
+          "name": "current_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_channel_id": {
+          "name": "creation_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_session_id": {
+          "name": "creation_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__routines_tenant_id": {
+          "name": "idx_routine__routines_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_bot_id": {
+          "name": "idx_routine__routines_bot_id",
+          "columns": [
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_creator_id": {
+          "name": "idx_routine__routines_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_status": {
+          "name": "idx_routine__routines_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_next_run_at": {
+          "name": "idx_routine__routines_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_tenant_status": {
+          "name": "idx_routine__routines_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_creation_channel_id": {
+          "name": "idx_routine__routines_creation_channel_id",
+          "columns": [
+            {
+              "expression": "creation_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__routines_source_ref": {
+          "name": "idx_routine__routines_source_ref",
+          "columns": [
+            {
+              "expression": "source_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__routines_tenant_id_tenants_id_fk": {
+          "name": "routine__routines_tenant_id_tenants_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__routines_bot_id_im_bots_id_fk": {
+          "name": "routine__routines_bot_id_im_bots_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_bots",
+          "columnsFrom": ["bot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__routines_creator_id_im_users_id_fk": {
+          "name": "routine__routines_creator_id_im_users_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__routines_document_id_documents_id_fk": {
+          "name": "routine__routines_document_id_documents_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__routines_creation_channel_id_im_channels_id_fk": {
+          "name": "routine__routines_creation_channel_id_im_channels_id_fk",
+          "tableFrom": "routine__routines",
+          "tableTo": "im_channels",
+          "columnsFrom": ["creation_channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__executions": {
+      "name": "routine__executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_version": {
+          "name": "routine_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskcast_task_id": {
+          "name": "taskcast_task_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_execution_id": {
+          "name": "source_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__executions_routine_id": {
+          "name": "idx_routine__executions_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__executions_status": {
+          "name": "idx_routine__executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__executions_routine_version": {
+          "name": "idx_routine__executions_routine_version",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "routine_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__executions_routine_id_routine__routines_id_fk": {
+          "name": "routine__executions_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__executions_channel_id_im_channels_id_fk": {
+          "name": "routine__executions_channel_id_im_channels_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "im_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__executions_trigger_id_routine__triggers_id_fk": {
+          "name": "routine__executions_trigger_id_routine__triggers_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "routine__triggers",
+          "columnsFrom": ["trigger_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__executions_document_version_id_document_versions_id_fk": {
+          "name": "routine__executions_document_version_id_document_versions_id_fk",
+          "tableFrom": "routine__executions",
+          "tableTo": "document_versions",
+          "columnsFrom": ["document_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_routine__executions_taskcast": {
+          "name": "uq_routine__executions_taskcast",
+          "nullsNotDistinct": false,
+          "columns": ["taskcast_task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__steps": {
+      "name": "routine__steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__steps_execution_id": {
+          "name": "idx_routine__steps_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__steps_routine_id": {
+          "name": "idx_routine__steps_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__steps_execution_id_routine__executions_id_fk": {
+          "name": "routine__steps_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__steps",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__steps_routine_id_routine__routines_id_fk": {
+          "name": "routine__steps_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__steps",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__deliverables": {
+      "name": "routine__deliverables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__deliverables_execution_id": {
+          "name": "idx_routine__deliverables_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__deliverables_routine_id": {
+          "name": "idx_routine__deliverables_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__deliverables_execution_id_routine__executions_id_fk": {
+          "name": "routine__deliverables_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__deliverables",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__deliverables_routine_id_routine__routines_id_fk": {
+          "name": "routine__deliverables_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__deliverables",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__interventions": {
+      "name": "routine__interventions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "routine__intervention_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__interventions_execution_id": {
+          "name": "idx_routine__interventions_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__interventions_routine_id": {
+          "name": "idx_routine__interventions_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__interventions_status": {
+          "name": "idx_routine__interventions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__interventions_execution_id_routine__executions_id_fk": {
+          "name": "routine__interventions_execution_id_routine__executions_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_routine_id_routine__routines_id_fk": {
+          "name": "routine__interventions_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_step_id_routine__steps_id_fk": {
+          "name": "routine__interventions_step_id_routine__steps_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "routine__steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine__interventions_resolved_by_im_users_id_fk": {
+          "name": "routine__interventions_resolved_by_im_users_id_fk",
+          "tableFrom": "routine__interventions",
+          "tableTo": "im_users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine__triggers": {
+      "name": "routine__triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "routine__trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routine__triggers_routine_id": {
+          "name": "idx_routine__triggers_routine_id",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routine__triggers_scan": {
+          "name": "idx_routine__triggers_scan",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine__triggers_routine_id_routine__routines_id_fk": {
+          "name": "routine__triggers_routine_id_routine__routines_id_fk",
+          "tableFrom": "routine__triggers",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource__type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "authorizations": {
+          "name": "authorizations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_tenant_id": {
+          "name": "idx_resources_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_tenant_type": {
+          "name": "idx_resources_tenant_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_status": {
+          "name": "idx_resources_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_tenant_id_tenants_id_fk": {
+          "name": "resources_tenant_id_tenants_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_creator_id_im_users_id_fk": {
+          "name": "resources_creator_id_im_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_usage_logs": {
+      "name": "resource_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "resource__actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resource_usage_logs_resource_created": {
+          "name": "idx_resource_usage_logs_resource_created",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resource_usage_logs_actor_created": {
+          "name": "idx_resource_usage_logs_actor_created",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_usage_logs_resource_id_resources_id_fk": {
+          "name": "resource_usage_logs_resource_id_resources_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_usage_logs_routine_id_routine__routines_id_fk": {
+          "name": "resource_usage_logs_routine_id_routine__routines_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "routine__routines",
+          "columnsFrom": ["routine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "resource_usage_logs_execution_id_routine__executions_id_fk": {
+          "name": "resource_usage_logs_execution_id_routine__executions_id_fk",
+          "tableFrom": "resource_usage_logs",
+          "tableTo": "routine__executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "skill__type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_tenant_id": {
+          "name": "idx_skills_tenant_id",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_tenant_id_tenants_id_fk": {
+          "name": "skills_tenant_id_tenants_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skills_creator_id_im_users_id_fk": {
+          "name": "skills_creator_id_im_users_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_versions": {
+      "name": "skill_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "skill_version__status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "file_manifest": {
+          "name": "file_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_versions_skill_version": {
+          "name": "idx_skill_versions_skill_version",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_versions_skill_id_skills_id_fk": {
+          "name": "skill_versions_skill_id_skills_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "skills",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_versions_creator_id_im_users_id_fk": {
+          "name": "skill_versions_creator_id_im_users_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "im_users",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_files": {
+      "name": "skill_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_files_skill_id": {
+          "name": "idx_skill_files_skill_id",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_files_skill_id_skills_id_fk": {
+          "name": "skill_files_skill_id_skills_id_fk",
+          "tableFrom": "skill_files",
+          "tableTo": "skills",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_wikis": {
+      "name": "workspace_wikis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder9_folder_id": {
+          "name": "folder9_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_mode": {
+          "name": "approval_mode",
+          "type": "wiki_approval_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "human_permission": {
+          "name": "human_permission",
+          "type": "wiki_permission_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'write'"
+        },
+        "agent_permission": {
+          "name": "agent_permission",
+          "type": "wiki_permission_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_wikis_workspace_slug_unique": {
+          "name": "workspace_wikis_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_wikis\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_wikis_folder9_unique": {
+          "name": "workspace_wikis_folder9_unique",
+          "columns": [
+            {
+              "expression": "folder9_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_wikis_workspace_idx": {
+          "name": "workspace_wikis_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_wikis_workspace_id_tenants_id_fk": {
+          "name": "workspace_wikis_workspace_id_tenants_id_fk",
+          "tableFrom": "workspace_wikis",
+          "tableTo": "tenants",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_suggestion_status": {
+      "name": "document_suggestion_status",
+      "schema": "public",
+      "values": ["pending", "approved", "rejected"]
+    },
+    "public.bot_type": {
+      "name": "bot_type",
+      "schema": "public",
+      "values": ["system", "custom", "webhook"]
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member"]
+    },
+    "public.property_value_type": {
+      "name": "property_value_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "number",
+        "boolean",
+        "single_select",
+        "multi_select",
+        "person",
+        "date",
+        "timestamp",
+        "date_range",
+        "timestamp_range",
+        "recurring",
+        "url",
+        "message_ref",
+        "file",
+        "image",
+        "tags"
+      ]
+    },
+    "public.channel_type": {
+      "name": "channel_type",
+      "schema": "public",
+      "values": [
+        "direct",
+        "public",
+        "private",
+        "task",
+        "tracking",
+        "echo",
+        "routine-session",
+        "topic-session"
+      ]
+    },
+    "public.file_visibility": {
+      "name": "file_visibility",
+      "schema": "public",
+      "values": ["private", "channel", "workspace", "public"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["online", "offline", "away", "busy"]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": ["human", "bot", "system"]
+    },
+    "public.user_email_change_request_status": {
+      "name": "user_email_change_request_status",
+      "schema": "public",
+      "values": ["pending", "confirmed", "cancelled", "expired"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["text", "file", "image", "system", "tracking", "long_text"]
+    },
+    "public.ack_status": {
+      "name": "ack_status",
+      "schema": "public",
+      "values": ["sent", "delivered", "read"]
+    },
+    "public.outbox_status": {
+      "name": "outbox_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.notification_category": {
+      "name": "notification_category",
+      "schema": "public",
+      "values": ["message", "system", "workspace"]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": ["low", "normal", "high", "urgent"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "mention",
+        "channel_mention",
+        "everyone_mention",
+        "here_mention",
+        "reply",
+        "thread_reply",
+        "dm_received",
+        "system_announcement",
+        "maintenance_notice",
+        "version_update",
+        "workspace_invitation",
+        "role_changed",
+        "member_joined",
+        "member_left",
+        "channel_invite"
+      ]
+    },
+    "public.installed_application_status": {
+      "name": "installed_application_status",
+      "schema": "public",
+      "values": ["active", "inactive", "pending", "error"]
+    },
+    "public.push_platform": {
+      "name": "push_platform",
+      "schema": "public",
+      "values": ["ios", "android"]
+    },
+    "public.relation_kind": {
+      "name": "relation_kind",
+      "schema": "public",
+      "values": ["parent", "related"]
+    },
+    "public.tenant_plan": {
+      "name": "tenant_plan",
+      "schema": "public",
+      "values": ["free", "pro", "enterprise"]
+    },
+    "public.tenant_role": {
+      "name": "tenant_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "guest"]
+    },
+    "public.routine__schedule_type": {
+      "name": "routine__schedule_type",
+      "schema": "public",
+      "values": ["once", "recurring"]
+    },
+    "public.routine__status": {
+      "name": "routine__status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "upcoming",
+        "in_progress",
+        "paused",
+        "pending_action",
+        "completed",
+        "failed",
+        "stopped",
+        "timeout"
+      ]
+    },
+    "public.routine__step_status": {
+      "name": "routine__step_status",
+      "schema": "public",
+      "values": ["pending", "in_progress", "completed", "failed"]
+    },
+    "public.routine__intervention_status": {
+      "name": "routine__intervention_status",
+      "schema": "public",
+      "values": ["pending", "resolved", "expired"]
+    },
+    "public.routine__trigger_type": {
+      "name": "routine__trigger_type",
+      "schema": "public",
+      "values": ["manual", "interval", "schedule", "channel_message"]
+    },
+    "public.resource__status": {
+      "name": "resource__status",
+      "schema": "public",
+      "values": ["online", "offline", "error", "configuring"]
+    },
+    "public.resource__type": {
+      "name": "resource__type",
+      "schema": "public",
+      "values": ["agent_computer", "api"]
+    },
+    "public.resource__actor_type": {
+      "name": "resource__actor_type",
+      "schema": "public",
+      "values": ["agent", "user"]
+    },
+    "public.skill__type": {
+      "name": "skill__type",
+      "schema": "public",
+      "values": ["claude_code_skill", "prompt_template", "general"]
+    },
+    "public.skill_version__status": {
+      "name": "skill_version__status",
+      "schema": "public",
+      "values": ["draft", "published", "suggested", "rejected"]
+    },
+    "public.wiki_approval_mode": {
+      "name": "wiki_approval_mode",
+      "schema": "public",
+      "values": ["auto", "review"]
+    },
+    "public.wiki_permission_level": {
+      "name": "wiki_permission_level",
+      "schema": "public",
+      "values": ["read", "propose", "write"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/libs/database/migrations/meta/_journal.json
+++ b/apps/server/libs/database/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1777795200001,
       "tag": "0056_quick_justice",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1777575466136,
+      "tag": "0057_yielding_radioactive_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.schema.spec.ts
+++ b/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.schema.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Structural smoke tests for workspace_folder_mounts.
+ *
+ * The session scope stores the full team9 sessionId in scope_id. Real
+ * sessionIds include tenantId + agentId + scope + channel/topic/routine id,
+ * so the column must be wider than a single UUID-shaped identifier.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as schema from '../index.js';
+
+describe('workspace_folder_mounts schema', () => {
+  it('allows full team9 sessionIds in scopeId', () => {
+    const maxObservedSessionIdLength =
+      'team9/019c23cb-7920-7742-bd40-abb445d1c8eb/common-staff-019dc2ac-655e-7189-82d3-171e26bb1223/dm/019ddd76-5b08-7551-9a9e-92739dd89d22'
+        .length;
+    const configuredLength = (
+      schema.workspaceFolderMounts.scopeId as unknown as {
+        config: { length: number };
+      }
+    ).config.length;
+
+    expect(configuredLength).toBeGreaterThanOrEqual(maxObservedSessionIdLength);
+  });
+});

--- a/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.ts
+++ b/apps/server/libs/database/src/schemas/folder9/workspace-folder-mounts.ts
@@ -27,7 +27,7 @@ export const workspaceFolderMounts = pgTable(
     /** 'session' | 'agent' | 'routine' | 'user' */
     scope: varchar('scope', { length: 32 }).notNull(),
     /** sessionId / botId / routineId / userId */
-    scopeId: varchar('scope_id', { length: 128 }).notNull(),
+    scopeId: varchar('scope_id', { length: 256 }).notNull(),
     /** 'tmp' | 'home' | 'document' (room for future) */
     mountKey: varchar('mount_key', { length: 32 }).notNull(),
     /** 'light' | 'managed' — denormalized so subsequent operations don't

--- a/docs/superpowers/plans/2026-05-01-tool-events-standard.md
+++ b/docs/superpowers/plans/2026-05-01-tool-events-standard.md
@@ -1,0 +1,1071 @@
+# Tool Events Standard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize Team9 tool-call events so failed tools display as failed, running tools appear before final results, and expanded tool details show complete arguments/results.
+
+**Architecture:** Add a shared frontend normalization layer for tool event display, then route `ToolCallBlock`, `MessageList`, `TrackingCard`, and `TrackingEventItem` through it. Add a server-side metadata normalizer at message ingestion so new `tool_result` messages consistently include `success`, `errorMessage`, and related standard fields while preserving existing `tool_call` / `tool_result` rows.
+
+**Tech Stack:** React 19, TypeScript, Vitest, NestJS, Drizzle-backed IM messages, Socket.io streaming events.
+
+---
+
+## File Structure
+
+- Create `apps/client/src/lib/tool-events.ts`
+  - Frontend-only helper for unwrapping result content, detecting legacy failures, deriving display status, and building stable display data for `ToolCallBlock`.
+- Create `apps/client/src/lib/__tests__/tool-events.test.ts`
+  - Unit coverage for success/failure priority, wrapped result parsing, running state, and arg text fallback.
+- Modify `apps/client/src/types/im.ts`
+  - Extend `AgentEventMetadata` with optional `toolArgsText`, `toolPhase`, `errorCode`, `errorMessage`, `resultTruncated`, `fullContentMessageId`, `completedAt`, and `updatedAt`.
+- Modify `apps/client/src/lib/agent-event-metadata.ts`
+  - Preserve the new optional metadata fields when normalizing tracking snapshots.
+- Modify `apps/client/src/components/channel/ToolCallBlock.tsx`
+  - Render from `buildToolDisplayState()`, support optional result metadata/content, show running cards, and fetch full result content on expand when a result message is truncated.
+- Modify `apps/client/src/components/channel/__tests__/ToolCallBlock.test.tsx`
+  - Add regression coverage for `success:false`, wrapped legacy failures, running calls, streamed arg text, and full-content fetch.
+- Modify `apps/client/src/components/channel/MessageList.tsx`
+  - Render standalone running `tool_call` messages with `ToolCallBlock`, not generic `TrackingEventItem`.
+- Modify `apps/client/src/components/channel/TrackingCard.tsx`
+  - Render unpaired active/running `tool_call` items with `ToolCallBlock`.
+- Modify `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.ts`
+  - Server helper that standardizes tool-result metadata at ingestion.
+- Modify `apps/server/apps/gateway/src/im/messages/messages.controller.ts`
+  - Normalize metadata before sending create-message requests to im-worker.
+- Add `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts`
+  - Unit coverage for status/success normalization and legacy result parsing.
+- Modify `docs/superpowers/specs/2026-05-01-tool-events-design.md` only if implementation discovers a deliberate contract change.
+
+Keep existing uncommitted `apps/server/apps/gateway/src/routines/*` changes out of all commits for this plan.
+
+---
+
+### Task 1: Frontend Tool Event Normalization
+
+**Files:**
+
+- Create: `apps/client/src/lib/tool-events.ts`
+- Create: `apps/client/src/lib/__tests__/tool-events.test.ts`
+- Modify: `apps/client/src/types/im.ts`
+- Modify: `apps/client/src/lib/agent-event-metadata.ts`
+
+- [ ] **Step 1: Extend `AgentEventMetadata` types**
+
+In `apps/client/src/types/im.ts`, add these optional fields after `toolArgs?: Record<string, unknown>;`:
+
+```ts
+  toolArgsText?: string;
+  toolPhase?: "args_streaming" | "executing";
+```
+
+Add these optional result fields after `success?: boolean;`:
+
+```ts
+  errorCode?: string;
+  errorMessage?: string;
+  resultTruncated?: boolean;
+  fullContentMessageId?: string;
+  completedAt?: string;
+  updatedAt?: string;
+```
+
+- [ ] **Step 2: Preserve new fields in snapshot metadata normalization**
+
+In `apps/client/src/lib/agent-event-metadata.ts`, add these spreads inside the returned object in `getAgentEventMetadata()`:
+
+```ts
+    ...(typeof value.toolArgsText === "string"
+      ? { toolArgsText: value.toolArgsText }
+      : {}),
+    ...(value.toolPhase === "args_streaming" || value.toolPhase === "executing"
+      ? { toolPhase: value.toolPhase }
+      : {}),
+    ...(typeof value.errorCode === "string"
+      ? { errorCode: value.errorCode }
+      : {}),
+    ...(typeof value.errorMessage === "string"
+      ? { errorMessage: value.errorMessage }
+      : {}),
+    ...(typeof value.resultTruncated === "boolean"
+      ? { resultTruncated: value.resultTruncated }
+      : {}),
+    ...(typeof value.fullContentMessageId === "string"
+      ? { fullContentMessageId: value.fullContentMessageId }
+      : {}),
+    ...(typeof value.completedAt === "string"
+      ? { completedAt: value.completedAt }
+      : {}),
+    ...(typeof value.updatedAt === "string" ? { updatedAt: value.updatedAt } : {}),
+```
+
+- [ ] **Step 3: Write failing normalization tests**
+
+Create `apps/client/src/lib/__tests__/tool-events.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildToolDisplayState, unwrapToolResultContent } from "../tool-events";
+import type { AgentEventMetadata } from "@/types/im";
+
+function callMeta(
+  overrides: Partial<AgentEventMetadata> = {},
+): AgentEventMetadata {
+  return {
+    agentEventType: "tool_call",
+    status: "running",
+    toolCallId: "tc-1",
+    toolName: "send_message",
+    toolArgs: { message: "hello" },
+    ...overrides,
+  };
+}
+
+function resultMeta(
+  overrides: Partial<AgentEventMetadata> = {},
+): AgentEventMetadata {
+  return {
+    agentEventType: "tool_result",
+    status: "completed",
+    toolCallId: "tc-1",
+    success: true,
+    ...overrides,
+  };
+}
+
+describe("unwrapToolResultContent", () => {
+  it("unwraps text blocks from tool result content wrappers", () => {
+    const raw = JSON.stringify({
+      content: [{ type: "text", text: '{"success":false}' }],
+      details: {},
+    });
+
+    expect(unwrapToolResultContent(raw)).toBe('{"success":false}');
+  });
+});
+
+describe("buildToolDisplayState", () => {
+  it("treats success false as failure even when status is completed", () => {
+    const state = buildToolDisplayState({
+      callMetadata: callMeta(),
+      resultMetadata: resultMeta({ success: false }),
+      resultContent: '{"ok":false}',
+    });
+
+    expect(state.status).toBe("error");
+    expect(state.isError).toBe(true);
+    expect(state.indicator).toBe("cross");
+  });
+
+  it("detects legacy wrapped success false payloads as failure", () => {
+    const wrapped = JSON.stringify({
+      content: [{ type: "text", text: '{"success":false,"error":"denied"}' }],
+    });
+
+    const state = buildToolDisplayState({
+      callMetadata: callMeta(),
+      resultMetadata: resultMeta({ success: undefined }),
+      resultContent: wrapped,
+    });
+
+    expect(state.status).toBe("error");
+    expect(state.errorMessage).toBe("denied");
+  });
+
+  it("renders a missing result as running", () => {
+    const state = buildToolDisplayState({
+      callMetadata: callMeta({ toolArgsText: '{"message":"hel' }),
+    });
+
+    expect(state.status).toBe("loading");
+    expect(state.isRunning).toBe(true);
+    expect(state.argsText).toBe('{"message":"hel');
+  });
+
+  it("uses completed result as success when no failure evidence exists", () => {
+    const state = buildToolDisplayState({
+      callMetadata: callMeta(),
+      resultMetadata: resultMeta({ success: true }),
+      resultContent: '{"success":true}',
+    });
+
+    expect(state.status).toBe("success");
+    expect(state.isSuccess).toBe(true);
+    expect(state.indicator).toBe("check");
+  });
+});
+```
+
+- [ ] **Step 4: Run the failing frontend tests**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/lib/__tests__/tool-events.test.ts
+```
+
+Expected: fail because `apps/client/src/lib/tool-events.ts` does not exist.
+
+- [ ] **Step 5: Implement `tool-events.ts`**
+
+Create `apps/client/src/lib/tool-events.ts`:
+
+```ts
+import { formatParams } from "@/config/toolParamConfig";
+import type { StatusType } from "@/config/toolLabels";
+import type { AgentEventMetadata } from "@/types/im";
+
+export type ToolIndicator = "check" | "cross" | "none";
+
+export interface ToolDisplayState {
+  toolName: string;
+  status: StatusType;
+  isRunning: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  indicator: ToolIndicator;
+  argsSummary: string;
+  argsText: string;
+  resultText: string;
+  errorMessage?: string;
+}
+
+interface BuildToolDisplayStateInput {
+  callMetadata: AgentEventMetadata;
+  resultMetadata?: AgentEventMetadata;
+  resultContent?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+export function unwrapToolResultContent(raw = ""): string {
+  const parsed = tryParseJson(raw);
+  if (isRecord(parsed) && Array.isArray(parsed.content)) {
+    const texts = parsed.content
+      .filter((block): block is { type: string; text: string } => {
+        return (
+          isRecord(block) &&
+          block.type === "text" &&
+          typeof block.text === "string"
+        );
+      })
+      .map((block) => block.text);
+    if (texts.length > 0) return texts.join("\n");
+  }
+  return raw;
+}
+
+function findFailure(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (payload.success === false) {
+    if (typeof payload.errorMessage === "string") return payload.errorMessage;
+    if (typeof payload.error === "string") return payload.error;
+    return "Tool returned success=false";
+  }
+  if (typeof payload.errorMessage === "string") return payload.errorMessage;
+  if (typeof payload.error === "string") return payload.error;
+  return undefined;
+}
+
+function detectLegacyFailure(resultText: string): string | undefined {
+  const parsed = tryParseJson(resultText);
+  return findFailure(parsed);
+}
+
+function formatArgs(toolName: string, metadata: AgentEventMetadata): string {
+  if (metadata.toolArgs) return formatParams(toolName, metadata.toolArgs);
+  return metadata.toolArgsText ?? "";
+}
+
+export function buildToolDisplayState({
+  callMetadata,
+  resultMetadata,
+  resultContent = "",
+}: BuildToolDisplayStateInput): ToolDisplayState {
+  const toolName =
+    callMetadata.toolName ?? resultMetadata?.toolName ?? "Unknown tool";
+  const resultText = unwrapToolResultContent(resultContent);
+  const explicitFailure =
+    resultMetadata?.success === false ||
+    resultMetadata?.status === "failed" ||
+    resultMetadata?.status === "cancelled" ||
+    resultMetadata?.status === "timeout";
+  const legacyFailure = resultText
+    ? detectLegacyFailure(resultText)
+    : undefined;
+  const errorMessage =
+    resultMetadata?.errorMessage ?? legacyFailure ?? undefined;
+
+  const status: StatusType =
+    !resultMetadata || resultMetadata.status === "running"
+      ? "loading"
+      : explicitFailure || legacyFailure
+        ? "error"
+        : "success";
+
+  return {
+    toolName,
+    status,
+    isRunning: status === "loading",
+    isError: status === "error",
+    isSuccess: status === "success",
+    indicator:
+      status === "success" ? "check" : status === "error" ? "cross" : "none",
+    argsSummary: formatArgs(toolName, callMetadata),
+    argsText: callMetadata.toolArgs
+      ? JSON.stringify(callMetadata.toolArgs, null, 2)
+      : (callMetadata.toolArgsText ?? ""),
+    resultText,
+    ...(errorMessage ? { errorMessage } : {}),
+  };
+}
+```
+
+- [ ] **Step 6: Run normalization tests until green**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/lib/__tests__/tool-events.test.ts
+```
+
+Expected: pass with 4 tests.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add apps/client/src/types/im.ts apps/client/src/lib/agent-event-metadata.ts apps/client/src/lib/tool-events.ts apps/client/src/lib/__tests__/tool-events.test.ts
+git commit -m "feat(client): normalize tool event display state"
+```
+
+Expected: commit includes only the four frontend normalization files.
+
+---
+
+### Task 2: ToolCallBlock Uses Normalized State And Full Result Content
+
+**Files:**
+
+- Modify: `apps/client/src/components/channel/ToolCallBlock.tsx`
+- Modify: `apps/client/src/components/channel/__tests__/ToolCallBlock.test.tsx`
+
+- [ ] **Step 1: Add failing tests for failure priority and running state**
+
+In `apps/client/src/components/channel/__tests__/ToolCallBlock.test.tsx`, add these tests under `describe("status indicators", ...)`:
+
+```tsx
+it("shows failure when result success is false even if status is completed", () => {
+  render(
+    <ToolCallBlock
+      callMetadata={makeCallMeta("RunScript")}
+      resultMetadata={makeResultMeta("completed", { success: false })}
+      resultContent='{"success":false,"error":"script failed"}'
+    />,
+  );
+
+  expect(screen.getByText("Tool call failed")).toBeInTheDocument();
+  expect(screen.getByText("\u2718")).toBeInTheDocument();
+  expect(screen.queryByText("\u2714")).not.toBeInTheDocument();
+});
+
+it("shows failure when wrapped legacy result content has success false", () => {
+  const wrappedContent = JSON.stringify({
+    content: [
+      {
+        type: "text",
+        text: '{"success":false,"error":"permission denied"}',
+      },
+    ],
+  });
+
+  render(
+    <ToolCallBlock
+      callMetadata={makeCallMeta("RunScript")}
+      resultMetadata={makeResultMeta("completed", { success: undefined })}
+      resultContent={wrappedContent}
+    />,
+  );
+
+  expect(screen.getByText("Tool call failed")).toBeInTheDocument();
+  expect(screen.getByText("\u2718")).toBeInTheDocument();
+});
+
+it("renders a running tool call without result metadata", () => {
+  render(
+    <ToolCallBlock
+      callMetadata={makeCallMeta("RunScript", undefined, {
+        status: "running",
+        toolArgsText: '{"cmd":"pnpm test',
+      })}
+      resultContent=""
+    />,
+  );
+
+  expect(screen.getByText("Calling tool")).toBeInTheDocument();
+  expect(screen.queryByText("\u2714")).not.toBeInTheDocument();
+  expect(screen.queryByText("\u2718")).not.toBeInTheDocument();
+  expect(screen.getByText(/RunScript/)).toBeInTheDocument();
+});
+```
+
+Update the local helper signatures in the same test file:
+
+```ts
+function makeCallMeta(
+  toolName: string,
+  toolArgs?: Record<string, unknown>,
+  overrides: Partial<AgentEventMetadata> = {},
+): AgentEventMetadata {
+  return {
+    agentEventType: "tool_call",
+    status: "completed",
+    toolName,
+    toolCallId: "tc-1",
+    toolArgs,
+    ...overrides,
+  };
+}
+
+function makeResultMeta(
+  status: "completed" | "failed" | "running" = "completed",
+  overrides: Partial<AgentEventMetadata> = {},
+): AgentEventMetadata {
+  return {
+    agentEventType: "tool_result",
+    status,
+    success: status === "completed",
+    toolCallId: "tc-1",
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 2: Run failing ToolCallBlock tests**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/components/channel/__tests__/ToolCallBlock.test.tsx
+```
+
+Expected: the new `success:false` and missing-result tests fail.
+
+- [ ] **Step 3: Update ToolCallBlock props and normalized rendering**
+
+In `apps/client/src/components/channel/ToolCallBlock.tsx`, change the props:
+
+```ts
+interface ToolCallBlockProps {
+  callMetadata: AgentEventMetadata;
+  resultMetadata?: AgentEventMetadata;
+  resultContent?: string;
+  resultMessage?: Pick<
+    Message,
+    "id" | "type" | "content" | "isTruncated" | "fullContentLength"
+  >;
+}
+```
+
+Add imports:
+
+```ts
+import { useFullContent } from "@/hooks/useMessages";
+import { buildToolDisplayState } from "@/lib/tool-events";
+import type { AgentEventMetadata, Message } from "@/types/im";
+```
+
+Replace local `unwrapResultContent()` and `deriveLabelStatus()` usage with:
+
+```ts
+const fullContentTargetId =
+  resultMetadata?.fullContentMessageId ??
+  (resultMessage?.isTruncated ? resultMessage.id : undefined);
+const shouldFetchFullContent = isExpanded && !!fullContentTargetId;
+const { data: fullContentData } = useFullContent(
+  fullContentTargetId,
+  shouldFetchFullContent,
+);
+const effectiveResultContent =
+  fullContentData?.content ?? resultContent ?? resultMessage?.content ?? "";
+const displayState = buildToolDisplayState({
+  callMetadata,
+  resultMetadata,
+  resultContent: effectiveResultContent,
+});
+const labelStatus = displayState.status;
+```
+
+Use these display-state fields:
+
+```ts
+const toolName = displayState.toolName;
+const paramsSummary = displayState.argsSummary;
+const displayLine = paramsSummary ? `${toolName}(${paramsSummary})` : toolName;
+const unwrapped = displayState.resultText;
+const indicatorChar =
+  displayState.indicator === "cross"
+    ? "\u2718"
+    : displayState.indicator === "check"
+      ? "\u2714"
+      : "";
+```
+
+Render Args from `displayState.argsText`:
+
+```tsx
+{
+  displayState.argsText && (
+    <div>
+      <span className="text-xs font-semibold text-muted-foreground">
+        {t("tracking.toolCall.argsLabel")}
+      </span>
+      <pre className="mt-0.5 p-2 rounded-md text-xs leading-relaxed max-h-32 overflow-y-auto whitespace-pre-wrap break-all bg-muted/60 border border-border font-mono text-foreground/85">
+        {displayState.argsText}
+      </pre>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run ToolCallBlock tests until green**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/components/channel/__tests__/ToolCallBlock.test.tsx
+```
+
+Expected: all ToolCallBlock tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add apps/client/src/components/channel/ToolCallBlock.tsx apps/client/src/components/channel/__tests__/ToolCallBlock.test.tsx
+git commit -m "fix(client): derive tool status from standardized metadata"
+```
+
+Expected: commit includes only `ToolCallBlock` and its tests.
+
+---
+
+### Task 3: Running Tool Calls Render As Tool Cards
+
+**Files:**
+
+- Modify: `apps/client/src/components/channel/MessageList.tsx`
+- Modify: `apps/client/src/components/channel/TrackingCard.tsx`
+- Modify: `apps/client/src/components/channel/__tests__/MessageList.test.tsx`
+- Modify: `apps/client/src/components/channel/__tests__/TrackingCard.test.tsx`
+
+- [ ] **Step 1: Add MessageList failing test for standalone running tool_call**
+
+In `apps/client/src/components/channel/__tests__/MessageList.test.tsx`, add:
+
+```tsx
+it("renders an unpaired running tool_call as a ToolCallBlock", () => {
+  const messages = [
+    {
+      ...makeToolCall("call-1", "tc-running", "RunScript"),
+      metadata: {
+        agentEventType: "tool_call",
+        status: "running",
+        toolCallId: "tc-running",
+        toolName: "RunScript",
+        toolArgsText: '{"cmd":"pnpm test',
+      },
+    },
+  ];
+
+  renderMessageList({ messages });
+
+  const blocks = screen.getAllByTestId("tool-call-block");
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0].getAttribute("data-tool-call-id")).toBe("tc-running");
+  expect(blocks[0].getAttribute("data-result-tool-call-id")).toBe("");
+});
+```
+
+If the test file lacks `renderMessageList`, use its existing render helper and pass the `messages` prop exactly like the surrounding direct-channel tests.
+
+- [ ] **Step 2: Add TrackingCard failing test for active running tool_call**
+
+In `apps/client/src/components/channel/__tests__/TrackingCard.test.tsx`, add:
+
+```tsx
+it("renders an active streaming tool_call as ToolCallBlock", () => {
+  render(
+    <TrackingCard
+      message={makeTrackingMessage({
+        trackingChannelId: "tracking-1",
+      })}
+    />,
+  );
+
+  mockUseTrackingChannel.mockReturnValue({
+    isActivated: true,
+    latestMessages: [],
+    totalMessageCount: 0,
+    isLoading: false,
+    activeStream: {
+      streamId: "stream-tool",
+      content: "",
+      metadata: {
+        agentEventType: "tool_call",
+        status: "running",
+        toolCallId: "tc-stream",
+        toolName: "RunScript",
+        toolArgsText: '{"cmd":"pnpm',
+      },
+    },
+  });
+
+  expect(mockToolCallBlock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      callMetadata: expect.objectContaining({
+        toolCallId: "tc-stream",
+        toolName: "RunScript",
+      }),
+      resultMetadata: undefined,
+    }),
+  );
+});
+```
+
+Place the `mockUseTrackingChannel.mockReturnValue()` before `render()` if the current mock structure reads hook data during render.
+
+- [ ] **Step 3: Run failing list/card tests**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/components/channel/__tests__/MessageList.test.tsx src/components/channel/__tests__/TrackingCard.test.tsx
+```
+
+Expected: new running tool-call assertions fail because unpaired calls still render through `TrackingEventItem`.
+
+- [ ] **Step 4: Update MessageList standalone tool_call branch**
+
+In `apps/client/src/components/channel/MessageList.tsx`, after the paired `tool_call + tool_result` branch and before the `tool_result` hiding branch, add:
+
+```tsx
+if (agentMeta?.agentEventType === "tool_call" && agentMeta.toolCallId) {
+  const prevItem = listDataRef.current[itemIndex - 1];
+  const prevIsAgentEvent =
+    prevItem?.type === "message" && !!getAgentMeta(prevItem.message);
+  const isFirstInGroup = !prevIsAgentEvent;
+
+  return (
+    <div
+      id={`message-${message.id}`}
+      className={cn(
+        "ml-2 mr-4 border-l-2 border-border bg-muted/30 rounded-r-md pr-4",
+        isFirstInGroup ? "mt-1 pt-1.5" : "",
+        "pb-0.5",
+      )}
+      style={{ paddingLeft: "9px" }}
+    >
+      <ToolCallBlock callMetadata={agentMeta} resultContent="" />
+    </div>
+  );
+}
+```
+
+In the paired branch, pass result message metadata:
+
+```tsx
+<ToolCallBlock
+  callMetadata={agentMeta}
+  resultMetadata={nextMeta}
+  resultContent={nextMsg?.content ?? ""}
+  resultMessage={nextMsg}
+/>
+```
+
+- [ ] **Step 5: Update TrackingCard render path**
+
+In `apps/client/src/components/channel/TrackingCard.tsx`, inside `visibleRenderItems.map`, add a branch before generic `TrackingEventItem`:
+
+```tsx
+if (ri.item.metadata.agentEventType === "tool_call") {
+  return (
+    <ToolCallBlock
+      key={ri.item.id}
+      callMetadata={ri.item.metadata}
+      resultContent=""
+    />
+  );
+}
+```
+
+- [ ] **Step 6: Run list/card tests until green**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/components/channel/__tests__/MessageList.test.tsx src/components/channel/__tests__/TrackingCard.test.tsx
+```
+
+Expected: MessageList and TrackingCard tests pass.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add apps/client/src/components/channel/MessageList.tsx apps/client/src/components/channel/TrackingCard.tsx apps/client/src/components/channel/__tests__/MessageList.test.tsx apps/client/src/components/channel/__tests__/TrackingCard.test.tsx
+git commit -m "feat(client): show running tool calls immediately"
+```
+
+Expected: commit includes only running tool-call render changes and tests.
+
+---
+
+### Task 4: Server Tool Result Metadata Normalization
+
+**Files:**
+
+- Create: `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.ts`
+- Create: `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts`
+- Modify: `apps/server/apps/gateway/src/im/messages/messages.controller.ts`
+- Modify: `apps/server/apps/gateway/src/im/streaming/streaming.controller.ts`
+
+- [ ] **Step 1: Write failing server normalization tests**
+
+Create `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts`:
+
+```ts
+import { normalizeToolEventMetadata } from "./tool-event-metadata.js";
+
+describe("normalizeToolEventMetadata", () => {
+  it("sets success false when a completed tool_result content has success false", () => {
+    const result = normalizeToolEventMetadata(
+      {
+        agentEventType: "tool_result",
+        status: "completed",
+        toolCallId: "tc-1",
+      },
+      '{"success":false,"error":"denied"}',
+    );
+
+    expect(result).toMatchObject({
+      agentEventType: "tool_result",
+      status: "failed",
+      success: false,
+      errorMessage: "denied",
+    });
+  });
+
+  it("sets success false for failed status without changing toolCallId", () => {
+    const result = normalizeToolEventMetadata(
+      {
+        agentEventType: "tool_result",
+        status: "failed",
+        toolCallId: "tc-2",
+      },
+      "permission denied",
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      success: false,
+      toolCallId: "tc-2",
+      errorMessage: "permission denied",
+    });
+  });
+
+  it("sets success true for completed tool_result with no failure evidence", () => {
+    const result = normalizeToolEventMetadata(
+      {
+        agentEventType: "tool_result",
+        status: "completed",
+        toolCallId: "tc-3",
+      },
+      '{"success":true}',
+    );
+
+    expect(result).toMatchObject({
+      status: "completed",
+      success: true,
+      toolCallId: "tc-3",
+    });
+  });
+
+  it("returns non-tool metadata unchanged", () => {
+    const metadata = { agentEventType: "thinking", status: "completed" };
+    expect(normalizeToolEventMetadata(metadata, "x")).toBe(metadata);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing server test**
+
+Run:
+
+```bash
+pnpm -C apps/server test apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts
+```
+
+Expected: fail because the helper file does not exist.
+
+- [ ] **Step 3: Implement server helper**
+
+Create `apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.ts`:
+
+```ts
+type Metadata = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function unwrapTextContent(raw: string): string {
+  const parsed = parseJson(raw);
+  if (isRecord(parsed) && Array.isArray(parsed.content)) {
+    const text = parsed.content
+      .filter(
+        (block): block is { type: string; text: string } =>
+          isRecord(block) &&
+          block.type === "text" &&
+          typeof block.text === "string",
+      )
+      .map((block) => block.text)
+      .join("\n");
+    if (text) return text;
+  }
+  return raw;
+}
+
+function getFailureMessage(content: string): string | undefined {
+  const unwrapped = unwrapTextContent(content);
+  const parsed = parseJson(unwrapped);
+  if (isRecord(parsed)) {
+    if (parsed.success === false) {
+      if (typeof parsed.errorMessage === "string") return parsed.errorMessage;
+      if (typeof parsed.error === "string") return parsed.error;
+      return "Tool returned success=false";
+    }
+    if (typeof parsed.errorMessage === "string") return parsed.errorMessage;
+    if (typeof parsed.error === "string") return parsed.error;
+  }
+  return unwrapped.trim() || undefined;
+}
+
+export function normalizeToolEventMetadata(
+  metadata: Metadata | undefined,
+  content: string,
+): Metadata | undefined {
+  if (!metadata || metadata.agentEventType !== "tool_result") {
+    return metadata;
+  }
+
+  const failedStatus =
+    metadata.status === "failed" ||
+    metadata.status === "cancelled" ||
+    metadata.status === "timeout";
+  const failureMessage =
+    metadata.success === false || failedStatus
+      ? typeof metadata.errorMessage === "string"
+        ? metadata.errorMessage
+        : getFailureMessage(content)
+      : getFailureMessage(content);
+  const failedByPayload = failureMessage && metadata.success !== true;
+  const success = failedStatus || failedByPayload ? false : true;
+
+  return {
+    ...metadata,
+    status: success ? (metadata.status ?? "completed") : "failed",
+    success,
+    completedAt:
+      typeof metadata.completedAt === "string"
+        ? metadata.completedAt
+        : new Date().toISOString(),
+    ...(!success && failureMessage ? { errorMessage: failureMessage } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: Run server helper test until green**
+
+Run:
+
+```bash
+pnpm -C apps/server test apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts
+```
+
+Expected: helper tests pass.
+
+- [ ] **Step 5: Normalize metadata in HTTP message creation**
+
+In `apps/server/apps/gateway/src/im/messages/messages.controller.ts`, import:
+
+```ts
+import { normalizeToolEventMetadata } from "./utils/tool-event-metadata.js";
+```
+
+Replace metadata creation in `createChannelMessage()` with:
+
+```ts
+const rawMetadata = dto.clientContext
+  ? { ...(dto.metadata ?? {}), clientContext: dto.clientContext }
+  : dto.metadata;
+const metadata = normalizeToolEventMetadata(rawMetadata, normalizedContent);
+```
+
+- [ ] **Step 6: Normalize metadata in streaming finalization**
+
+In `apps/server/apps/gateway/src/im/streaming/streaming.controller.ts`, import:
+
+```ts
+import { normalizeToolEventMetadata } from "../messages/utils/tool-event-metadata.js";
+```
+
+Before `createMessage()` in `endStreaming()`, replace the metadata assignment with:
+
+```ts
+const metadata = normalizeToolEventMetadata(
+  Object.keys(metadata).length > 0 ? metadata : session.metadata,
+  dto.content,
+);
+```
+
+If this collides with the existing `const metadata` declaration, rename the mutable object to `baseMetadata` first:
+
+```ts
+const baseMetadata: Record<string, unknown> = {};
+if (dto.thinking) {
+  baseMetadata.thinking = dto.thinking;
+}
+const metadata = normalizeToolEventMetadata(
+  Object.keys(baseMetadata).length > 0 ? baseMetadata : session.metadata,
+  dto.content,
+);
+```
+
+- [ ] **Step 7: Run focused server tests**
+
+Run:
+
+```bash
+pnpm -C apps/server test apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts apps/gateway/src/im/streaming/streaming.controller.spec.ts
+```
+
+Expected: tests pass.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.ts apps/server/apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts apps/server/apps/gateway/src/im/messages/messages.controller.ts apps/server/apps/gateway/src/im/streaming/streaming.controller.ts
+git commit -m "feat(server): normalize tool result metadata"
+```
+
+Expected: commit excludes existing unrelated `apps/server/apps/gateway/src/routines/*` changes.
+
+---
+
+### Task 5: Verification Pass
+
+**Files:**
+
+- Read: `docs/superpowers/specs/2026-05-01-tool-events-design.md`
+- Read: `docs/superpowers/plans/2026-05-01-tool-events-standard.md`
+
+- [ ] **Step 1: Run frontend focused tests**
+
+Run:
+
+```bash
+pnpm -C apps/client test src/lib/__tests__/tool-events.test.ts src/components/channel/__tests__/ToolCallBlock.test.tsx src/components/channel/__tests__/MessageList.test.tsx src/components/channel/__tests__/TrackingCard.test.tsx
+```
+
+Expected: all listed frontend tests pass.
+
+- [ ] **Step 2: Run server focused tests**
+
+Run:
+
+```bash
+pnpm -C apps/server test apps/gateway/src/im/messages/utils/tool-event-metadata.spec.ts apps/gateway/src/im/streaming/streaming.controller.spec.ts
+```
+
+Expected: all listed server tests pass.
+
+- [ ] **Step 3: Run typecheck and lint**
+
+Run:
+
+```bash
+pnpm -C apps/client typecheck
+pnpm -C apps/client lint:ci
+pnpm -C apps/server lint:ci
+```
+
+Expected: commands exit 0. The client route generator may print existing route-test warnings; those warnings are acceptable only if `pnpm -C apps/client typecheck` exits 0.
+
+- [ ] **Step 4: Confirm unrelated files are still unstaged**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only the pre-existing `apps/server/apps/gateway/src/routines/*` files remain modified after all task commits, unless the user explicitly asks to include them.
+
+- [ ] **Step 5: Final commit if verification changed generated files**
+
+If lint or formatting changed files after Task 4, run:
+
+```bash
+git add apps/client/src apps/server/apps/gateway/src/im/messages apps/server/apps/gateway/src/im/streaming
+git diff --cached --name-only
+git commit -m "chore: finalize tool event standard"
+```
+
+Expected: this commit contains only formatting or generated changes caused by verification.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Deterministic failure display is covered by Tasks 1, 2, and 4.
+- Running tool display is covered by Task 3.
+- Full expanded result content is covered by Task 2.
+- Server-side standard metadata is covered by Task 4.
+- Historical compatibility is covered by Task 1 content parsing and Task 2 rendering.
+
+Type consistency:
+
+- The frontend helper uses `StatusType` from `apps/client/src/config/toolLabels.ts`.
+- The display helper returns `status`, and `ToolCallBlock` continues feeding that status into `getLabelKey()`.
+- The first implementation uses `toolPhase` on `tool_call` metadata instead of adding a new `tool_delta` union member.
+
+Scope:
+
+- This plan does not migrate old rows.
+- This plan does not redesign the full tracking channel model.
+- This plan keeps unrelated routines files out of the work.

--- a/docs/superpowers/specs/2026-05-01-tool-events-design.md
+++ b/docs/superpowers/specs/2026-05-01-tool-events-design.md
@@ -1,0 +1,208 @@
+# Tool Events Display Standard Design
+
+## Context
+
+Team9 currently renders agent tool activity from persisted `tool_call` and
+`tool_result` agent-event messages. The UI pairs adjacent messages by
+`toolCallId` and renders them with `ToolCallBlock`.
+
+Three problems need to be solved together:
+
+1. Some tool failures are rendered as successful calls because the UI mainly
+   checks `metadata.status === "failed"` and does not consistently honor
+   structured failure data such as `success: false` or `{ error: ... }` in the
+   result payload.
+2. Tool calls do not stream visibly while arguments are being generated or
+   execution is pending. Users often see no useful progress until the final
+   result message exists.
+3. Long tool arguments or results may be truncated either by compact UI
+   summaries or by server-side `long_text` preview truncation. Expanded views
+   should show the same complete content the agent produced.
+
+The chosen approach is a compatible standardization of tool lifecycle events,
+not a full rewrite of the agent event model.
+
+## Goals
+
+- Define one tool event contract for Team9 tools.
+- Make success/failure display deterministic across tools.
+- Show running tool calls as soon as a call starts, including streaming
+  argument updates.
+- Keep compact rows readable while guaranteeing expanded rows can show full
+  arguments and results.
+- Preserve compatibility with existing persisted `tool_call` and `tool_result`
+  messages.
+
+## Non-Goals
+
+- Do not replace the entire `AgentEventMetadata` model.
+- Do not migrate historical database rows.
+- Do not redesign the visual style of tracking rows beyond what is needed for
+  status accuracy, streaming, and full expanded content.
+- Do not change unrelated routine execution behavior.
+
+## Event Contract
+
+Tool activity is represented by a lifecycle over one `toolCallId`.
+
+### `tool_call`
+
+Emitted when the model starts describing or invoking a tool. It may contain
+partial arguments.
+
+```ts
+interface ToolCallEventMetadata {
+  agentEventType: "tool_call";
+  status: "running";
+  toolCallId: string;
+  toolName: string;
+  toolArgs?: Record<string, unknown>;
+  toolArgsText?: string;
+  startedAt: string;
+}
+```
+
+### `tool_delta`
+
+Emitted while arguments or execution state change. To preserve compatibility,
+the first implementation may encode this as `agentEventType: "tool_call"` plus
+`toolPhase`, or add `"tool_delta"` to the metadata union if that is lower risk
+after implementation planning.
+
+```ts
+interface ToolDeltaEventMetadata {
+  agentEventType: "tool_delta";
+  status: "running";
+  toolCallId: string;
+  toolName: string;
+  toolArgs?: Record<string, unknown>;
+  toolArgsText?: string;
+  toolPhase: "args_streaming" | "executing";
+  updatedAt: string;
+}
+```
+
+### `tool_result`
+
+Emitted once the tool finishes, fails, is cancelled, or times out. `success` is
+required for newly emitted events.
+
+```ts
+interface ToolResultEventMetadata {
+  agentEventType: "tool_result";
+  status: "completed" | "failed" | "cancelled" | "timeout";
+  success: boolean;
+  toolCallId: string;
+  toolName?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  resultTruncated?: boolean;
+  fullContentMessageId?: string;
+  completedAt: string;
+}
+```
+
+## Success And Failure Semantics
+
+The UI uses one normalization helper to derive display state.
+
+Priority order:
+
+1. `tool_result.success === false` means failure, regardless of `status`.
+2. `status` of `failed`, `cancelled`, or `timeout` means non-success.
+3. For legacy result content, if parsed JSON contains a top-level
+   `success: false`, `error`, or `errorMessage`, display failure.
+4. A running call without a result displays running.
+5. A completed result without failure evidence displays success.
+
+This lets tools return formatted failure content without accidentally producing
+a green checkmark.
+
+## Streaming Behavior
+
+The UI should render a tool card as soon as the call starts.
+
+- While args are streaming, show the tool name and current argument text or
+  structured args.
+- While execution is pending after args are complete, keep the row in running
+  state and show an executing label.
+- When the final result arrives, merge the final result into the same card.
+- If a persisted `tool_result` arrives before a matching `tool_call`, keep the
+  existing defensive behavior and render it as a standalone event until pairing
+  data exists.
+
+The first implementation should reuse existing WebSocket/streaming paths where
+possible, adding only the smallest event extension needed for tool deltas.
+
+## Full Content And Truncation
+
+There are two valid truncation layers:
+
+- Compact UI summaries can truncate one-line labels and argument summaries.
+- Server previews for `long_text` messages can truncate persisted message
+  content for list performance.
+
+Expanded tool panels must not be limited by either layer.
+
+Rules:
+
+- Full `toolArgs` are displayed in the expanded args section when available.
+- `toolArgsText` is displayed when structured args are incomplete or still
+  streaming.
+- If the result message is `long_text` or carries `isTruncated`, the expanded
+  result section fetches `/full-content` and renders that content.
+- If the final metadata carries `resultTruncated` and `fullContentMessageId`,
+  the expanded result section fetches that full content target.
+- Compact summaries may continue using `formatParams`, but the expanded panel
+  uses the original data.
+
+## Frontend Changes
+
+- Add a tool event normalization helper that accepts call metadata, optional
+  delta metadata, result metadata, and result content.
+- Update `ToolCallBlock` to render from normalized state.
+- Update `TrackingEventItem` or its caller path so running `tool_call` items use
+  the same normalized display logic as paired calls.
+- Update `TrackingCard`, `TrackingModal`, and `MessageList` pairing paths to
+  share the same helper.
+- Add regression tests for:
+  - `success: false` with `status: "completed"` renders failure.
+  - Wrapped result content containing `success:false` renders failure.
+  - A running tool call without result renders a running tool card.
+  - Streaming argument updates replace the visible running args.
+  - Expanded long result loads full content when the preview is truncated.
+
+## Backend And Agent Changes
+
+- Introduce a small server-side helper for building tool event metadata.
+- Ensure newly emitted `tool_result` metadata always includes `success`.
+- Standardize exception handling in the tool wrapper:
+  - thrown exceptions become `success:false`, `status:"failed"`, and
+    `errorMessage`;
+  - business failures returned by tools are normalized to `success:false`;
+  - successful returns are normalized to `success:true`.
+- Emit running call metadata before a long tool begins execution.
+- Emit argument deltas while the model is streaming tool arguments when the
+  upstream provider exposes them.
+- Preserve old event names and existing `tool_call` / `tool_result` message
+  shape so current persisted rows remain renderable.
+
+## Compatibility
+
+Existing rows are supported by fallback parsing:
+
+- Missing `success` falls back to status and result-content inspection.
+- Missing `toolName` falls back to the call metadata, then `"Unknown tool"`.
+- Missing structured args falls back to `toolArgsText`, then compact content.
+
+No migration is required for historical messages.
+
+## Open Implementation Notes
+
+- During planning, inspect where base-model and OpenClaw agents currently emit
+  tool events. If only one path emits tool events, standardize there first.
+- Decide whether `tool_delta` should become a new `AgentEventMetadata` union
+  member or be represented as `tool_call` with a `toolPhase` field for the
+  first iteration.
+- Keep unrelated `apps/server/apps/gateway/src/routines/*` working tree changes
+  out of the implementation commit unless explicitly requested.


### PR DESCRIPTION
## Summary
- 14 commits including:
  - `feat`: writable Folder9 scoped mounts, widen folder mount scope ids (migration 0057)
  - `fix(ahand)`: wire AppHandle through reload, default config_path to ~/.ahand/config.toml
  - `fix(client)`: localize browser config-error toasts (zh-CN), clip long sidebar subtitles, preserve streaming thinking order
  - Stop sending legacy routine document content
  - Docs: tool events implementation plan + display standard

## Migration
- New: `0057_yielding_radioactive_man.sql` — `ALTER TABLE workspace_folder_mounts ALTER COLUMN scope_id SET DATA TYPE varchar(256)` (column widening, backward compatible)
- **Will be run manually on prod via `pnpm db:migrate` BEFORE merging this PR** (prod does not auto-migrate)

## Test plan
- [ ] CI passes
- [ ] Prod migration 0057 applied
- [ ] Railway prod deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)