### PR TITLE
Force light theme and en-locale money formatting

### DIFF
--- a/apps/client/src/components/billing/plan-card.tsx
+++ b/apps/client/src/components/billing/plan-card.tsx
@@ -38,7 +38,7 @@ function getWorkspaceT(): WorkspaceT {
 export function formatMoney(amountCents: number) {
   const hasFraction = amountCents % 100 !== 0;
 
-  return new Intl.NumberFormat(getLocale(), {
+  return new Intl.NumberFormat("en", {
     style: "currency",
     currency: "USD",
     minimumFractionDigits: hasFraction ? 2 : 0,

--- a/apps/client/src/components/layout/contents/MoreMainContent.tsx
+++ b/apps/client/src/components/layout/contents/MoreMainContent.tsx
@@ -1,12 +1,9 @@
 import {
   Settings,
-  Palette,
   Globe,
   ChevronRight,
   Users,
   Link2,
-  Sun,
-  Moon,
   Check,
   Building2,
   Type,
@@ -28,7 +25,6 @@ import { InviteManagementDialog } from "@/components/workspace/InviteManagementD
 import { NotificationPreferencesDialog } from "@/components/settings/NotificationPreferencesDialog";
 import { FontSizeDialog } from "@/components/settings/FontSizeDialog";
 import { useWorkspaceStore } from "@/stores";
-import { useThemeToggle } from "@/hooks/useTheme";
 import { useCurrentWorkspaceRole } from "@/hooks/useWorkspace";
 import { supportedLanguages } from "@/i18n";
 import { changeLanguage, useLanguageLoading } from "@/i18n/loadLanguage";
@@ -45,7 +41,6 @@ const settingsGroups = [
   {
     titleKey: "preferences",
     items: [
-      { id: "appearance", labelKey: "appearance", icon: Palette },
       { id: "fontSize", labelKey: "fontSize", icon: Type },
       { id: "language", labelKey: "language", icon: Globe },
     ],
@@ -57,13 +52,11 @@ export function MoreMainContent() {
   const { t: tWorkspace } = useTranslation("workspace");
   const navigate = useNavigate();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
-  const [isAppearanceDialogOpen, setIsAppearanceDialogOpen] = useState(false);
   const [isNotificationDialogOpen, setIsNotificationDialogOpen] =
     useState(false);
   const [isLanguageDialogOpen, setIsLanguageDialogOpen] = useState(false);
   const [isFontSizeDialogOpen, setIsFontSizeDialogOpen] = useState(false);
   const { isLoading: isLanguageLoading } = useLanguageLoading();
-  const { theme, setTheme } = useThemeToggle();
   const { isOwnerOrAdmin } = useCurrentWorkspaceRole();
 
   // Get current selected workspace
@@ -94,8 +87,6 @@ export function MoreMainContent() {
       navigate({ to: "/more/members" });
     } else if (id === "workspace-settings") {
       navigate({ to: "/more/workspace-settings" });
-    } else if (id === "appearance") {
-      setIsAppearanceDialogOpen(true);
     } else if (id === "notifications") {
       setIsNotificationDialogOpen(true);
     } else if (id === "language") {
@@ -196,61 +187,6 @@ export function MoreMainContent() {
           workspaceId={selectedWorkspaceId}
         />
       )}
-
-      {/* Appearance Dialog */}
-      <Dialog
-        open={isAppearanceDialogOpen}
-        onOpenChange={setIsAppearanceDialogOpen}
-      >
-        <DialogContent className="sm:max-w-md dark:bg-card">
-          <DialogHeader>
-            <DialogTitle className="dark:text-foreground">
-              {t("theme")}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="grid grid-cols-2 gap-4 py-4">
-            <button
-              onClick={() => setTheme("light")}
-              className={`flex flex-col items-center gap-3 p-4 rounded-lg border-2 transition-all ${
-                theme === "light"
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 dark:border-border"
-              }`}
-            >
-              <div className="w-12 h-12 rounded-full bg-warning/10 flex items-center justify-center">
-                <Sun className="w-6 h-6 text-warning" />
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium dark:text-foreground">
-                  {t("lightTheme")}
-                </span>
-                {theme === "light" && (
-                  <Check className="w-4 h-4 text-primary" />
-                )}
-              </div>
-            </button>
-
-            <button
-              onClick={() => setTheme("dark")}
-              className={`flex flex-col items-center gap-3 p-4 rounded-lg border-2 transition-all ${
-                theme === "dark"
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 dark:border-border"
-              }`}
-            >
-              <div className="w-12 h-12 rounded-full bg-foreground flex items-center justify-center">
-                <Moon className="w-6 h-6 text-muted" />
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium dark:text-foreground">
-                  {t("darkTheme")}
-                </span>
-                {theme === "dark" && <Check className="w-4 h-4 text-primary" />}
-              </div>
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
 
       {/* Notification Preferences Dialog */}
       <NotificationPreferencesDialog

--- a/apps/client/src/hooks/useTheme.ts
+++ b/apps/client/src/hooks/useTheme.ts
@@ -3,21 +3,20 @@ import { useTheme as useThemeState, useAppStore } from "@/stores/useAppStore";
 
 /**
  * Hook that syncs the theme state with the DOM.
- * Applies the 'dark' class to document.documentElement when theme is 'dark'.
+ * Dark mode is currently disabled product-wide — this hook forces light mode
+ * and migrates any persisted "dark" preference back to "light" for old users.
  * Should be called once at the app root level.
  */
 export function useThemeEffect() {
   const theme = useThemeState();
+  const setTheme = useAppStore((state) => state.setTheme);
 
   useEffect(() => {
-    const root = document.documentElement;
-
     if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
+      setTheme("light");
     }
-  }, [theme]);
+    document.documentElement.classList.remove("dark");
+  }, [theme, setTheme]);
 
   return theme;
 }

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -81,6 +81,9 @@ export interface ChannelSnapshot {
     content: string;
     metadata: AgentEventMetadata;
     createdAt: string;
+    type?: Message["type"];
+    isTruncated?: boolean;
+    fullContentLength?: number;
   }>;
 }
 


### PR DESCRIPTION
## Summary
- 禁用 More 设置中的深色模式切换入口，强制全局使用 light 主题，并把已持久化为 `dark` 的旧用户偏好迁回 `light`
- `formatMoney` 在格式化美元金额时固定使用 `en` locale，避免在中文等 locale 下出现 `US$` 前缀

## Test plan
- [ ] 启动客户端，确认 More → 设置中不再出现 Appearance 入口，且 `<html>` 上不再带 `dark` class
- [ ] 将 localStorage 中的主题手动设置为 `dark`，刷新后应被自动迁回 `light`
- [ ] 切换到中文 locale，确认账单/订阅页面金额显示为 `$x.xx` 而不是 `US$x.xx`