### PR TITLE
[codex] Add agent session channel panel

### DIFF
--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -33,6 +33,8 @@ import type {
 } from "@/types/properties";
 import { useBotModelSwitch } from "@/hooks/useBotModelSwitch";
 import { useChannelModel } from "@/hooks/useChannelModel";
+import { useChannelAgentSession } from "@/hooks/useChannelAgentSession";
+import { useAgentSessionComponents } from "@/hooks/useAgentSessionComponents";
 import {
   applyBotThinkingMessage,
   getBotThinkingIds,
@@ -53,6 +55,7 @@ import type {
 } from "@/types/im";
 import { isValidMessageId } from "@/lib/utils";
 import { fileApi } from "@/services/api/file";
+import { AgentSessionPanel } from "./agent-session/AgentSessionPanel";
 
 // ==================== ChannelFilesList ====================
 
@@ -380,11 +383,23 @@ export function ChannelView({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isSnapped, setIsSnapped] = useState(false);
   const [threadPanelWidth, setThreadPanelWidth] = useState(600);
+  const [agentPanelWidth, setAgentPanelWidth] = useState(360);
   const threadPanelWidthRef = useRef(threadPanelWidth);
   threadPanelWidthRef.current = threadPanelWidth;
 
-  const threadPanelCount =
-    (primaryThread.isOpen ? 1 : 0) + (secondaryThread.isOpen ? 1 : 0);
+  const agentSession = useChannelAgentSession(channelId, !isPreviewMode);
+  const shouldShowAgentSessionPanel =
+    !!agentSession.data &&
+    (agentSession.data.supported || !!agentSession.data.unsupportedReason);
+  const agentComponents = useAgentSessionComponents(
+    channelId,
+    shouldShowAgentSessionPanel && agentSession.data?.supported === true,
+  );
+  const agentPanelCount = shouldShowAgentSessionPanel ? 1 : 0;
+  const openThreadPanelCount =
+    (primaryThread.isOpen && primaryThread.rootMessageId ? 1 : 0) +
+    (secondaryThread.isOpen && secondaryThread.rootMessageId ? 1 : 0);
+  const sidePanelCount = agentPanelCount + openThreadPanelCount;
 
   // Bot response indicator state (local)
   const [thinkingStatuses, setThinkingStatuses] = useState<BotThinkingStatus[]>(
@@ -562,7 +577,7 @@ export function ChannelView({
   // because the outer container size doesn't change when children resize).
   useEffect(() => {
     const el = containerRef.current;
-    if (!el || threadPanelCount === 0) {
+    if (!el || sidePanelCount === 0) {
       setIsSnapped(false);
       return;
     }
@@ -570,7 +585,9 @@ export function ChannelView({
     const recalc = () => {
       const containerWidth = el.getBoundingClientRect().width;
       const mainChatWidth =
-        containerWidth - threadPanelCount * threadPanelWidthRef.current;
+        containerWidth -
+        agentPanelCount * agentPanelWidth -
+        openThreadPanelCount * threadPanelWidthRef.current;
       setIsSnapped(mainChatWidth < 400);
     };
 
@@ -580,7 +597,13 @@ export function ChannelView({
     const observer = new ResizeObserver(() => recalc());
     observer.observe(el);
     return () => observer.disconnect();
-  }, [threadPanelCount, threadPanelWidth]);
+  }, [
+    agentPanelCount,
+    agentPanelWidth,
+    openThreadPanelCount,
+    sidePanelCount,
+    threadPanelWidth,
+  ]);
 
   const handleSendMessage = async (
     payload: { content: string; contentAst?: Record<string, unknown> },
@@ -741,6 +764,17 @@ export function ChannelView({
           />
         )}
       </div>
+
+      {agentSession.data && shouldShowAgentSessionPanel && (
+        <AgentSessionPanel
+          binding={agentSession.data}
+          components={agentComponents.data}
+          isLoading={agentComponents.isLoading}
+          isError={agentComponents.isError}
+          width={agentPanelWidth}
+          onWidthChange={setAgentPanelWidth}
+        />
+      )}
 
       {/* Thread panel sidebars - up to 2 layers (hidden for direct messages) */}
       {channel?.type !== "direct" &&

--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -387,13 +387,22 @@ export function ChannelView({
   const threadPanelWidthRef = useRef(threadPanelWidth);
   threadPanelWidthRef.current = threadPanelWidth;
 
-  const agentSession = useChannelAgentSession(channelId, !isPreviewMode);
+  const isAgentSessionCandidate =
+    !isPreviewMode &&
+    (isBotDm || channel?.type === "tracking" || channel?.type === "task");
+  const agentSession = useChannelAgentSession(
+    channelId,
+    isAgentSessionCandidate,
+  );
   const shouldShowAgentSessionPanel =
     !!agentSession.data &&
-    (agentSession.data.supported || !!agentSession.data.unsupportedReason);
+    (agentSession.data.supported ||
+      (!!agentSession.data.unsupportedReason &&
+        agentSession.data.unsupportedReason !== "no_bot"));
   const agentComponents = useAgentSessionComponents(
     channelId,
     shouldShowAgentSessionPanel && agentSession.data?.supported === true,
+    agentSession.data?.sessionId,
   );
   const agentPanelCount = shouldShowAgentSessionPanel ? 1 : 0;
   const openThreadPanelCount =
@@ -588,7 +597,7 @@ export function ChannelView({
         containerWidth -
         agentPanelCount * agentPanelWidth -
         openThreadPanelCount * threadPanelWidthRef.current;
-      setIsSnapped(mainChatWidth < 400);
+      setIsSnapped(openThreadPanelCount > 0 && mainChatWidth < 400);
     };
 
     // Recalculate immediately for threadPanelWidth changes

--- a/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
@@ -1,6 +1,29 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelView } from "../ChannelView";
+
+const viewState = vi.hoisted(() => ({
+  channel: {
+    id: "channel-1",
+    tenantId: "tenant-1",
+    type: "direct",
+    name: "Agent",
+    isArchived: false,
+    otherUser: { id: "bot-user-1", userType: "bot" },
+  } as any,
+  agentSession: {
+    data: {
+      channelId: "channel-1",
+      channelType: "direct",
+      kind: "dm",
+      supported: true,
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      botUserId: "bot-user-1",
+      sessionId: "session-1",
+    },
+  } as any,
+}));
 
 vi.stubGlobal(
   "ResizeObserver",
@@ -48,14 +71,7 @@ vi.mock("@/services/websocket", () => ({
 
 vi.mock("@/hooks/useChannels", () => ({
   useChannel: () => ({
-    data: {
-      id: "channel-1",
-      tenantId: "tenant-1",
-      type: "direct",
-      name: "Agent",
-      isArchived: false,
-      otherUser: { id: "bot-user-1", userType: "bot" },
-    },
+    data: viewState.channel,
     isLoading: false,
   }),
   useChannelMembers: () => ({ data: [] }),
@@ -126,18 +142,7 @@ vi.mock("@/hooks/useBotStartupCountdown", () => ({
 }));
 
 vi.mock("@/hooks/useChannelAgentSession", () => ({
-  useChannelAgentSession: () => ({
-    data: {
-      channelId: "channel-1",
-      channelType: "direct",
-      kind: "dm",
-      supported: true,
-      tenantId: "tenant-1",
-      agentId: "agent-1",
-      botUserId: "bot-user-1",
-      sessionId: "session-1",
-    },
-  }),
+  useChannelAgentSession: () => viewState.agentSession,
 }));
 
 vi.mock("@/hooks/useAgentSessionComponents", () => ({
@@ -154,7 +159,9 @@ vi.mock("../agent-session/AgentSessionPanel", () => ({
 
 vi.mock("../ChannelHeader", () => ({ ChannelHeader: () => <div /> }));
 vi.mock("../ChannelTabs", () => ({ ChannelTabs: () => <div /> }));
-vi.mock("../ChannelContent", () => ({ ChannelContent: () => <div /> }));
+vi.mock("../ChannelContent", () => ({
+  ChannelContent: () => <div data-testid="channel-content" />,
+}));
 vi.mock("../ThreadPanel", () => ({ ThreadPanel: () => <aside /> }));
 vi.mock("../JoinChannelPrompt", () => ({ JoinChannelPrompt: () => null }));
 vi.mock("../BotStartupOverlay", () => ({ BotStartupOverlay: () => null }));
@@ -169,9 +176,70 @@ vi.mock("@/services/api/file", () => ({
 }));
 
 describe("ChannelView agent session panel", () => {
+  beforeEach(() => {
+    viewState.channel = {
+      id: "channel-1",
+      tenantId: "tenant-1",
+      type: "direct",
+      name: "Agent",
+      isArchived: false,
+      otherUser: { id: "bot-user-1", userType: "bot" },
+    };
+    viewState.agentSession = {
+      data: {
+        channelId: "channel-1",
+        channelType: "direct",
+        kind: "dm",
+        supported: true,
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        botUserId: "bot-user-1",
+        sessionId: "session-1",
+      },
+    };
+  });
+
   it("renders the session panel for a supported binding", () => {
     render(<ChannelView channelId="channel-1" />);
 
     expect(screen.getByText("Agent Session Panel")).toBeInTheDocument();
+  });
+
+  it("hides no_bot unsupported bindings on ordinary channels", () => {
+    viewState.channel = {
+      id: "channel-1",
+      tenantId: "tenant-1",
+      type: "public",
+      name: "General",
+      isArchived: false,
+      otherUser: undefined,
+    };
+    viewState.agentSession = {
+      data: {
+        channelId: "channel-1",
+        channelType: "public",
+        kind: null,
+        supported: false,
+        unsupportedReason: "no_bot",
+        tenantId: "tenant-1",
+        agentId: null,
+        botUserId: null,
+        sessionId: null,
+      },
+    };
+
+    render(<ChannelView channelId="channel-1" />);
+
+    expect(screen.queryByText("Agent Session Panel")).not.toBeInTheDocument();
+  });
+
+  it("keeps chat visible when only the agent session panel is open", async () => {
+    render(<ChannelView channelId="channel-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Agent Session Panel")).toBeInTheDocument(),
+    );
+    const chatShell = screen.getByTestId("channel-content").closest(".flex-1");
+    expect(chatShell?.className).not.toContain("hidden");
   });
 });

--- a/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChannelView } from "../ChannelView";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    disconnect() {}
+  },
+);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock("@/stores", () => ({
+  useUser: () => ({ id: "user-1" }),
+}));
+
+vi.mock("@/hooks/useThread", () => ({
+  useThreadStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      primaryThread: { isOpen: false, rootMessageId: null },
+      secondaryThread: { isOpen: false, rootMessageId: null },
+      openPrimaryThread: vi.fn(),
+      closePrimaryThread: vi.fn(),
+    }),
+}));
+
+vi.mock("@/hooks/useSyncChannel", () => ({
+  useSyncChannel: vi.fn(),
+}));
+
+vi.mock("@/hooks/useEffectOncePerKey", () => ({
+  useEffectOncePerKey: vi.fn(),
+}));
+
+vi.mock("@/services/websocket", () => ({
+  default: {
+    onNewMessage: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useChannels", () => ({
+  useChannel: () => ({
+    data: {
+      id: "channel-1",
+      tenantId: "tenant-1",
+      type: "direct",
+      name: "Agent",
+      isArchived: false,
+      otherUser: { id: "bot-user-1", userType: "bot" },
+    },
+    isLoading: false,
+  }),
+  useChannelMembers: () => ({ data: [] }),
+  useMarkAsRead: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useMessages", () => ({
+  useChannelMessages: () => ({
+    data: { pages: [{ messages: [] }] },
+    isLoading: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    hasPreviousPage: false,
+    isFetchingPreviousPage: false,
+    fetchPreviousPage: vi.fn(),
+  }),
+  useSendMessage: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useChannelTabs", () => ({
+  useChannelTabs: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useChannelViews", () => ({
+  useChannelViews: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useMessageJump", () => ({
+  useMessageJump: () => ({
+    jumpToMessage: vi.fn(),
+    highlightId: null,
+    seq: 0,
+  }),
+}));
+
+vi.mock("@/hooks/useBotModelSwitch", () => ({
+  useBotModelSwitch: () => ({ agentModelFamily: null }),
+}));
+
+vi.mock("@/hooks/useChannelModel", () => ({
+  useChannelModel: () => ({
+    data: null,
+    isError: true,
+    isUpdating: false,
+    updateModel: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useOpenClawBotInstanceStatus", () => ({
+  useOpenClawBotInstanceStatus: () => ({
+    isInstanceStopped: false,
+    isInstanceStarting: false,
+    isOpenClawBot: false,
+    canStart: false,
+    startInstance: vi.fn(),
+    isStarting: false,
+  }),
+}));
+
+vi.mock("@/hooks/useBotStartupCountdown", () => ({
+  useBotStartupCountdown: () => ({
+    phase: "ready",
+    remainingSeconds: 0,
+    startChatting: vi.fn(),
+    showOverlay: false,
+  }),
+}));
+
+vi.mock("@/hooks/useChannelAgentSession", () => ({
+  useChannelAgentSession: () => ({
+    data: {
+      channelId: "channel-1",
+      channelType: "direct",
+      kind: "dm",
+      supported: true,
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      botUserId: "bot-user-1",
+      sessionId: "session-1",
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useAgentSessionComponents", () => ({
+  useAgentSessionComponents: () => ({
+    data: { sessionId: "session-1", components: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("../agent-session/AgentSessionPanel", () => ({
+  AgentSessionPanel: () => <aside>Agent Session Panel</aside>,
+}));
+
+vi.mock("../ChannelHeader", () => ({ ChannelHeader: () => <div /> }));
+vi.mock("../ChannelTabs", () => ({ ChannelTabs: () => <div /> }));
+vi.mock("../ChannelContent", () => ({ ChannelContent: () => <div /> }));
+vi.mock("../ThreadPanel", () => ({ ThreadPanel: () => <aside /> }));
+vi.mock("../JoinChannelPrompt", () => ({ JoinChannelPrompt: () => null }));
+vi.mock("../BotStartupOverlay", () => ({ BotStartupOverlay: () => null }));
+vi.mock("../BotInstanceStoppedBanner", () => ({
+  BotInstanceStoppedBanner: () => null,
+}));
+vi.mock("../views/TableView", () => ({ TableView: () => <div /> }));
+vi.mock("../views/BoardView", () => ({ BoardView: () => <div /> }));
+vi.mock("../views/CalendarView", () => ({ CalendarView: () => <div /> }));
+vi.mock("@/services/api/file", () => ({
+  fileApi: { getDownloadUrl: vi.fn() },
+}));
+
+describe("ChannelView agent session panel", () => {
+  it("renders the session panel for a supported binding", () => {
+    render(<ChannelView channelId="channel-1" />);
+
+    expect(screen.getByText("Agent Session Panel")).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/components/channel/agent-session/AgentSessionPanel.tsx
+++ b/apps/client/src/components/channel/agent-session/AgentSessionPanel.tsx
@@ -1,0 +1,70 @@
+import { Loader2 } from "lucide-react";
+import type {
+  AgentSessionBinding,
+  SafeSessionComponentsResponse,
+} from "@/types/im";
+import { ResizeHandle } from "../ResizeHandle";
+import { AgentSessionStatusHeader } from "./AgentSessionStatusHeader";
+import { SessionComponentList } from "./SessionComponentList";
+import { TaskContextSection } from "./TaskContextSection";
+import { TrackingContextSection } from "./TrackingContextSection";
+
+interface AgentSessionPanelProps {
+  binding: AgentSessionBinding;
+  components: SafeSessionComponentsResponse | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  width: number;
+  onWidthChange: (width: number) => void;
+}
+
+export function AgentSessionPanel({
+  binding,
+  components,
+  isLoading,
+  isError,
+  width,
+  onWidthChange,
+}: AgentSessionPanelProps) {
+  return (
+    <aside
+      className="relative flex h-full shrink-0 flex-col overflow-hidden border-l border-border bg-background"
+      style={{ width }}
+    >
+      <ResizeHandle
+        width={width}
+        onWidthChange={onWidthChange}
+        minWidth={300}
+        maxWidth={520}
+      />
+      {!binding.supported ? (
+        <div className="p-4">
+          <h2 className="text-sm font-semibold">Runtime details unavailable</h2>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {binding.unsupportedReason ?? "unsupported"}
+          </p>
+        </div>
+      ) : (
+        <>
+          <AgentSessionStatusHeader binding={binding} />
+          {isLoading && (
+            <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              Loading components
+            </div>
+          )}
+          {isError && (
+            <p className="p-3 text-xs text-destructive">
+              Failed to load component data
+            </p>
+          )}
+          {!isLoading && !isError && (
+            <SessionComponentList components={components} />
+          )}
+          <TaskContextSection binding={binding} />
+          <TrackingContextSection binding={binding} />
+        </>
+      )}
+    </aside>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/AgentSessionStatusHeader.tsx
+++ b/apps/client/src/components/channel/agent-session/AgentSessionStatusHeader.tsx
@@ -1,0 +1,30 @@
+import { Activity, Circle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { AgentSessionBinding } from "@/types/im";
+
+export function AgentSessionStatusHeader({
+  binding,
+}: {
+  binding: AgentSessionBinding;
+}) {
+  const state = binding.status?.activityState ?? "inactive";
+
+  return (
+    <div className="border-b border-border px-3 py-3">
+      <div className="flex items-center gap-2">
+        <Activity className="size-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold">Agent Session</h2>
+        <Badge
+          variant={state === "active" ? "default" : "outline"}
+          className="ml-auto"
+        >
+          {state}
+        </Badge>
+      </div>
+      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+        <Circle className="size-2 fill-current" />
+        <span className="truncate">{binding.kind ?? binding.channelType}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/SessionComponentList.tsx
+++ b/apps/client/src/components/channel/agent-session/SessionComponentList.tsx
@@ -1,0 +1,23 @@
+import type { SafeSessionComponentsResponse } from "@/types/im";
+import { SessionComponentRow } from "./SessionComponentRow";
+
+export function SessionComponentList({
+  components,
+}: {
+  components: SafeSessionComponentsResponse | undefined;
+}) {
+  const rows = components?.components ?? [];
+  if (rows.length === 0) {
+    return (
+      <p className="p-3 text-xs text-muted-foreground">No component data</p>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto px-3">
+      {rows.map((component) => (
+        <SessionComponentRow key={component.id} component={component} />
+      ))}
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/SessionComponentRow.tsx
+++ b/apps/client/src/components/channel/agent-session/SessionComponentRow.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { SafeSessionComponentItem } from "@/types/im";
+
+export function SessionComponentRow({
+  component,
+}: {
+  component: SafeSessionComponentItem;
+}) {
+  const [open, setOpen] = useState(true);
+  const data = component.latestData?.data ?? null;
+
+  return (
+    <div className="border-b border-border/60 py-2 last:border-b-0">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="min-w-0 flex-1 truncate text-xs font-medium">
+          {component.id}
+        </span>
+        {component.runtimeInjectedOnly && (
+          <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+            injected
+          </Badge>
+        )}
+        {open ? (
+          <ChevronUp className="size-3 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="size-3 text-muted-foreground" />
+        )}
+      </button>
+      {open && (
+        <pre className="mt-2 max-h-48 overflow-auto rounded border border-border/60 bg-muted/30 p-2 text-[11px] leading-4 text-muted-foreground">
+          {data ? JSON.stringify(data, null, 2) : "No snapshot yet"}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/TaskContextSection.tsx
+++ b/apps/client/src/components/channel/agent-session/TaskContextSection.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "@/components/ui/badge";
+import type { AgentSessionBinding } from "@/types/im";
+
+export function TaskContextSection({
+  binding,
+}: {
+  binding: AgentSessionBinding;
+}) {
+  if (binding.kind !== "routine-execution") return null;
+
+  return (
+    <div className="border-t border-border px-3 py-3 text-xs">
+      <div className="mb-2 font-medium">Task</div>
+      <div className="space-y-1 text-muted-foreground">
+        {binding.taskStatus && (
+          <Badge variant="outline">{binding.taskStatus}</Badge>
+        )}
+        {binding.routineId && (
+          <div className="truncate">Routine: {binding.routineId}</div>
+        )}
+        {binding.executionId && (
+          <div className="truncate">Execution: {binding.executionId}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/TrackingContextSection.tsx
+++ b/apps/client/src/components/channel/agent-session/TrackingContextSection.tsx
@@ -1,0 +1,16 @@
+import type { AgentSessionBinding } from "@/types/im";
+
+export function TrackingContextSection({
+  binding,
+}: {
+  binding: AgentSessionBinding;
+}) {
+  if (binding.kind !== "tracking") return null;
+
+  return (
+    <div className="border-t border-border px-3 py-3 text-xs text-muted-foreground">
+      <div className="mb-1 font-medium text-foreground">Tracking</div>
+      <div className="truncate">Channel: {binding.channelId}</div>
+    </div>
+  );
+}

--- a/apps/client/src/components/channel/agent-session/__tests__/AgentSessionPanel.test.tsx
+++ b/apps/client/src/components/channel/agent-session/__tests__/AgentSessionPanel.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentSessionPanel } from "../AgentSessionPanel";
+
+const binding = {
+  channelId: "ch-1",
+  channelType: "direct" as const,
+  kind: "dm" as const,
+  supported: true,
+  tenantId: "tenant-1",
+  agentId: "agent-1",
+  botUserId: "bot-user-1",
+  sessionId: "session-1",
+  status: { exists: true, activityState: "active" as const, queueLength: 1 },
+};
+
+describe("AgentSessionPanel", () => {
+  it("renders active binding and component data", () => {
+    render(
+      <AgentSessionPanel
+        binding={binding}
+        components={{
+          sessionId: "session-1",
+          components: [
+            {
+              id: "persona",
+              typeKey: "persona",
+              runtimeInjectedOnly: false,
+              latestData: {
+                data: { mood: "focused" },
+                capturedAtCallId: null,
+                capturedAt: 1700000000000,
+              },
+            },
+          ],
+        }}
+        isLoading={false}
+        isError={false}
+        width={360}
+        onWidthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Agent Session")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("persona")).toBeInTheDocument();
+    expect(screen.getByText(/focused/)).toBeInTheDocument();
+  });
+
+  it("renders unsupported fallback", () => {
+    render(
+      <AgentSessionPanel
+        binding={{
+          ...binding,
+          supported: false,
+          kind: null,
+          sessionId: null,
+          unsupportedReason: "not_hive_managed",
+        }}
+        components={undefined}
+        isLoading={false}
+        isError={false}
+        width={360}
+        onWidthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Runtime details unavailable")).toBeInTheDocument();
+    expect(screen.getByText("not_hive_managed")).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
+++ b/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAgentSessionComponents } from "../useAgentSessionComponents";
+
+const mockApi = vi.hoisted(() => ({
+  channels: {
+    getAgentSessionComponents: vi.fn(),
+  },
+}));
+
+const auth = vi.hoisted(() => ({
+  getValidAccessToken: vi.fn(),
+  redirectToLogin: vi.fn(),
+}));
+
+const eventSources = vi.hoisted(() => [] as MockEventSource[]);
+
+class MockEventSource {
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public readonly url: string) {
+    eventSources.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+vi.stubGlobal("EventSource", MockEventSource);
+
+vi.mock("@/services/api", () => ({ api: { im: mockApi } }));
+vi.mock("@/services/api/im", () => ({ default: mockApi }));
+vi.mock("@/services/auth-session", () => auth);
+vi.mock("@/constants/api-base-url", () => ({
+  API_BASE_URL: "http://localhost:3000",
+}));
+
+function makeWrapper(
+  queryClient: QueryClient,
+): ComponentType<{ children: ReactNode }> {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useAgentSessionComponents", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    eventSources.length = 0;
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    auth.getValidAccessToken.mockResolvedValue("token-1");
+    mockApi.channels.getAgentSessionComponents.mockResolvedValue({
+      sessionId: "session-1",
+      components: [
+        {
+          id: "persona",
+          typeKey: "persona",
+          runtimeInjectedOnly: false,
+          latestData: null,
+        },
+      ],
+    });
+  });
+
+  it("loads initial components and opens authenticated SSE", async () => {
+    const { result } = renderHook(
+      () => useAgentSessionComponents("channel-1", true),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    await waitFor(() =>
+      expect(result.current.data?.components).toHaveLength(1),
+    );
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+    expect(eventSources[0].url).toContain(
+      "/v1/im/channels/channel-1/agent-session/events?token=token-1",
+    );
+  });
+
+  it("directly patches latestData from component_data_snapshot", async () => {
+    const { result } = renderHook(
+      () => useAgentSessionComponents("channel-1", true),
+      { wrapper: makeWrapper(queryClient) },
+    );
+    await waitFor(() =>
+      expect(result.current.data?.components).toHaveLength(1),
+    );
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    act(() => {
+      eventSources[0].onmessage?.({
+        data: JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "session-1",
+          timestamp: 1700000000000,
+          turnIndex: 2,
+          components: [{ componentId: "persona", data: { mood: "focused" } }],
+        }),
+      } as MessageEvent<string>);
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.components[0].latestData).toEqual({
+        data: { mood: "focused" },
+        capturedAtCallId: null,
+        capturedAt: 1700000000000,
+      }),
+    );
+    expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts unknown components and refetches once", async () => {
+    renderHook(() => useAgentSessionComponents("channel-1", true), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() =>
+      expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(
+        1,
+      ),
+    );
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    act(() => {
+      eventSources[0].onmessage?.({
+        data: JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "session-1",
+          timestamp: 1700000000100,
+          turnIndex: 3,
+          components: [{ componentId: "host", data: { cwd: "/tmp" } }],
+        }),
+      } as MessageEvent<string>);
+    });
+
+    await waitFor(() =>
+      expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(
+        2,
+      ),
+    );
+  });
+});

--- a/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
+++ b/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
@@ -2,7 +2,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ComponentType, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useAgentSessionComponents } from "../useAgentSessionComponents";
+import {
+  agentSessionComponentsKey,
+  useAgentSessionComponents,
+} from "../useAgentSessionComponents";
 
 const mockApi = vi.hoisted(() => ({
   channels: {
@@ -21,10 +24,29 @@ class MockEventSource {
   onopen: (() => void) | null = null;
   onmessage: ((event: MessageEvent<string>) => void) | null = null;
   onerror: (() => void) | null = null;
+  private readonly listeners = new Map<
+    string,
+    Array<(event: MessageEvent<string>) => void>
+  >();
   closed = false;
 
   constructor(public readonly url: string) {
     eventSources.push(this);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent<string>) => void,
+  ) {
+    const current = this.listeners.get(type) ?? [];
+    current.push(listener);
+    this.listeners.set(type, current);
+  }
+
+  dispatch(type: string, data: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ data } as MessageEvent<string>);
+    }
   }
 
   close() {
@@ -89,6 +111,17 @@ describe("useAgentSessionComponents", () => {
     );
   });
 
+  it("encodes the channel id in the SSE URL", async () => {
+    renderHook(() => useAgentSessionComponents("channel/1", true), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+    expect(eventSources[0].url).toContain(
+      "/v1/im/channels/channel%2F1/agent-session/events?token=token-1",
+    );
+  });
+
   it("directly patches latestData from component_data_snapshot", async () => {
     const { result } = renderHook(
       () => useAgentSessionComponents("channel-1", true),
@@ -121,6 +154,72 @@ describe("useAgentSessionComponents", () => {
     expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(1);
   });
 
+  it("handles named component_data_snapshot SSE events", async () => {
+    const { result } = renderHook(
+      () => useAgentSessionComponents("channel-1", true),
+      { wrapper: makeWrapper(queryClient) },
+    );
+    await waitFor(() =>
+      expect(result.current.data?.components).toHaveLength(1),
+    );
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    act(() => {
+      eventSources[0].dispatch(
+        "component_data_snapshot",
+        JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "session-1",
+          timestamp: 1700000000200,
+          turnIndex: 4,
+          components: [{ componentId: "persona", data: { mood: "named" } }],
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.components[0].latestData).toEqual({
+        data: { mood: "named" },
+        capturedAtCallId: null,
+        capturedAt: 1700000000200,
+      }),
+    );
+  });
+
+  it("ignores stale sessions and malformed component entries", async () => {
+    renderHook(() => useAgentSessionComponents("channel-1", true), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    act(() => {
+      eventSources[0].onmessage?.({
+        data: JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "old-session",
+          timestamp: 1700000000000,
+          turnIndex: 2,
+          components: [{ componentId: "persona", data: { mood: "stale" } }],
+        }),
+      } as MessageEvent<string>);
+      eventSources[0].onmessage?.({
+        data: JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "session-1",
+          timestamp: 1700000000001,
+          turnIndex: 3,
+          components: [{ componentId: 42, data: { mood: "bad" } }],
+        }),
+      } as MessageEvent<string>);
+    });
+
+    const cached = queryClient.getQueryData<{
+      components: Array<{ latestData: unknown }>;
+    }>(agentSessionComponentsKey("channel-1"));
+    expect(cached?.components[0].latestData).toBeNull();
+    expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(1);
+  });
+
   it("inserts unknown components and refetches once", async () => {
     renderHook(() => useAgentSessionComponents("channel-1", true), {
       wrapper: makeWrapper(queryClient),
@@ -149,5 +248,30 @@ describe("useAgentSessionComponents", () => {
         2,
       ),
     );
+  });
+
+  it("deduplicates reconnect timers after repeated errors", async () => {
+    renderHook(() => useAgentSessionComponents("channel-1", true), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        eventSources[0].onerror?.();
+        eventSources[0].onerror?.();
+      });
+      expect(eventSources[0].closed).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(2_000);
+        await Promise.resolve();
+      });
+
+      expect(eventSources).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
+++ b/apps/client/src/hooks/__tests__/useAgentSessionComponents.test.tsx
@@ -98,7 +98,7 @@ describe("useAgentSessionComponents", () => {
 
   it("loads initial components and opens authenticated SSE", async () => {
     const { result } = renderHook(
-      () => useAgentSessionComponents("channel-1", true),
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
       { wrapper: makeWrapper(queryClient) },
     );
 
@@ -112,9 +112,12 @@ describe("useAgentSessionComponents", () => {
   });
 
   it("encodes the channel id in the SSE URL", async () => {
-    renderHook(() => useAgentSessionComponents("channel/1", true), {
-      wrapper: makeWrapper(queryClient),
-    });
+    renderHook(
+      () => useAgentSessionComponents("channel/1", true, "session-1"),
+      {
+        wrapper: makeWrapper(queryClient),
+      },
+    );
 
     await waitFor(() => expect(eventSources).toHaveLength(1));
     expect(eventSources[0].url).toContain(
@@ -124,7 +127,7 @@ describe("useAgentSessionComponents", () => {
 
   it("directly patches latestData from component_data_snapshot", async () => {
     const { result } = renderHook(
-      () => useAgentSessionComponents("channel-1", true),
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
       { wrapper: makeWrapper(queryClient) },
     );
     await waitFor(() =>
@@ -156,7 +159,7 @@ describe("useAgentSessionComponents", () => {
 
   it("handles named component_data_snapshot SSE events", async () => {
     const { result } = renderHook(
-      () => useAgentSessionComponents("channel-1", true),
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
       { wrapper: makeWrapper(queryClient) },
     );
     await waitFor(() =>
@@ -186,10 +189,13 @@ describe("useAgentSessionComponents", () => {
     );
   });
 
-  it("ignores stale sessions and malformed component entries", async () => {
-    renderHook(() => useAgentSessionComponents("channel-1", true), {
-      wrapper: makeWrapper(queryClient),
-    });
+  it("refetches on stale sessions and ignores malformed component entries", async () => {
+    renderHook(
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
+      {
+        wrapper: makeWrapper(queryClient),
+      },
+    );
     await waitFor(() => expect(eventSources).toHaveLength(1));
 
     act(() => {
@@ -213,17 +219,25 @@ describe("useAgentSessionComponents", () => {
       } as MessageEvent<string>);
     });
 
+    await waitFor(() =>
+      expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(
+        2,
+      ),
+    );
+
     const cached = queryClient.getQueryData<{
       components: Array<{ latestData: unknown }>;
-    }>(agentSessionComponentsKey("channel-1"));
+    }>(agentSessionComponentsKey("channel-1", "session-1"));
     expect(cached?.components[0].latestData).toBeNull();
-    expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(1);
   });
 
   it("inserts unknown components and refetches once", async () => {
-    renderHook(() => useAgentSessionComponents("channel-1", true), {
-      wrapper: makeWrapper(queryClient),
-    });
+    renderHook(
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
+      {
+        wrapper: makeWrapper(queryClient),
+      },
+    );
     await waitFor(() =>
       expect(mockApi.channels.getAgentSessionComponents).toHaveBeenCalledTimes(
         1,
@@ -251,9 +265,12 @@ describe("useAgentSessionComponents", () => {
   });
 
   it("deduplicates reconnect timers after repeated errors", async () => {
-    renderHook(() => useAgentSessionComponents("channel-1", true), {
-      wrapper: makeWrapper(queryClient),
-    });
+    renderHook(
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
+      {
+        wrapper: makeWrapper(queryClient),
+      },
+    );
     await waitFor(() => expect(eventSources).toHaveLength(1));
 
     vi.useFakeTimers();
@@ -270,6 +287,53 @@ describe("useAgentSessionComponents", () => {
       });
 
       expect(eventSources).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("forces token refresh and resumes from the last event id after errors", async () => {
+    auth.getValidAccessToken
+      .mockResolvedValueOnce("token-1")
+      .mockResolvedValueOnce("token-2");
+
+    renderHook(
+      () => useAgentSessionComponents("channel-1", true, "session-1"),
+      {
+        wrapper: makeWrapper(queryClient),
+      },
+    );
+    await waitFor(() => expect(eventSources).toHaveLength(1));
+
+    act(() => {
+      eventSources[0].onmessage?.({
+        data: JSON.stringify({
+          type: "component_data_snapshot",
+          sessionId: "session-1",
+          timestamp: 1700000000300,
+          turnIndex: 5,
+          components: [{ componentId: "persona", data: { mood: "fresh" } }],
+        }),
+        lastEventId: "event-7",
+      } as MessageEvent<string>);
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        eventSources[0].onerror?.();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(eventSources).toHaveLength(2);
+      expect(auth.getValidAccessToken).toHaveBeenLastCalledWith({
+        forceRefresh: true,
+      });
+      expect(eventSources[1].url).toContain("token=token-2");
+      expect(eventSources[1].url).toContain("lastEventId=event-7");
     } finally {
       vi.useRealTimers();
     }

--- a/apps/client/src/hooks/useAgentSessionComponents.ts
+++ b/apps/client/src/hooks/useAgentSessionComponents.ts
@@ -1,0 +1,146 @@
+import { useEffect, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import imApi from "@/services/api/im";
+import { API_BASE_URL } from "@/constants/api-base-url";
+import { getValidAccessToken, redirectToLogin } from "@/services/auth-session";
+import type {
+  ComponentDataSnapshotEvent,
+  SafeSessionComponentItem,
+  SafeSessionComponentsResponse,
+} from "@/types/im";
+
+export function agentSessionComponentsKey(
+  channelId: string | null | undefined,
+) {
+  return ["channel-agent-session-components", channelId] as const;
+}
+
+function isSnapshotEvent(value: unknown): value is ComponentDataSnapshotEvent {
+  const event = value as ComponentDataSnapshotEvent;
+  return (
+    event?.type === "component_data_snapshot" &&
+    typeof event.timestamp === "number" &&
+    Array.isArray(event.components)
+  );
+}
+
+function patchComponents(
+  current: SafeSessionComponentsResponse | undefined,
+  event: ComponentDataSnapshotEvent,
+): { next: SafeSessionComponentsResponse | undefined; hasUnknown: boolean } {
+  if (!current) return { next: current, hasUnknown: false };
+
+  let hasUnknown = false;
+  const byId = new Map(
+    current.components.map((component) => [component.id, component]),
+  );
+
+  for (const update of event.components) {
+    const existing = byId.get(update.componentId);
+    const latestData = {
+      data: update.data,
+      capturedAtCallId: null,
+      capturedAt: event.timestamp,
+    };
+
+    if (existing) {
+      byId.set(update.componentId, { ...existing, latestData });
+    } else {
+      hasUnknown = true;
+      byId.set(update.componentId, {
+        id: update.componentId,
+        typeKey: update.componentId,
+        runtimeInjectedOnly: true,
+        latestData,
+      } satisfies SafeSessionComponentItem);
+    }
+  }
+
+  return {
+    next: { ...current, components: Array.from(byId.values()) },
+    hasUnknown,
+  };
+}
+
+export function useAgentSessionComponents(
+  channelId: string | null | undefined,
+  enabled = true,
+) {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(
+    () => agentSessionComponentsKey(channelId),
+    [channelId],
+  );
+  const isEnabled = enabled && !!channelId;
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () =>
+      imApi.channels.getAgentSessionComponents(channelId as string),
+    enabled: isEnabled,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (!isEnabled || !channelId) return;
+
+    let source: EventSource | null = null;
+    let disposed = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const open = async () => {
+      const token = await getValidAccessToken();
+      if (!token) {
+        if (!disposed) redirectToLogin();
+        return;
+      }
+      if (disposed) return;
+
+      source = new EventSource(
+        `${API_BASE_URL}/v1/im/channels/${channelId}/agent-session/events?token=${encodeURIComponent(
+          token,
+        )}`,
+      );
+      source.onopen = () => {
+        void queryClient.invalidateQueries({ queryKey });
+      };
+      source.onmessage = (message: MessageEvent<string>) => {
+        try {
+          const parsed = JSON.parse(message.data) as unknown;
+          if (!isSnapshotEvent(parsed)) return;
+
+          let shouldRefetch = false;
+          queryClient.setQueryData<SafeSessionComponentsResponse>(
+            queryKey,
+            (current) => {
+              const patched = patchComponents(current, parsed);
+              shouldRefetch = patched.hasUnknown;
+              return patched.next;
+            },
+          );
+          if (shouldRefetch) {
+            void queryClient.invalidateQueries({ queryKey });
+          }
+        } catch {
+          // Ignore heartbeats and malformed records.
+        }
+      };
+      source.onerror = () => {
+        if (disposed) return;
+        source?.close();
+        source = null;
+        reconnectTimer = setTimeout(() => void open(), 2_000);
+      };
+    };
+
+    void open();
+
+    return () => {
+      disposed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      source?.close();
+    };
+  }, [channelId, isEnabled, queryClient, queryKey]);
+
+  return query;
+}

--- a/apps/client/src/hooks/useAgentSessionComponents.ts
+++ b/apps/client/src/hooks/useAgentSessionComponents.ts
@@ -15,12 +15,24 @@ export function agentSessionComponentsKey(
   return ["channel-agent-session-components", channelId] as const;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function isSnapshotEvent(value: unknown): value is ComponentDataSnapshotEvent {
-  const event = value as ComponentDataSnapshotEvent;
+  if (!isRecord(value)) return false;
   return (
-    event?.type === "component_data_snapshot" &&
-    typeof event.timestamp === "number" &&
-    Array.isArray(event.components)
+    value.type === "component_data_snapshot" &&
+    typeof value.sessionId === "string" &&
+    typeof value.timestamp === "number" &&
+    typeof value.turnIndex === "number" &&
+    Array.isArray(value.components) &&
+    value.components.every(
+      (component) =>
+        isRecord(component) &&
+        typeof component.componentId === "string" &&
+        isRecord(component.data),
+    )
   );
 }
 
@@ -29,6 +41,9 @@ function patchComponents(
   event: ComponentDataSnapshotEvent,
 ): { next: SafeSessionComponentsResponse | undefined; hasUnknown: boolean } {
   if (!current) return { next: current, hasUnknown: false };
+  if (current.sessionId !== event.sessionId) {
+    return { next: current, hasUnknown: false };
+  }
 
   let hasUnknown = false;
   const byId = new Map(
@@ -97,14 +112,14 @@ export function useAgentSessionComponents(
       if (disposed) return;
 
       source = new EventSource(
-        `${API_BASE_URL}/v1/im/channels/${channelId}/agent-session/events?token=${encodeURIComponent(
-          token,
-        )}`,
+        `${API_BASE_URL}/v1/im/channels/${encodeURIComponent(
+          channelId,
+        )}/agent-session/events?token=${encodeURIComponent(token)}`,
       );
       source.onopen = () => {
         void queryClient.invalidateQueries({ queryKey });
       };
-      source.onmessage = (message: MessageEvent<string>) => {
+      const handleMessage = (message: MessageEvent<string>) => {
         try {
           const parsed = JSON.parse(message.data) as unknown;
           if (!isSnapshotEvent(parsed)) return;
@@ -125,11 +140,19 @@ export function useAgentSessionComponents(
           // Ignore heartbeats and malformed records.
         }
       };
+      source.onmessage = handleMessage;
+      source.addEventListener(
+        "component_data_snapshot",
+        handleMessage as EventListener,
+      );
       source.onerror = () => {
-        if (disposed) return;
+        if (disposed || reconnectTimer) return;
         source?.close();
         source = null;
-        reconnectTimer = setTimeout(() => void open(), 2_000);
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          void open();
+        }, 2_000);
       };
     };
 

--- a/apps/client/src/hooks/useAgentSessionComponents.ts
+++ b/apps/client/src/hooks/useAgentSessionComponents.ts
@@ -8,11 +8,17 @@ import type {
   SafeSessionComponentItem,
   SafeSessionComponentsResponse,
 } from "@/types/im";
+import { channelAgentSessionKey } from "./useChannelAgentSession";
 
 export function agentSessionComponentsKey(
   channelId: string | null | undefined,
+  sessionId?: string | null,
 ) {
-  return ["channel-agent-session-components", channelId] as const;
+  return [
+    "channel-agent-session-components",
+    channelId,
+    sessionId ?? null,
+  ] as const;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -39,10 +45,16 @@ function isSnapshotEvent(value: unknown): value is ComponentDataSnapshotEvent {
 function patchComponents(
   current: SafeSessionComponentsResponse | undefined,
   event: ComponentDataSnapshotEvent,
-): { next: SafeSessionComponentsResponse | undefined; hasUnknown: boolean } {
-  if (!current) return { next: current, hasUnknown: false };
+): {
+  next: SafeSessionComponentsResponse | undefined;
+  hasUnknown: boolean;
+  isStaleSession: boolean;
+} {
+  if (!current) {
+    return { next: current, hasUnknown: false, isStaleSession: false };
+  }
   if (current.sessionId !== event.sessionId) {
-    return { next: current, hasUnknown: false };
+    return { next: current, hasUnknown: false, isStaleSession: true };
   }
 
   let hasUnknown = false;
@@ -74,19 +86,21 @@ function patchComponents(
   return {
     next: { ...current, components: Array.from(byId.values()) },
     hasUnknown,
+    isStaleSession: false,
   };
 }
 
 export function useAgentSessionComponents(
   channelId: string | null | undefined,
   enabled = true,
+  sessionId?: string | null,
 ) {
   const queryClient = useQueryClient();
   const queryKey = useMemo(
-    () => agentSessionComponentsKey(channelId),
-    [channelId],
+    () => agentSessionComponentsKey(channelId, sessionId),
+    [channelId, sessionId],
   );
-  const isEnabled = enabled && !!channelId;
+  const isEnabled = enabled && !!channelId && !!sessionId;
 
   const query = useQuery({
     queryKey,
@@ -102,39 +116,54 @@ export function useAgentSessionComponents(
     let source: EventSource | null = null;
     let disposed = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let shouldForceRefresh = false;
+    let lastEventId: string | null = null;
 
     const open = async () => {
-      const token = await getValidAccessToken();
+      const token = shouldForceRefresh
+        ? await getValidAccessToken({ forceRefresh: true })
+        : await getValidAccessToken();
+      shouldForceRefresh = false;
       if (!token) {
         if (!disposed) redirectToLogin();
         return;
       }
       if (disposed) return;
 
+      const params = new URLSearchParams({ token });
+      if (lastEventId) params.set("lastEventId", lastEventId);
       source = new EventSource(
         `${API_BASE_URL}/v1/im/channels/${encodeURIComponent(
           channelId,
-        )}/agent-session/events?token=${encodeURIComponent(token)}`,
+        )}/agent-session/events?${params.toString()}`,
       );
       source.onopen = () => {
         void queryClient.invalidateQueries({ queryKey });
       };
       const handleMessage = (message: MessageEvent<string>) => {
+        if (message.lastEventId) lastEventId = message.lastEventId;
         try {
           const parsed = JSON.parse(message.data) as unknown;
           if (!isSnapshotEvent(parsed)) return;
 
           let shouldRefetch = false;
+          let isStaleSession = false;
           queryClient.setQueryData<SafeSessionComponentsResponse>(
             queryKey,
             (current) => {
               const patched = patchComponents(current, parsed);
-              shouldRefetch = patched.hasUnknown;
+              shouldRefetch = patched.hasUnknown || patched.isStaleSession;
+              isStaleSession = patched.isStaleSession;
               return patched.next;
             },
           );
           if (shouldRefetch) {
             void queryClient.invalidateQueries({ queryKey });
+          }
+          if (isStaleSession) {
+            void queryClient.invalidateQueries({
+              queryKey: channelAgentSessionKey(channelId),
+            });
           }
         } catch {
           // Ignore heartbeats and malformed records.
@@ -147,6 +176,7 @@ export function useAgentSessionComponents(
       );
       source.onerror = () => {
         if (disposed || reconnectTimer) return;
+        shouldForceRefresh = true;
         source?.close();
         source = null;
         reconnectTimer = setTimeout(() => {

--- a/apps/client/src/hooks/useChannelAgentSession.ts
+++ b/apps/client/src/hooks/useChannelAgentSession.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import imApi from "@/services/api/im";
+
+export function channelAgentSessionKey(channelId: string | null | undefined) {
+  return ["channel-agent-session", channelId] as const;
+}
+
+export function useChannelAgentSession(
+  channelId: string | null | undefined,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: channelAgentSessionKey(channelId),
+    queryFn: () => imApi.channels.getAgentSession(channelId as string),
+    enabled: enabled && !!channelId,
+    staleTime: 15_000,
+    retry: false,
+  });
+}

--- a/apps/client/src/services/api/__tests__/agent-session.test.ts
+++ b/apps/client/src/services/api/__tests__/agent-session.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHttp = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("../../http", () => ({
+  default: mockHttp,
+}));
+
+vi.mock("@/lib/tauri", () => ({ isTauriApp: vi.fn() }));
+vi.mock("@/stores/useAhandStore", () => ({
+  useAhandStore: { getState: vi.fn() },
+}));
+vi.mock("@/stores/useAppStore", () => ({
+  useAppStore: { getState: vi.fn() },
+}));
+vi.mock("../normalize-reactions", () => ({
+  normalizeMessage: (message: unknown) => message,
+  normalizeMessages: (messages: unknown) => messages,
+}));
+
+import { channelsApi } from "../im";
+
+describe("channelsApi agent session endpoints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getAgentSession calls the channel agent-session endpoint and unwraps data", async () => {
+    const payload = {
+      channelId: "ch-1",
+      channelType: "direct",
+      kind: "dm",
+      supported: true,
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      botUserId: "bot-1",
+      sessionId: "session-1",
+    };
+    mockHttp.get.mockResolvedValueOnce({ data: payload });
+
+    const result = await channelsApi.getAgentSession("ch-1");
+
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      "/v1/im/channels/ch-1/agent-session",
+    );
+    expect(result).toBe(payload);
+  });
+
+  it("getAgentSessionComponents calls the channel components endpoint and unwraps data", async () => {
+    const payload = {
+      sessionId: "session-1",
+      components: [
+        {
+          id: "component-1",
+          typeKey: "summary",
+          runtimeInjectedOnly: false,
+          latestData: {
+            data: { text: "hello" },
+            capturedAtCallId: null,
+            capturedAt: 123,
+          },
+        },
+      ],
+    };
+    mockHttp.get.mockResolvedValueOnce({ data: payload });
+
+    const result = await channelsApi.getAgentSessionComponents("ch-1");
+
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      "/v1/im/channels/ch-1/agent-session/components",
+    );
+    expect(result).toBe(payload);
+  });
+});

--- a/apps/client/src/services/api/im.ts
+++ b/apps/client/src/services/api/im.ts
@@ -30,6 +30,8 @@ import type {
   GetSubRepliesParams,
   SyncMessagesResponse,
   SyncAckDto,
+  AgentSessionBinding,
+  SafeSessionComponentsResponse,
 } from "@/types/im";
 import { normalizeMessage, normalizeMessages } from "./normalize-reactions";
 
@@ -176,6 +178,22 @@ export const channelsApi = {
     await http.patch(`/v1/im/channels/${channelId}/sidebar-visibility`, {
       show,
     });
+  },
+
+  getAgentSession: async (channelId: string): Promise<AgentSessionBinding> => {
+    const response = await http.get<AgentSessionBinding>(
+      `/v1/im/channels/${channelId}/agent-session`,
+    );
+    return response.data;
+  },
+
+  getAgentSessionComponents: async (
+    channelId: string,
+  ): Promise<SafeSessionComponentsResponse> => {
+    const response = await http.get<SafeSessionComponentsResponse>(
+      `/v1/im/channels/${channelId}/agent-session/components`,
+    );
+    return response.data;
   },
 
   // Get the effective LLM model for this channel's agent session.

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -20,6 +20,78 @@ export type MemberRole = "owner" | "admin" | "member";
 export type UserStatus = "online" | "offline" | "away" | "busy";
 export type MessageSendStatus = "sending" | "sent" | "failed";
 export type AgentType = "base_model" | "openclaw";
+export type AgentSessionBindingKind =
+  | "dm"
+  | "routine-creation"
+  | "topic-session"
+  | "routine-execution"
+  | "tracking";
+
+export type AgentSessionUnsupportedReason =
+  | "no_bot"
+  | "not_hive_managed"
+  | "session_not_created";
+
+export interface AgentSessionStatus {
+  exists: boolean;
+  status?: "active" | "disposed";
+  ownedBy?: string | null;
+  queueLength?: number;
+  activityState?: "active" | "inactive";
+  unavailableReason?: "not_found" | "agent_pi_unavailable";
+}
+
+export interface AgentSessionBinding {
+  channelId: string;
+  channelType: ChannelType;
+  kind: AgentSessionBindingKind | null;
+  supported: boolean;
+  unsupportedReason?: AgentSessionUnsupportedReason;
+  tenantId: string | null;
+  agentId: string | null;
+  botUserId: string | null;
+  sessionId: string | null;
+  routineId?: string;
+  executionId?: string;
+  taskcastTaskId?: string | null;
+  taskStatus?: string;
+  status?: AgentSessionStatus;
+}
+
+export interface SafeSessionComponentItem {
+  id: string;
+  typeKey: string;
+  priority?: number;
+  runtimeInjectedOnly: boolean;
+  schema?: unknown[];
+  latestData: {
+    data: Record<string, unknown>;
+    capturedAtCallId: string | null;
+    capturedAt: number;
+  } | null;
+}
+
+export interface SafeSessionComponentsResponse {
+  sessionId: string;
+  components: SafeSessionComponentItem[];
+}
+
+export interface AgentSessionEvent {
+  type: string;
+  sessionId: string;
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+export interface ComponentDataSnapshotEvent extends AgentSessionEvent {
+  type: "component_data_snapshot";
+  timestamp: number;
+  turnIndex: number;
+  components: Array<{
+    componentId: string;
+    data: Record<string, unknown>;
+  }>;
+}
 
 export interface AgentEventMetadata {
   agentEventType:

--- a/apps/client/src/types/im.ts
+++ b/apps/client/src/types/im.ts
@@ -30,6 +30,7 @@ export type AgentSessionBindingKind =
 export type AgentSessionUnsupportedReason =
   | "no_bot"
   | "not_hive_managed"
+  | "ambiguous_bot"
   | "session_not_created";
 
 export interface AgentSessionStatus {

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
@@ -134,6 +134,60 @@ describe('AgentSessionBindingService', () => {
     });
   });
 
+  it('does not support a topic-session setting without an active Hive bot row', async () => {
+    dbMock.push([
+      {
+        id: 'topic-1',
+        tenantId: 'tenant-1',
+        type: 'topic-session',
+        propertySettings: {
+          topicSession: {
+            agentId: 'agent-from-settings',
+            sessionId: 'team9/tenant-1/agent-from-settings/dm/topic-1',
+          },
+        },
+      },
+    ]);
+    dbMock.push([]);
+
+    await expect(service.resolve('topic-1', 'user-1')).resolves.toMatchObject({
+      kind: 'topic-session',
+      supported: false,
+      unsupportedReason: 'no_bot',
+      sessionId: null,
+    });
+  });
+
+  it('does not let topic-session settings override a non-Hive bot row', async () => {
+    dbMock.push([
+      {
+        id: 'topic-1',
+        tenantId: 'tenant-1',
+        type: 'topic-session',
+        propertySettings: {
+          topicSession: {
+            agentId: 'agent-from-settings',
+            sessionId: 'team9/tenant-1/agent-from-settings/dm/topic-1',
+          },
+        },
+      },
+    ]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        managedProvider: 'openclaw',
+        managedMeta: { instanceId: 'instance-1' },
+      },
+    ]);
+
+    await expect(service.resolve('topic-1', 'user-1')).resolves.toMatchObject({
+      kind: 'topic-session',
+      supported: false,
+      unsupportedReason: 'not_hive_managed',
+      sessionId: null,
+    });
+  });
+
   it('resolves a routine creation session channel', async () => {
     dbMock.push([
       { id: 'routine-channel', tenantId: 'tenant-1', type: 'routine-session' },

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
@@ -26,11 +26,18 @@ function createDbMock() {
 
 describe('AgentSessionBindingService', () => {
   let dbMock: ReturnType<typeof createDbMock>;
+  let channelsService: { assertReadAccess: jest.Mock<(...args: any[]) => any> };
   let service: AgentSessionBindingService;
 
   beforeEach(() => {
     dbMock = createDbMock();
-    service = new AgentSessionBindingService(dbMock.db as any);
+    channelsService = {
+      assertReadAccess: jest.fn<any>().mockResolvedValue(undefined),
+    };
+    service = new AgentSessionBindingService(
+      dbMock.db as any,
+      channelsService as any,
+    );
   });
 
   it('throws 404 when the channel does not exist', async () => {
@@ -43,16 +50,21 @@ describe('AgentSessionBindingService', () => {
 
   it('throws 403 when the user is not a channel member', async () => {
     dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
-    dbMock.push([]);
+    channelsService.assertReadAccess.mockRejectedValueOnce(
+      new ForbiddenException('Access denied'),
+    );
 
     await expect(service.resolve('channel-1', 'user-1')).rejects.toBeInstanceOf(
       ForbiddenException,
+    );
+    expect(channelsService.assertReadAccess).toHaveBeenCalledWith(
+      'channel-1',
+      'user-1',
     );
   });
 
   it('derives a direct bot DM session id', async () => {
     dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
-    dbMock.push([{ id: 'member-1' }]);
     dbMock.push([
       {
         botUserId: 'bot-user-1',
@@ -73,6 +85,26 @@ describe('AgentSessionBindingService', () => {
     );
   });
 
+  it('derives a tracking channel session id after read access is granted', async () => {
+    dbMock.push([{ id: 'track-1', tenantId: 'tenant-1', type: 'tracking' }]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(service.resolve('track-1', 'user-1')).resolves.toMatchObject({
+      channelId: 'track-1',
+      kind: 'tracking',
+      supported: true,
+      agentId: 'agent-1',
+      botUserId: 'bot-user-1',
+      sessionId: 'team9/tenant-1/agent-1/tracking/track-1',
+    });
+  });
+
   it('prefers topic-session propertySettings session id', async () => {
     dbMock.push([
       {
@@ -87,7 +119,6 @@ describe('AgentSessionBindingService', () => {
         },
       },
     ]);
-    dbMock.push([{ id: 'member-1' }]);
     dbMock.push([
       {
         botUserId: 'bot-user-1',
@@ -103,9 +134,98 @@ describe('AgentSessionBindingService', () => {
     });
   });
 
+  it('resolves a routine creation session channel', async () => {
+    dbMock.push([
+      { id: 'routine-channel', tenantId: 'tenant-1', type: 'routine-session' },
+    ]);
+    dbMock.push([
+      {
+        routineId: 'routine-1',
+        creationSessionId: 'team9/tenant-1/agent-1/dm/routine-channel',
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('routine-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-creation',
+      supported: true,
+      routineId: 'routine-1',
+      agentId: 'agent-1',
+      botUserId: 'bot-user-1',
+      sessionId: 'team9/tenant-1/agent-1/dm/routine-channel',
+    });
+  });
+
+  it('returns unsupported when a routine creation channel has no routine row', async () => {
+    dbMock.push([
+      { id: 'routine-channel', tenantId: 'tenant-1', type: 'routine-session' },
+    ]);
+    dbMock.push([]);
+
+    await expect(
+      service.resolve('routine-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-creation',
+      supported: false,
+      unsupportedReason: 'no_bot',
+      sessionId: null,
+    });
+  });
+
+  it('returns unsupported when a routine creation channel is not Hive-managed', async () => {
+    dbMock.push([
+      { id: 'routine-channel', tenantId: 'tenant-1', type: 'routine-session' },
+    ]);
+    dbMock.push([
+      {
+        routineId: 'routine-1',
+        creationSessionId: 'team9/tenant-1/agent-1/dm/routine-channel',
+        botUserId: 'bot-user-1',
+        managedProvider: 'openclaw',
+        managedMeta: { instanceId: 'instance-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('routine-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-creation',
+      supported: false,
+      unsupportedReason: 'not_hive_managed',
+      sessionId: null,
+    });
+  });
+
+  it('returns unsupported when a routine creation session is missing', async () => {
+    dbMock.push([
+      { id: 'routine-channel', tenantId: 'tenant-1', type: 'routine-session' },
+    ]);
+    dbMock.push([
+      {
+        routineId: 'routine-1',
+        creationSessionId: null,
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('routine-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-creation',
+      supported: false,
+      unsupportedReason: 'session_not_created',
+      sessionId: null,
+    });
+  });
+
   it('resolves a Hive routine execution task channel', async () => {
     dbMock.push([{ id: 'task-channel', tenantId: 'tenant-1', type: 'task' }]);
-    dbMock.push([{ id: 'member-1' }]);
     dbMock.push([
       {
         executionId: 'exec-1',
@@ -127,12 +247,12 @@ describe('AgentSessionBindingService', () => {
       routineId: 'routine-1',
       executionId: 'exec-1',
       taskcastTaskId: 'agent_task_exec_exec-1',
+      taskStatus: 'in_progress',
     });
   });
 
   it('returns unsupported for OpenClaw task channel', async () => {
     dbMock.push([{ id: 'task-channel', tenantId: 'tenant-1', type: 'task' }]);
-    dbMock.push([{ id: 'member-1' }]);
     dbMock.push([
       {
         executionId: 'exec-1',

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
@@ -1,0 +1,155 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AgentSessionBindingService } from './agent-session-binding.service.js';
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+function createDbMock() {
+  const rows: unknown[][] = [];
+  const chain: Record<string, MockFn> = {};
+  for (const method of [
+    'select',
+    'from',
+    'where',
+    'limit',
+    'innerJoin',
+    'leftJoin',
+  ]) {
+    chain[method] = jest.fn<any>().mockReturnValue(chain);
+  }
+  chain.limit.mockImplementation(() => Promise.resolve(rows.shift() ?? []));
+  return {
+    db: chain,
+    push: (result: unknown[]) => rows.push(result),
+  };
+}
+
+describe('AgentSessionBindingService', () => {
+  let dbMock: ReturnType<typeof createDbMock>;
+  let service: AgentSessionBindingService;
+
+  beforeEach(() => {
+    dbMock = createDbMock();
+    service = new AgentSessionBindingService(dbMock.db as any);
+  });
+
+  it('throws 404 when the channel does not exist', async () => {
+    dbMock.push([]);
+
+    await expect(service.resolve('channel-1', 'user-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('throws 403 when the user is not a channel member', async () => {
+    dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
+    dbMock.push([]);
+
+    await expect(service.resolve('channel-1', 'user-1')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('derives a direct bot DM session id', async () => {
+    dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
+    dbMock.push([{ id: 'member-1' }]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(service.resolve('channel-1', 'user-1')).resolves.toMatchObject(
+      {
+        channelId: 'channel-1',
+        kind: 'dm',
+        supported: true,
+        agentId: 'agent-1',
+        botUserId: 'bot-user-1',
+        sessionId: 'team9/tenant-1/agent-1/dm/channel-1',
+      },
+    );
+  });
+
+  it('prefers topic-session propertySettings session id', async () => {
+    dbMock.push([
+      {
+        id: 'topic-1',
+        tenantId: 'tenant-1',
+        type: 'topic-session',
+        propertySettings: {
+          topicSession: {
+            agentId: 'agent-from-settings',
+            sessionId: 'team9/tenant-1/agent-from-settings/dm/topic-1',
+          },
+        },
+      },
+    ]);
+    dbMock.push([{ id: 'member-1' }]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-from-bot' },
+      },
+    ]);
+
+    await expect(service.resolve('topic-1', 'user-1')).resolves.toMatchObject({
+      kind: 'topic-session',
+      agentId: 'agent-from-settings',
+      sessionId: 'team9/tenant-1/agent-from-settings/dm/topic-1',
+    });
+  });
+
+  it('resolves a Hive routine execution task channel', async () => {
+    dbMock.push([{ id: 'task-channel', tenantId: 'tenant-1', type: 'task' }]);
+    dbMock.push([{ id: 'member-1' }]);
+    dbMock.push([
+      {
+        executionId: 'exec-1',
+        routineId: 'routine-1',
+        taskcastTaskId: 'agent_task_exec_exec-1',
+        taskStatus: 'in_progress',
+        botUserId: 'bot-user-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('task-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-execution',
+      supported: true,
+      sessionId: 'team9/tenant-1/agent-1/routine/exec-1',
+      routineId: 'routine-1',
+      executionId: 'exec-1',
+      taskcastTaskId: 'agent_task_exec_exec-1',
+    });
+  });
+
+  it('returns unsupported for OpenClaw task channel', async () => {
+    dbMock.push([{ id: 'task-channel', tenantId: 'tenant-1', type: 'task' }]);
+    dbMock.push([{ id: 'member-1' }]);
+    dbMock.push([
+      {
+        executionId: 'exec-1',
+        routineId: 'routine-1',
+        taskStatus: 'in_progress',
+        botUserId: 'bot-user-1',
+        managedProvider: 'openclaw',
+        managedMeta: { instanceId: 'instance-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('task-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      supported: false,
+      unsupportedReason: 'not_hive_managed',
+      sessionId: null,
+    });
+  });
+});

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.spec.ts
@@ -85,6 +85,52 @@ describe('AgentSessionBindingService', () => {
     );
   });
 
+  it('does not bind a channel to a bot from another tenant', async () => {
+    dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        botTenantId: 'other-tenant',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(service.resolve('channel-1', 'user-1')).resolves.toMatchObject(
+      {
+        supported: false,
+        unsupportedReason: 'no_bot',
+        sessionId: null,
+      },
+    );
+  });
+
+  it('rejects ambiguous channels with multiple active Hive bots', async () => {
+    dbMock.push([{ id: 'channel-1', tenantId: 'tenant-1', type: 'direct' }]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        botTenantId: 'tenant-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+      {
+        botUserId: 'bot-user-2',
+        botTenantId: 'tenant-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-2' },
+      },
+    ]);
+
+    await expect(service.resolve('channel-1', 'user-1')).resolves.toMatchObject(
+      {
+        supported: false,
+        unsupportedReason: 'ambiguous_bot',
+        sessionId: null,
+      },
+    );
+  });
+
   it('derives a tracking channel session id after read access is granted', async () => {
     dbMock.push([{ id: 'track-1', tenantId: 'tenant-1', type: 'tracking' }]);
     dbMock.push([
@@ -131,6 +177,37 @@ describe('AgentSessionBindingService', () => {
       kind: 'topic-session',
       agentId: 'agent-from-settings',
       sessionId: 'team9/tenant-1/agent-from-settings/dm/topic-1',
+    });
+  });
+
+  it('rejects malformed topic-session settings for another channel scope', async () => {
+    dbMock.push([
+      {
+        id: 'topic-1',
+        tenantId: 'tenant-1',
+        type: 'topic-session',
+        propertySettings: {
+          topicSession: {
+            agentId: 'agent-from-settings',
+            sessionId: 'team9/tenant-1/agent-from-settings/dm/other-channel',
+          },
+        },
+      },
+    ]);
+    dbMock.push([
+      {
+        botUserId: 'bot-user-1',
+        botTenantId: 'tenant-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-from-settings' },
+      },
+    ]);
+
+    await expect(service.resolve('topic-1', 'user-1')).resolves.toMatchObject({
+      kind: 'topic-session',
+      supported: false,
+      unsupportedReason: 'session_not_created',
+      sessionId: null,
     });
   });
 
@@ -211,6 +288,38 @@ describe('AgentSessionBindingService', () => {
       agentId: 'agent-1',
       botUserId: 'bot-user-1',
       sessionId: 'team9/tenant-1/agent-1/dm/routine-channel',
+    });
+  });
+
+  it('rejects a routine creation row that does not match the channel setting', async () => {
+    dbMock.push([
+      {
+        id: 'routine-channel',
+        tenantId: 'tenant-1',
+        type: 'routine-session',
+        propertySettings: {
+          routineSession: { purpose: 'creation', routineId: 'routine-1' },
+        },
+      },
+    ]);
+    dbMock.push([
+      {
+        routineId: 'other-routine',
+        creationSessionId: 'team9/tenant-1/agent-1/dm/routine-channel',
+        botUserId: 'bot-user-1',
+        botTenantId: 'tenant-1',
+        managedProvider: 'hive',
+        managedMeta: { agentId: 'agent-1' },
+      },
+    ]);
+
+    await expect(
+      service.resolve('routine-channel', 'user-1'),
+    ).resolves.toMatchObject({
+      kind: 'routine-creation',
+      supported: false,
+      unsupportedReason: 'session_not_created',
+      sessionId: null,
     });
   });
 

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
@@ -4,10 +4,14 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { DATABASE_CONNECTION } from '@team9/database';
+import {
+  DATABASE_CONNECTION,
+  and,
+  eq,
+  isNull,
+  type PostgresJsDatabase,
+} from '@team9/database';
 import * as schema from '@team9/database/schemas';
-import { and, eq, isNull } from 'drizzle-orm';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   AgentSessionBindingKind,
   AgentSessionBindingResponse,

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
@@ -1,9 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  ForbiddenException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import {
   DATABASE_CONNECTION,
   and,
@@ -17,6 +12,7 @@ import type {
   AgentSessionBindingResponse,
   AgentSessionUnsupportedReason,
 } from './agent-session.types.js';
+import { ChannelsService } from '../channels/channels.service.js';
 
 type ChannelRow = {
   id: string;
@@ -48,6 +44,7 @@ export class AgentSessionBindingService {
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly channelsService: ChannelsService,
   ) {}
 
   async resolve(
@@ -59,10 +56,7 @@ export class AgentSessionBindingService {
       throw new NotFoundException('Channel not found');
     }
 
-    const member = await this.findMembership(channelId, userId);
-    if (!member) {
-      throw new ForbiddenException('User is not a channel member');
-    }
+    await this.channelsService.assertReadAccess(channelId, userId);
 
     if (channel.type === 'task') {
       return this.resolveRoutineExecution(channel);
@@ -92,25 +86,6 @@ export class AgentSessionBindingService {
     return (channel as ChannelRow | undefined) ?? null;
   }
 
-  private async findMembership(
-    channelId: string,
-    userId: string,
-  ): Promise<{ id: string } | null> {
-    const [member] = await this.db
-      .select({ id: schema.channelMembers.id })
-      .from(schema.channelMembers)
-      .where(
-        and(
-          eq(schema.channelMembers.channelId, channelId),
-          eq(schema.channelMembers.userId, userId),
-          isNull(schema.channelMembers.leftAt),
-        ),
-      )
-      .limit(1);
-
-    return (member as { id: string } | undefined) ?? null;
-  }
-
   private async findChannelBot(
     channelId: string,
   ): Promise<BotBindingRow | null> {
@@ -122,6 +97,10 @@ export class AgentSessionBindingService {
       })
       .from(schema.channelMembers)
       .innerJoin(
+        schema.users,
+        eq(schema.users.id, schema.channelMembers.userId),
+      )
+      .innerJoin(
         schema.bots,
         eq(schema.bots.userId, schema.channelMembers.userId),
       )
@@ -129,6 +108,9 @@ export class AgentSessionBindingService {
         and(
           eq(schema.channelMembers.channelId, channelId),
           isNull(schema.channelMembers.leftAt),
+          eq(schema.users.userType, 'bot'),
+          eq(schema.users.isActive, true),
+          eq(schema.bots.isActive, true),
         ),
       )
       .limit(1);
@@ -149,7 +131,15 @@ export class AgentSessionBindingService {
       })
       .from(schema.routines)
       .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
-      .where(eq(schema.routines.creationChannelId, channel.id))
+      .leftJoin(schema.users, eq(schema.users.id, schema.bots.userId))
+      .where(
+        and(
+          eq(schema.routines.creationChannelId, channel.id),
+          eq(schema.users.userType, 'bot'),
+          eq(schema.users.isActive, true),
+          eq(schema.bots.isActive, true),
+        ),
+      )
       .limit(1);
 
     const row = (routine as RoutineSessionRow | undefined) ?? null;
@@ -201,7 +191,15 @@ export class AgentSessionBindingService {
         eq(schema.routines.id, schema.routineExecutions.routineId),
       )
       .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
-      .where(eq(schema.routineExecutions.channelId, channel.id))
+      .leftJoin(schema.users, eq(schema.users.id, schema.bots.userId))
+      .where(
+        and(
+          eq(schema.routineExecutions.channelId, channel.id),
+          eq(schema.users.userType, 'bot'),
+          eq(schema.users.isActive, true),
+          eq(schema.bots.isActive, true),
+        ),
+      )
       .limit(1);
 
     const row = (execution as RoutineExecutionRow | undefined) ?? null;

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
@@ -240,25 +240,11 @@ export class AgentSessionBindingService {
     const settingsSessionId = topicSession?.sessionId ?? null;
 
     if (!bot) {
-      if (
-        settingsAgentId &&
-        settingsSessionId &&
-        channel.type === 'topic-session'
-      ) {
-        return {
-          ...this.base(channel, 'topic-session'),
-          supported: true,
-          agentId: settingsAgentId,
-          botUserId: null,
-          sessionId: settingsSessionId,
-        };
-      }
-
       return this.unsupported(channel, kind, 'no_bot');
     }
 
     const unsupported = this.getUnsupportedReason(bot);
-    if (unsupported && !(settingsAgentId && settingsSessionId)) {
+    if (unsupported) {
       return this.unsupported(channel, kind, unsupported, bot);
     }
 

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
@@ -1,0 +1,361 @@
+import {
+  Inject,
+  Injectable,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { DATABASE_CONNECTION } from '@team9/database';
+import * as schema from '@team9/database/schemas';
+import { and, eq, isNull } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  AgentSessionBindingKind,
+  AgentSessionBindingResponse,
+  AgentSessionUnsupportedReason,
+} from './agent-session.types.js';
+
+type ChannelRow = {
+  id: string;
+  tenantId: string | null;
+  type: string;
+  propertySettings?: unknown;
+};
+
+type BotBindingRow = {
+  botUserId: string | null;
+  managedProvider: string | null;
+  managedMeta: schema.ManagedMeta | null;
+};
+
+type RoutineSessionRow = BotBindingRow & {
+  routineId: string;
+  creationSessionId: string | null;
+};
+
+type RoutineExecutionRow = BotBindingRow & {
+  executionId: string;
+  routineId: string;
+  taskcastTaskId: string | null;
+  taskStatus: string;
+};
+
+@Injectable()
+export class AgentSessionBindingService {
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  async resolve(
+    channelId: string,
+    userId: string,
+  ): Promise<AgentSessionBindingResponse> {
+    const channel = await this.findChannel(channelId);
+    if (!channel) {
+      throw new NotFoundException('Channel not found');
+    }
+
+    const member = await this.findMembership(channelId, userId);
+    if (!member) {
+      throw new ForbiddenException('User is not a channel member');
+    }
+
+    if (channel.type === 'task') {
+      return this.resolveRoutineExecution(channel);
+    }
+
+    if (channel.type === 'routine-session') {
+      return this.resolveRoutineSession(channel);
+    }
+
+    const bot = await this.findChannelBot(channel.id);
+    const kind = this.kindForChannelType(channel.type);
+    return this.resolveBotChannel(channel, kind, bot);
+  }
+
+  private async findChannel(channelId: string): Promise<ChannelRow | null> {
+    const [channel] = await this.db
+      .select({
+        id: schema.channels.id,
+        tenantId: schema.channels.tenantId,
+        type: schema.channels.type,
+        propertySettings: schema.channels.propertySettings,
+      })
+      .from(schema.channels)
+      .where(eq(schema.channels.id, channelId))
+      .limit(1);
+
+    return (channel as ChannelRow | undefined) ?? null;
+  }
+
+  private async findMembership(
+    channelId: string,
+    userId: string,
+  ): Promise<{ id: string } | null> {
+    const [member] = await this.db
+      .select({ id: schema.channelMembers.id })
+      .from(schema.channelMembers)
+      .where(
+        and(
+          eq(schema.channelMembers.channelId, channelId),
+          eq(schema.channelMembers.userId, userId),
+          isNull(schema.channelMembers.leftAt),
+        ),
+      )
+      .limit(1);
+
+    return (member as { id: string } | undefined) ?? null;
+  }
+
+  private async findChannelBot(
+    channelId: string,
+  ): Promise<BotBindingRow | null> {
+    const [bot] = await this.db
+      .select({
+        botUserId: schema.bots.userId,
+        managedProvider: schema.bots.managedProvider,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.channelMembers)
+      .innerJoin(
+        schema.bots,
+        eq(schema.bots.userId, schema.channelMembers.userId),
+      )
+      .where(
+        and(
+          eq(schema.channelMembers.channelId, channelId),
+          isNull(schema.channelMembers.leftAt),
+        ),
+      )
+      .limit(1);
+
+    return (bot as BotBindingRow | undefined) ?? null;
+  }
+
+  private async resolveRoutineSession(
+    channel: ChannelRow,
+  ): Promise<AgentSessionBindingResponse> {
+    const [routine] = await this.db
+      .select({
+        routineId: schema.routines.id,
+        creationSessionId: schema.routines.creationSessionId,
+        botUserId: schema.bots.userId,
+        managedProvider: schema.bots.managedProvider,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.routines)
+      .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
+      .where(eq(schema.routines.creationChannelId, channel.id))
+      .limit(1);
+
+    const row = (routine as RoutineSessionRow | undefined) ?? null;
+    if (!row) {
+      return this.unsupported(channel, 'routine-creation', 'no_bot');
+    }
+
+    const unsupported = this.getUnsupportedReason(row);
+    if (unsupported) {
+      return this.unsupported(channel, 'routine-creation', unsupported, row);
+    }
+
+    const agentId = row.managedMeta?.agentId ?? null;
+    if (!row.creationSessionId) {
+      return this.unsupported(
+        channel,
+        'routine-creation',
+        'session_not_created',
+        row,
+      );
+    }
+
+    return {
+      ...this.base(channel, 'routine-creation'),
+      supported: true,
+      agentId,
+      botUserId: row.botUserId,
+      sessionId: row.creationSessionId,
+      routineId: row.routineId,
+    };
+  }
+
+  private async resolveRoutineExecution(
+    channel: ChannelRow,
+  ): Promise<AgentSessionBindingResponse> {
+    const [execution] = await this.db
+      .select({
+        executionId: schema.routineExecutions.id,
+        routineId: schema.routineExecutions.routineId,
+        taskcastTaskId: schema.routineExecutions.taskcastTaskId,
+        taskStatus: schema.routineExecutions.status,
+        botUserId: schema.bots.userId,
+        managedProvider: schema.bots.managedProvider,
+        managedMeta: schema.bots.managedMeta,
+      })
+      .from(schema.routineExecutions)
+      .innerJoin(
+        schema.routines,
+        eq(schema.routines.id, schema.routineExecutions.routineId),
+      )
+      .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
+      .where(eq(schema.routineExecutions.channelId, channel.id))
+      .limit(1);
+
+    const row = (execution as RoutineExecutionRow | undefined) ?? null;
+    if (!row) {
+      return this.unsupported(
+        channel,
+        'routine-execution',
+        'session_not_created',
+      );
+    }
+
+    const unsupported = this.getUnsupportedReason(row);
+    if (unsupported) {
+      return this.unsupported(channel, 'routine-execution', unsupported, row);
+    }
+
+    const agentId = row.managedMeta?.agentId ?? null;
+    return {
+      ...this.base(channel, 'routine-execution'),
+      supported: true,
+      agentId,
+      botUserId: row.botUserId,
+      sessionId: `team9/${channel.tenantId ?? ''}/${agentId}/routine/${row.executionId}`,
+      routineId: row.routineId,
+      executionId: row.executionId,
+      taskcastTaskId: row.taskcastTaskId,
+      taskStatus: row.taskStatus,
+    };
+  }
+
+  private resolveBotChannel(
+    channel: ChannelRow,
+    kind: AgentSessionBindingKind | null,
+    bot: BotBindingRow | null,
+  ): AgentSessionBindingResponse {
+    const topicSession = this.getTopicSessionSettings(channel);
+    const settingsAgentId = topicSession?.agentId ?? null;
+    const settingsSessionId = topicSession?.sessionId ?? null;
+
+    if (!bot) {
+      if (
+        settingsAgentId &&
+        settingsSessionId &&
+        channel.type === 'topic-session'
+      ) {
+        return {
+          ...this.base(channel, 'topic-session'),
+          supported: true,
+          agentId: settingsAgentId,
+          botUserId: null,
+          sessionId: settingsSessionId,
+        };
+      }
+
+      return this.unsupported(channel, kind, 'no_bot');
+    }
+
+    const unsupported = this.getUnsupportedReason(bot);
+    if (unsupported && !(settingsAgentId && settingsSessionId)) {
+      return this.unsupported(channel, kind, unsupported, bot);
+    }
+
+    const agentId = settingsAgentId ?? bot.managedMeta?.agentId ?? null;
+    const sessionId =
+      settingsSessionId ?? this.buildSessionId(channel, kind, agentId);
+
+    if (!agentId || !sessionId) {
+      return this.unsupported(channel, kind, 'session_not_created', bot);
+    }
+
+    return {
+      ...this.base(channel, kind),
+      supported: true,
+      agentId,
+      botUserId: bot.botUserId,
+      sessionId,
+    };
+  }
+
+  private getUnsupportedReason(
+    bot: BotBindingRow,
+  ): AgentSessionUnsupportedReason | null {
+    if (!bot.botUserId) return 'no_bot';
+    if (bot.managedProvider !== 'hive' || !bot.managedMeta?.agentId) {
+      return 'not_hive_managed';
+    }
+    return null;
+  }
+
+  private unsupported(
+    channel: ChannelRow,
+    kind: AgentSessionBindingKind | null,
+    unsupportedReason: AgentSessionUnsupportedReason,
+    bot?: Partial<BotBindingRow> | null,
+  ): AgentSessionBindingResponse {
+    return {
+      ...this.base(channel, kind),
+      supported: false,
+      unsupportedReason,
+      agentId: bot?.managedMeta?.agentId ?? null,
+      botUserId: bot?.botUserId ?? null,
+      sessionId: null,
+    };
+  }
+
+  private base(
+    channel: ChannelRow,
+    kind: AgentSessionBindingKind | null,
+  ): Omit<
+    AgentSessionBindingResponse,
+    'supported' | 'unsupportedReason' | 'agentId' | 'botUserId' | 'sessionId'
+  > {
+    return {
+      channelId: channel.id,
+      channelType: channel.type,
+      kind,
+      tenantId: channel.tenantId,
+    };
+  }
+
+  private buildSessionId(
+    channel: ChannelRow,
+    kind: AgentSessionBindingKind | null,
+    agentId: string | null,
+  ): string | null {
+    if (!agentId) return null;
+
+    switch (kind) {
+      case 'dm':
+      case 'topic-session':
+        return `team9/${channel.tenantId ?? ''}/${agentId}/dm/${channel.id}`;
+      case 'tracking':
+        return `team9/${channel.tenantId ?? ''}/${agentId}/tracking/${channel.id}`;
+      default:
+        return null;
+    }
+  }
+
+  private kindForChannelType(type: string): AgentSessionBindingKind | null {
+    switch (type) {
+      case 'direct':
+        return 'dm';
+      case 'tracking':
+        return 'tracking';
+      case 'topic-session':
+        return 'topic-session';
+      default:
+        return null;
+    }
+  }
+
+  private getTopicSessionSettings(
+    channel: ChannelRow,
+  ): { agentId?: string; sessionId?: string } | null {
+    const settings = channel.propertySettings as
+      | { topicSession?: { agentId?: string; sessionId?: string } }
+      | null
+      | undefined;
+    return settings?.topicSession ?? null;
+  }
+}

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-binding.service.ts
@@ -23,18 +23,21 @@ type ChannelRow = {
 
 type BotBindingRow = {
   botUserId: string | null;
+  botTenantId?: string | null;
   managedProvider: string | null;
   managedMeta: schema.ManagedMeta | null;
 };
 
 type RoutineSessionRow = BotBindingRow & {
   routineId: string;
+  routineTenantId?: string | null;
   creationSessionId: string | null;
 };
 
 type RoutineExecutionRow = BotBindingRow & {
   executionId: string;
   routineId: string;
+  routineTenantId?: string | null;
   taskcastTaskId: string | null;
   taskStatus: string;
 };
@@ -66,9 +69,9 @@ export class AgentSessionBindingService {
       return this.resolveRoutineSession(channel);
     }
 
-    const bot = await this.findChannelBot(channel.id);
+    const bots = await this.findChannelBots(channel);
     const kind = this.kindForChannelType(channel.type);
-    return this.resolveBotChannel(channel, kind, bot);
+    return this.resolveBotChannel(channel, kind, bots);
   }
 
   private async findChannel(channelId: string): Promise<ChannelRow | null> {
@@ -86,12 +89,11 @@ export class AgentSessionBindingService {
     return (channel as ChannelRow | undefined) ?? null;
   }
 
-  private async findChannelBot(
-    channelId: string,
-  ): Promise<BotBindingRow | null> {
-    const [bot] = await this.db
+  private async findChannelBots(channel: ChannelRow): Promise<BotBindingRow[]> {
+    const rows = await this.db
       .select({
         botUserId: schema.bots.userId,
+        botTenantId: schema.installedApplications.tenantId,
         managedProvider: schema.bots.managedProvider,
         managedMeta: schema.bots.managedMeta,
       })
@@ -104,37 +106,62 @@ export class AgentSessionBindingService {
         schema.bots,
         eq(schema.bots.userId, schema.channelMembers.userId),
       )
+      .leftJoin(
+        schema.installedApplications,
+        eq(schema.bots.installedApplicationId, schema.installedApplications.id),
+      )
       .where(
         and(
-          eq(schema.channelMembers.channelId, channelId),
+          eq(schema.channelMembers.channelId, channel.id),
           isNull(schema.channelMembers.leftAt),
           eq(schema.users.userType, 'bot'),
           eq(schema.users.isActive, true),
           eq(schema.bots.isActive, true),
+          channel.tenantId
+            ? eq(schema.installedApplications.tenantId, channel.tenantId)
+            : undefined,
         ),
       )
-      .limit(1);
+      .limit(2);
 
-    return (bot as BotBindingRow | undefined) ?? null;
+    return (rows as BotBindingRow[]).filter((row) =>
+      this.botTenantMatches(channel, row),
+    );
   }
 
   private async resolveRoutineSession(
     channel: ChannelRow,
   ): Promise<AgentSessionBindingResponse> {
+    const routineSession = this.getRoutineSessionSettings(channel);
     const [routine] = await this.db
       .select({
         routineId: schema.routines.id,
+        routineTenantId: schema.routines.tenantId,
         creationSessionId: schema.routines.creationSessionId,
         botUserId: schema.bots.userId,
+        botTenantId: schema.installedApplications.tenantId,
         managedProvider: schema.bots.managedProvider,
         managedMeta: schema.bots.managedMeta,
       })
       .from(schema.routines)
       .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
+      .leftJoin(
+        schema.installedApplications,
+        eq(schema.bots.installedApplicationId, schema.installedApplications.id),
+      )
       .leftJoin(schema.users, eq(schema.users.id, schema.bots.userId))
       .where(
         and(
           eq(schema.routines.creationChannelId, channel.id),
+          routineSession?.routineId
+            ? eq(schema.routines.id, routineSession.routineId)
+            : undefined,
+          channel.tenantId
+            ? eq(schema.routines.tenantId, channel.tenantId)
+            : undefined,
+          channel.tenantId
+            ? eq(schema.installedApplications.tenantId, channel.tenantId)
+            : undefined,
           eq(schema.users.userType, 'bot'),
           eq(schema.users.isActive, true),
           eq(schema.bots.isActive, true),
@@ -145,6 +172,18 @@ export class AgentSessionBindingService {
     const row = (routine as RoutineSessionRow | undefined) ?? null;
     if (!row) {
       return this.unsupported(channel, 'routine-creation', 'no_bot');
+    }
+    if (
+      !this.botTenantMatches(channel, row) ||
+      !this.routineTenantMatches(channel, row) ||
+      (routineSession?.routineId && row.routineId !== routineSession.routineId)
+    ) {
+      return this.unsupported(
+        channel,
+        'routine-creation',
+        'session_not_created',
+        row,
+      );
     }
 
     const unsupported = this.getUnsupportedReason(row);
@@ -179,9 +218,11 @@ export class AgentSessionBindingService {
       .select({
         executionId: schema.routineExecutions.id,
         routineId: schema.routineExecutions.routineId,
+        routineTenantId: schema.routines.tenantId,
         taskcastTaskId: schema.routineExecutions.taskcastTaskId,
         taskStatus: schema.routineExecutions.status,
         botUserId: schema.bots.userId,
+        botTenantId: schema.installedApplications.tenantId,
         managedProvider: schema.bots.managedProvider,
         managedMeta: schema.bots.managedMeta,
       })
@@ -191,10 +232,20 @@ export class AgentSessionBindingService {
         eq(schema.routines.id, schema.routineExecutions.routineId),
       )
       .leftJoin(schema.bots, eq(schema.bots.id, schema.routines.botId))
+      .leftJoin(
+        schema.installedApplications,
+        eq(schema.bots.installedApplicationId, schema.installedApplications.id),
+      )
       .leftJoin(schema.users, eq(schema.users.id, schema.bots.userId))
       .where(
         and(
           eq(schema.routineExecutions.channelId, channel.id),
+          channel.tenantId
+            ? eq(schema.routines.tenantId, channel.tenantId)
+            : undefined,
+          channel.tenantId
+            ? eq(schema.installedApplications.tenantId, channel.tenantId)
+            : undefined,
           eq(schema.users.userType, 'bot'),
           eq(schema.users.isActive, true),
           eq(schema.bots.isActive, true),
@@ -208,6 +259,17 @@ export class AgentSessionBindingService {
         channel,
         'routine-execution',
         'session_not_created',
+      );
+    }
+    if (
+      !this.botTenantMatches(channel, row) ||
+      !this.routineTenantMatches(channel, row)
+    ) {
+      return this.unsupported(
+        channel,
+        'routine-execution',
+        'session_not_created',
+        row,
       );
     }
 
@@ -233,19 +295,38 @@ export class AgentSessionBindingService {
   private resolveBotChannel(
     channel: ChannelRow,
     kind: AgentSessionBindingKind | null,
-    bot: BotBindingRow | null,
+    bots: BotBindingRow[],
   ): AgentSessionBindingResponse {
     const topicSession = this.getTopicSessionSettings(channel);
     const settingsAgentId = topicSession?.agentId ?? null;
     const settingsSessionId = topicSession?.sessionId ?? null;
 
-    if (!bot) {
+    if (bots.length === 0) {
       return this.unsupported(channel, kind, 'no_bot');
     }
 
+    const hiveBots = bots.filter((bot) => !this.getUnsupportedReason(bot));
+    if (hiveBots.length > 1) {
+      return this.unsupported(channel, kind, 'ambiguous_bot');
+    }
+
+    const bot = hiveBots[0] ?? bots[0];
     const unsupported = this.getUnsupportedReason(bot);
     if (unsupported) {
       return this.unsupported(channel, kind, unsupported, bot);
+    }
+
+    if (
+      settingsSessionId &&
+      (!settingsAgentId ||
+        !this.isExpectedSessionId(
+          channel,
+          kind,
+          settingsAgentId,
+          settingsSessionId,
+        ))
+    ) {
+      return this.unsupported(channel, kind, 'session_not_created', bot);
     }
 
     const agentId = settingsAgentId ?? bot.managedMeta?.agentId ?? null;
@@ -345,5 +426,37 @@ export class AgentSessionBindingService {
       | null
       | undefined;
     return settings?.topicSession ?? null;
+  }
+
+  private getRoutineSessionSettings(
+    channel: ChannelRow,
+  ): { purpose?: string; routineId?: string } | null {
+    const settings = channel.propertySettings as
+      | { routineSession?: { purpose?: string; routineId?: string } }
+      | null
+      | undefined;
+    return settings?.routineSession ?? null;
+  }
+
+  private botTenantMatches(channel: ChannelRow, row: BotBindingRow): boolean {
+    if (!channel.tenantId || row.botTenantId === undefined) return true;
+    return row.botTenantId === channel.tenantId;
+  }
+
+  private routineTenantMatches(
+    channel: ChannelRow,
+    row: { routineTenantId?: string | null },
+  ): boolean {
+    if (!channel.tenantId || row.routineTenantId === undefined) return true;
+    return row.routineTenantId === channel.tenantId;
+  }
+
+  private isExpectedSessionId(
+    channel: ChannelRow,
+    kind: AgentSessionBindingKind | null,
+    agentId: string,
+    sessionId: string,
+  ): boolean {
+    return sessionId === this.buildSessionId(channel, kind, agentId);
   }
 }

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
@@ -51,6 +51,7 @@ describe('agent session redaction', () => {
               data: { mood: 'calm', credential: 'raw' },
               capturedAtCallId: 'call-1',
               capturedAt: 123,
+              token: 'raw-latest-token',
             },
           },
         ],
@@ -79,8 +80,14 @@ describe('agent session redaction', () => {
         sessionId: 's1',
         timestamp: 456,
         turnIndex: 1,
+        token: 'raw-event-token',
         components: [
-          { componentId: 'host', data: { authorization: 'Bearer x' } },
+          {
+            componentId: 'host',
+            token: 'raw-component-token',
+            effectiveConfig: { apiKey: 'raw' },
+            data: { authorization: 'Bearer x' },
+          },
         ],
       }),
     ).toEqual({

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
@@ -20,6 +20,22 @@ describe('agent session redaction', () => {
     });
   });
 
+  it('redacts camelCase secret keys', () => {
+    expect(
+      redactSensitiveValue({
+        accessToken: 'access-token',
+        clientSecret: 'client-secret',
+        team9AuthToken: { value: 'nested-token' },
+        keep: { value: 'visible' },
+      }),
+    ).toEqual({
+      accessToken: '[redacted]',
+      clientSecret: '[redacted]',
+      team9AuthToken: '[redacted]',
+      keep: { value: 'visible' },
+    });
+  });
+
   it('strips component configs and keeps redacted latest data', () => {
     expect(
       projectSafeComponents({

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  filterAgentSessionEvent,
+  projectSafeComponents,
+  redactSensitiveValue,
+} from './agent-session-redaction.js';
+
+describe('agent session redaction', () => {
+  it('redacts sensitive object keys recursively', () => {
+    expect(
+      redactSensitiveValue({
+        token: 'abc',
+        nested: { apiKey: 'def', keep: 'visible' },
+        list: [{ password: 'ghi' }, { ok: true }],
+      }),
+    ).toEqual({
+      token: '[redacted]',
+      nested: { apiKey: '[redacted]', keep: 'visible' },
+      list: [{ password: '[redacted]' }, { ok: true }],
+    });
+  });
+
+  it('strips component configs and keeps redacted latest data', () => {
+    expect(
+      projectSafeComponents({
+        sessionId: 's1',
+        components: [
+          {
+            id: 'persona',
+            typeKey: 'persona',
+            declaredConfig: { token: 'secret' },
+            effectiveConfig: { token: 'secret' },
+            runtimeInjectedOnly: false,
+            latestData: {
+              data: { mood: 'calm', credential: 'raw' },
+              capturedAtCallId: 'call-1',
+              capturedAt: 123,
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      sessionId: 's1',
+      components: [
+        {
+          id: 'persona',
+          typeKey: 'persona',
+          runtimeInjectedOnly: false,
+          latestData: {
+            data: { mood: 'calm', credential: '[redacted]' },
+            capturedAtCallId: 'call-1',
+            capturedAt: 123,
+          },
+        },
+      ],
+    });
+  });
+
+  it('allows component snapshots after redacting payload data', () => {
+    expect(
+      filterAgentSessionEvent({
+        type: 'component_data_snapshot',
+        sessionId: 's1',
+        timestamp: 456,
+        turnIndex: 1,
+        components: [
+          { componentId: 'host', data: { authorization: 'Bearer x' } },
+        ],
+      }),
+    ).toEqual({
+      type: 'component_data_snapshot',
+      sessionId: 's1',
+      timestamp: 456,
+      turnIndex: 1,
+      components: [
+        { componentId: 'host', data: { authorization: '[redacted]' } },
+      ],
+    });
+  });
+
+  it('drops non-allowlisted events', () => {
+    expect(
+      filterAgentSessionEvent({
+        type: 'tool_execution_start',
+        sessionId: 's1',
+        timestamp: 1,
+        args: { token: 'raw' },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
@@ -2,7 +2,7 @@ import type { HiveSessionComponentsResponse } from '@team9/claw-hive';
 import type { SafeSessionComponentsResponse } from './agent-session.types.js';
 
 const SENSITIVE_KEY_PATTERN =
-  /(^|[_-])(token|secret|password|apikey|api_key|authorization|credential)([_-]|$)/i;
+  /(token|secret|password|api[-_]?key|authorization|credential)/i;
 
 const ALLOWED_EVENT_TYPES = new Set([
   'agent_start',

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
@@ -47,11 +47,12 @@ export function projectSafeComponents(
       ...(component.schema !== undefined && { schema: component.schema }),
       latestData: component.latestData
         ? {
-            ...component.latestData,
             data: redactSensitiveValue(component.latestData.data) as Record<
               string,
               unknown
             >,
+            capturedAtCallId: component.latestData.capturedAtCallId,
+            capturedAt: component.latestData.capturedAt,
           }
         : null,
     })),
@@ -66,15 +67,40 @@ export function filterAgentSessionEvent(
 
   if (type !== 'component_data_snapshot') return event;
 
+  const sessionId =
+    typeof event.sessionId === 'string' ? event.sessionId : null;
+  const timestamp =
+    typeof event.timestamp === 'number' ? event.timestamp : null;
+  const turnIndex =
+    typeof event.turnIndex === 'number' ? event.turnIndex : null;
+  if (!sessionId || timestamp === null || turnIndex === null) return null;
+
   const components = Array.isArray(event.components)
-    ? event.components.map((component) => {
+    ? event.components.flatMap((component) => {
+        if (!component || typeof component !== 'object') return [];
         const row = component as Record<string, unknown>;
-        return {
-          ...row,
-          data: redactSensitiveValue(row.data) as Record<string, unknown>,
-        };
+        if (typeof row.componentId !== 'string') return [];
+        if (
+          !row.data ||
+          typeof row.data !== 'object' ||
+          Array.isArray(row.data)
+        ) {
+          return [];
+        }
+        return [
+          {
+            componentId: row.componentId,
+            data: redactSensitiveValue(row.data) as Record<string, unknown>,
+          },
+        ];
       })
     : [];
 
-  return { ...event, components };
+  return {
+    type,
+    sessionId,
+    timestamp,
+    turnIndex,
+    components,
+  };
 }

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session-redaction.ts
@@ -1,0 +1,80 @@
+import type { HiveSessionComponentsResponse } from '@team9/claw-hive';
+import type { SafeSessionComponentsResponse } from './agent-session.types.js';
+
+const SENSITIVE_KEY_PATTERN =
+  /(^|[_-])(token|secret|password|apikey|api_key|authorization|credential)([_-]|$)/i;
+
+const ALLOWED_EVENT_TYPES = new Set([
+  'agent_start',
+  'agent_end',
+  'run_start',
+  'run_end',
+  'worker_release',
+  'component_data_snapshot',
+  'model_change',
+  'thinking_level_change',
+  'a2ui_surface_update',
+  'a2ui_surface_delete',
+]);
+
+export function redactSensitiveValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveValue(item));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key)
+        ? '[redacted]'
+        : redactSensitiveValue(item),
+    ]),
+  );
+}
+
+export function projectSafeComponents(
+  response: HiveSessionComponentsResponse,
+): SafeSessionComponentsResponse {
+  return {
+    sessionId: response.sessionId,
+    components: response.components.map((component) => ({
+      id: component.id,
+      typeKey: component.typeKey,
+      ...(component.priority !== undefined && { priority: component.priority }),
+      runtimeInjectedOnly: component.runtimeInjectedOnly,
+      ...(component.schema !== undefined && { schema: component.schema }),
+      latestData: component.latestData
+        ? {
+            ...component.latestData,
+            data: redactSensitiveValue(component.latestData.data) as Record<
+              string,
+              unknown
+            >,
+          }
+        : null,
+    })),
+  };
+}
+
+export function filterAgentSessionEvent(
+  event: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const type = typeof event.type === 'string' ? event.type : null;
+  if (!type || !ALLOWED_EVENT_TYPES.has(type)) return null;
+
+  if (type !== 'component_data_snapshot') return event;
+
+  const components = Array.isArray(event.components)
+    ? event.components.map((component) => {
+        const row = component as Record<string, unknown>;
+        return {
+          ...row,
+          data: redactSensitiveValue(row.data) as Record<string, unknown>,
+        };
+      })
+    : [];
+
+  return { ...event, components };
+}

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
@@ -1,0 +1,179 @@
+import { NotFoundException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AgentSessionController } from './agent-session.controller.js';
+
+type MockFn = jest.Mock<(...args: any[]) => any>;
+
+describe('AgentSessionController', () => {
+  let bindingService: { resolve: MockFn };
+  let clawHive: { getSessionStatus: MockFn; getSessionComponents: MockFn };
+  let jwtService: { verify: MockFn };
+  let controller: AgentSessionController;
+
+  beforeEach(() => {
+    bindingService = {
+      resolve: jest.fn<any>(),
+    };
+    clawHive = {
+      getSessionStatus: jest.fn<any>(),
+      getSessionComponents: jest.fn<any>(),
+    };
+    jwtService = {
+      verify: jest.fn<any>(),
+    };
+    controller = new AgentSessionController(
+      bindingService as any,
+      clawHive as any,
+      jwtService as any,
+    );
+  });
+
+  it('returns binding plus active status when Hive reports ownership or queue activity', async () => {
+    bindingService.resolve.mockResolvedValue({
+      channelId: 'channel-1',
+      channelType: 'direct',
+      kind: 'dm',
+      tenantId: 'tenant-1',
+      supported: true,
+      agentId: 'agent-1',
+      botUserId: 'bot-user-1',
+      sessionId: 'session-1',
+    });
+    clawHive.getSessionStatus.mockResolvedValue({
+      sessionId: 'session-1',
+      isStreaming: false,
+      ownedBy: 'worker-1',
+      queueLength: 0,
+    });
+
+    await expect(
+      controller.getBinding('user-1', 'channel-1'),
+    ).resolves.toMatchObject({
+      channelId: 'channel-1',
+      supported: true,
+      sessionId: 'session-1',
+      status: {
+        exists: true,
+        status: 'active',
+        ownedBy: 'worker-1',
+        queueLength: 0,
+        activityState: 'active',
+      },
+    });
+    expect(clawHive.getSessionStatus).toHaveBeenCalledWith(
+      'session-1',
+      'tenant-1',
+    );
+  });
+
+  it('maps missing Hive status to not_found without failing binding lookup', async () => {
+    bindingService.resolve.mockResolvedValue({
+      channelId: 'channel-1',
+      channelType: 'direct',
+      kind: 'dm',
+      tenantId: null,
+      supported: true,
+      agentId: 'agent-1',
+      botUserId: 'bot-user-1',
+      sessionId: 'session-1',
+    });
+    clawHive.getSessionStatus.mockResolvedValue(null);
+
+    await expect(controller.getBinding('user-1', 'channel-1')).resolves.toEqual(
+      expect.objectContaining({
+        status: { exists: false, unavailableReason: 'not_found' },
+      }),
+    );
+  });
+
+  it('returns sanitized projected components and strips configs', async () => {
+    bindingService.resolve.mockResolvedValue({
+      channelId: 'channel-1',
+      channelType: 'direct',
+      kind: 'dm',
+      tenantId: 'tenant-1',
+      supported: true,
+      agentId: 'agent-1',
+      botUserId: 'bot-user-1',
+      sessionId: 'session-1',
+    });
+    clawHive.getSessionComponents.mockResolvedValue({
+      sessionId: 'session-1',
+      components: [
+        {
+          id: 'workspace',
+          typeKey: 'just-bash-team9-workspace',
+          priority: 10,
+          declaredConfig: { token: 'secret' },
+          effectiveConfig: { apiKey: 'secret' },
+          schema: [{ name: 'folder' }],
+          runtimeInjectedOnly: false,
+          latestData: {
+            data: { folder: '/tmp/project', authorization: 'Bearer secret' },
+            capturedAtCallId: 'call-1',
+            capturedAt: 123,
+          },
+        },
+      ],
+    });
+
+    await expect(
+      controller.getComponents('user-1', 'channel-1'),
+    ).resolves.toEqual({
+      sessionId: 'session-1',
+      components: [
+        {
+          id: 'workspace',
+          typeKey: 'just-bash-team9-workspace',
+          priority: 10,
+          schema: [{ name: 'folder' }],
+          runtimeInjectedOnly: false,
+          latestData: {
+            data: { folder: '/tmp/project', authorization: '[redacted]' },
+            capturedAtCallId: 'call-1',
+            capturedAt: 123,
+          },
+        },
+      ],
+    });
+    expect(clawHive.getSessionComponents).toHaveBeenCalledWith(
+      'session-1',
+      'tenant-1',
+    );
+  });
+
+  it('throws NotFoundException for unsupported component bindings', async () => {
+    bindingService.resolve.mockResolvedValue({
+      channelId: 'channel-1',
+      channelType: 'public',
+      kind: null,
+      tenantId: null,
+      supported: false,
+      unsupportedReason: 'no_bot',
+      agentId: null,
+      botUserId: null,
+      sessionId: null,
+    });
+
+    await expect(
+      controller.getComponents('user-1', 'channel-1'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(clawHive.getSessionComponents).not.toHaveBeenCalled();
+  });
+
+  it('filters SSE records through the agent session allowlist and redaction', () => {
+    expect(
+      (controller as any).filterSseRecord(
+        'event: message\ndata: {"type":"tool_execution_start","args":{"token":"raw"}}',
+      ),
+    ).toBeNull();
+
+    expect(
+      (controller as any).filterSseRecord(
+        'id: 7\ndata: {"type":"component_data_snapshot","components":[{"componentId":"host","data":{"credential":"raw","visible":true}}]}',
+      ),
+    ).toBe(
+      'id: 7\ndata: {"type":"component_data_snapshot","components":[{"componentId":"host","data":{"credential":"[redacted]","visible":true}}]}',
+    );
+  });
+});

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
@@ -186,4 +186,16 @@ describe('AgentSessionController', () => {
       'data: ping',
     );
   });
+
+  it('does not let comment-prefixed SSE records bypass data filtering', () => {
+    expect(
+      (controller as any).filterSseRecord(
+        ': keepalive\ndata: {"type":"tool_execution_start","args":{"token":"raw"}}',
+      ),
+    ).toBeNull();
+
+    expect((controller as any).filterSseRecord(': keepalive')).toBe(
+      ': keepalive',
+    );
+  });
 });

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
@@ -176,4 +176,14 @@ describe('AgentSessionController', () => {
       'id: 7\ndata: {"type":"component_data_snapshot","components":[{"componentId":"host","data":{"credential":"[redacted]","visible":true}}]}',
     );
   });
+
+  it('drops non-json SSE data records except ping heartbeats', () => {
+    expect((controller as any).filterSseRecord('data: internal-event')).toBe(
+      null,
+    );
+
+    expect((controller as any).filterSseRecord('data: ping')).toBe(
+      'data: ping',
+    );
+  });
 });

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.spec.ts
@@ -170,10 +170,10 @@ describe('AgentSessionController', () => {
 
     expect(
       (controller as any).filterSseRecord(
-        'id: 7\ndata: {"type":"component_data_snapshot","components":[{"componentId":"host","data":{"credential":"raw","visible":true}}]}',
+        'id: 7\nretry: 1000\n: debug\nevent: component_data_snapshot\ndata: {"type":"component_data_snapshot","sessionId":"s1","timestamp":1,"turnIndex":0,"token":"raw","components":[{"componentId":"host","token":"raw","data":{"credential":"raw","visible":true}}]}',
       ),
     ).toBe(
-      'id: 7\ndata: {"type":"component_data_snapshot","components":[{"componentId":"host","data":{"credential":"[redacted]","visible":true}}]}',
+      'id: 7\nevent: component_data_snapshot\ndata: {"type":"component_data_snapshot","sessionId":"s1","timestamp":1,"turnIndex":0,"components":[{"componentId":"host","data":{"credential":"[redacted]","visible":true}}]}',
     );
   });
 
@@ -197,5 +197,19 @@ describe('AgentSessionController', () => {
     expect((controller as any).filterSseRecord(': keepalive')).toBe(
       ': keepalive',
     );
+  });
+
+  it('drops unknown no-data SSE records and sanitizes ping heartbeats', () => {
+    expect((controller as any).filterSseRecord('event: debug')).toBeNull();
+    expect((controller as any).filterSseRecord('retry: 1000')).toBeNull();
+    expect(
+      (controller as any).filterSseRecord(': internal raw state'),
+    ).toBeNull();
+
+    expect(
+      (controller as any).filterSseRecord(
+        'id: 7\n: internal raw state\ndata: ping',
+      ),
+    ).toBe('data: ping');
   });
 });

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
@@ -255,7 +255,7 @@ export class AgentSessionController {
         '\n',
       );
     } catch {
-      return record;
+      return null;
     }
   }
 }

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
@@ -234,7 +234,6 @@ export class AgentSessionController {
   private filterSseRecord(record: string): string | null {
     const trimmed = record.trim();
     if (trimmed.length === 0) return null;
-    if (trimmed.startsWith(':')) return record;
 
     const lines = record.split(/\r?\n/);
     const dataLines = lines.filter((line) => line.startsWith('data:'));

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
@@ -1,0 +1,261 @@
+import {
+  Controller,
+  Get,
+  Logger,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import type { Request, Response } from 'express';
+import { AuthGuard, CurrentUser, type JwtPayload } from '@team9/auth';
+import { ClawHiveService } from '@team9/claw-hive';
+import { env } from '@team9/shared';
+import { AgentSessionBindingService } from './agent-session-binding.service.js';
+import type {
+  AgentSessionBindingResponse,
+  AgentSessionStatus,
+  SafeSessionComponentsResponse,
+} from './agent-session.types.js';
+import {
+  filterAgentSessionEvent,
+  projectSafeComponents,
+} from './agent-session-redaction.js';
+
+@Controller({ path: 'im/channels', version: '1' })
+export class AgentSessionController {
+  private readonly logger = new Logger(AgentSessionController.name);
+  private readonly hiveBaseUrl: string;
+  private readonly hiveAuthToken: string;
+
+  constructor(
+    private readonly bindingService: AgentSessionBindingService,
+    private readonly clawHive: ClawHiveService,
+    private readonly jwtService: JwtService,
+  ) {
+    this.hiveBaseUrl = env.CLAW_HIVE_API_URL ?? 'http://localhost:4100';
+    this.hiveAuthToken = env.CLAW_HIVE_AUTH_TOKEN ?? '';
+  }
+
+  @Get(':channelId/agent-session')
+  @UseGuards(AuthGuard)
+  async getBinding(
+    @CurrentUser('sub') userId: string,
+    @Param('channelId', ParseUUIDPipe) channelId: string,
+  ): Promise<AgentSessionBindingResponse> {
+    const binding = await this.bindingService.resolve(channelId, userId);
+    if (!binding.supported || !binding.sessionId) return binding;
+
+    return {
+      ...binding,
+      status: await this.getBestEffortStatus(binding),
+    };
+  }
+
+  @Get(':channelId/agent-session/components')
+  @UseGuards(AuthGuard)
+  async getComponents(
+    @CurrentUser('sub') userId: string,
+    @Param('channelId', ParseUUIDPipe) channelId: string,
+  ): Promise<SafeSessionComponentsResponse> {
+    const binding = await this.bindingService.resolve(channelId, userId);
+    if (!binding.supported || !binding.sessionId) {
+      throw new NotFoundException('Agent session not available');
+    }
+
+    const response = await this.clawHive.getSessionComponents(
+      binding.sessionId,
+      binding.tenantId ?? undefined,
+    );
+    if (!response) {
+      throw new NotFoundException('Agent session components not found');
+    }
+
+    return projectSafeComponents(response);
+  }
+
+  @Get(':channelId/agent-session/events')
+  async streamEvents(
+    @Param('channelId', ParseUUIDPipe) channelId: string,
+    @Query('token') queryToken: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const token = this.extractBearerToken(req) ?? queryToken;
+    if (!token) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    let userId: string;
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token, {
+        publicKey: env.JWT_PUBLIC_KEY,
+        algorithms: ['ES256'],
+      });
+      userId = payload.sub;
+    } catch {
+      res.status(401).json({ error: 'Invalid token' });
+      return;
+    }
+
+    const binding = await this.bindingService.resolve(channelId, userId);
+    if (!binding.supported || !binding.sessionId) {
+      res.status(404).json({ error: 'Agent session not available' });
+      return;
+    }
+
+    const upstream = `${this.hiveBaseUrl}/api/sessions/${encodeURIComponent(
+      binding.sessionId,
+    )}/events`;
+    const headers: Record<string, string> = {
+      Accept: 'text/event-stream',
+      'X-Hive-Auth': this.hiveAuthToken,
+    };
+    if (binding.tenantId) headers['X-Hive-Tenant'] = binding.tenantId;
+    const lastEventId = req.headers['last-event-id'] as string | undefined;
+    if (lastEventId) headers['Last-Event-ID'] = lastEventId;
+
+    const controller = new AbortController();
+    req.on('close', () => controller.abort());
+
+    try {
+      const upstreamRes = await fetch(upstream, {
+        headers,
+        signal: controller.signal,
+      });
+
+      if (!upstreamRes.ok || !upstreamRes.body) {
+        this.logger.warn(
+          `Hive session SSE upstream ${upstreamRes.status} for session ${binding.sessionId}`,
+        );
+        res.status(502).json({ error: 'Hive upstream unavailable' });
+        return;
+      }
+
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+      res.flushHeaders();
+
+      await this.pipeSseRecords(upstreamRes.body, res);
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') return;
+      this.logger.error(`Hive session SSE proxy error: ${error}`);
+      if (!res.headersSent) {
+        res.status(502).json({ error: 'Hive upstream unavailable' });
+      }
+    }
+  }
+
+  private async getBestEffortStatus(
+    binding: AgentSessionBindingResponse,
+  ): Promise<AgentSessionStatus> {
+    try {
+      const status = await this.clawHive.getSessionStatus(
+        binding.sessionId!,
+        binding.tenantId ?? undefined,
+      );
+      if (!status) {
+        return { exists: false, unavailableReason: 'not_found' };
+      }
+
+      const queueLength = status.queueLength ?? 0;
+      const active = status.ownedBy !== null || queueLength > 0;
+      return {
+        exists: true,
+        status: 'active',
+        ownedBy: status.ownedBy,
+        queueLength,
+        activityState: active ? 'active' : 'inactive',
+      };
+    } catch {
+      return { exists: false, unavailableReason: 'agent_pi_unavailable' };
+    }
+  }
+
+  private extractBearerToken(req: Request): string | undefined {
+    const authorization = req.headers.authorization;
+    if (!authorization) return undefined;
+    const [scheme, token] = authorization.split(' ');
+    if (scheme !== 'Bearer' || !token) return undefined;
+    return token;
+  }
+
+  private async pipeSseRecords(
+    body: ReadableStream<Uint8Array>,
+    res: Response,
+  ): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let split = this.findRecordBoundary(buffer);
+        while (split) {
+          const record = buffer.slice(0, split.index);
+          buffer = buffer.slice(split.index + split.length);
+          const forwarded = this.filterSseRecord(record);
+          if (forwarded) res.write(`${forwarded}\n\n`);
+          split = this.findRecordBoundary(buffer);
+        }
+      }
+
+      if (buffer.length > 0) {
+        const forwarded = this.filterSseRecord(buffer);
+        if (forwarded) res.write(`${forwarded}\n\n`);
+      }
+    } finally {
+      res.end();
+    }
+  }
+
+  private findRecordBoundary(
+    buffer: string,
+  ): { index: number; length: number } | null {
+    const lf = buffer.indexOf('\n\n');
+    const crlf = buffer.indexOf('\r\n\r\n');
+    if (lf === -1 && crlf === -1) return null;
+    if (lf === -1) return { index: crlf, length: 4 };
+    if (crlf === -1) return { index: lf, length: 2 };
+    return lf < crlf ? { index: lf, length: 2 } : { index: crlf, length: 4 };
+  }
+
+  private filterSseRecord(record: string): string | null {
+    const trimmed = record.trim();
+    if (trimmed.length === 0) return null;
+    if (trimmed.startsWith(':')) return record;
+
+    const lines = record.split(/\r?\n/);
+    const dataLines = lines.filter((line) => line.startsWith('data:'));
+    if (dataLines.length === 0) return record;
+
+    const rawData = dataLines
+      .map((line) => line.slice('data:'.length).trimStart())
+      .join('\n')
+      .trim();
+    if (rawData === 'ping' || rawData === '"ping"') return record;
+
+    try {
+      const parsed = JSON.parse(rawData) as Record<string, unknown>;
+      const filtered = filterAgentSessionEvent(parsed);
+      if (!filtered) return null;
+      const directiveLines = lines.filter((line) => !line.startsWith('data:'));
+      return [...directiveLines, `data: ${JSON.stringify(filtered)}`].join(
+        '\n',
+      );
+    } catch {
+      return record;
+    }
+  }
+}

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.controller.ts
@@ -117,7 +117,9 @@ export class AgentSessionController {
       'X-Hive-Auth': this.hiveAuthToken,
     };
     if (binding.tenantId) headers['X-Hive-Tenant'] = binding.tenantId;
-    const lastEventId = req.headers['last-event-id'] as string | undefined;
+    const lastEventId =
+      (req.headers['last-event-id'] as string | undefined) ??
+      this.safeLastEventId(req.query.lastEventId);
     if (lastEventId) headers['Last-Event-ID'] = lastEventId;
 
     const controller = new AbortController();
@@ -206,18 +208,36 @@ export class AgentSessionController {
           const record = buffer.slice(0, split.index);
           buffer = buffer.slice(split.index + split.length);
           const forwarded = this.filterSseRecord(record);
-          if (forwarded) res.write(`${forwarded}\n\n`);
+          if (forwarded) await this.writeSseRecord(res, forwarded);
           split = this.findRecordBoundary(buffer);
         }
       }
 
       if (buffer.length > 0) {
         const forwarded = this.filterSseRecord(buffer);
-        if (forwarded) res.write(`${forwarded}\n\n`);
+        if (forwarded) await this.writeSseRecord(res, forwarded);
       }
     } finally {
+      await reader.cancel().catch(() => undefined);
       res.end();
     }
+  }
+
+  private async writeSseRecord(res: Response, record: string): Promise<void> {
+    if (res.destroyed) return;
+    if (res.write(`${record}\n\n`)) return;
+
+    await new Promise<void>((resolve) => {
+      const cleanup = () => {
+        res.off('drain', cleanup);
+        res.off('close', cleanup);
+        res.off('error', cleanup);
+        resolve();
+      };
+      res.once('drain', cleanup);
+      res.once('close', cleanup);
+      res.once('error', cleanup);
+    });
   }
 
   private findRecordBoundary(
@@ -237,24 +257,56 @@ export class AgentSessionController {
 
     const lines = record.split(/\r?\n/);
     const dataLines = lines.filter((line) => line.startsWith('data:'));
-    if (dataLines.length === 0) return record;
+    if (dataLines.length === 0) {
+      return trimmed === ': keepalive' || trimmed === ': ping' ? trimmed : null;
+    }
 
     const rawData = dataLines
       .map((line) => line.slice('data:'.length).trimStart())
       .join('\n')
       .trim();
-    if (rawData === 'ping' || rawData === '"ping"') return record;
+    if (rawData === 'ping' || rawData === '"ping"') return 'data: ping';
 
     try {
       const parsed = JSON.parse(rawData) as Record<string, unknown>;
       const filtered = filterAgentSessionEvent(parsed);
       if (!filtered) return null;
-      const directiveLines = lines.filter((line) => !line.startsWith('data:'));
+      const directiveLines = this.safeSseDirectiveLines(lines, filtered);
       return [...directiveLines, `data: ${JSON.stringify(filtered)}`].join(
         '\n',
       );
     } catch {
       return null;
     }
+  }
+
+  private safeSseDirectiveLines(
+    lines: string[],
+    event: Record<string, unknown>,
+  ): string[] {
+    const directives: string[] = [];
+    const idLine = lines.find((line) => line.startsWith('id:'));
+    const id = idLine?.slice('id:'.length).trim();
+    if (id && this.isSafeSseDirectiveValue(id)) {
+      directives.push(`id: ${id}`);
+    }
+
+    const eventLine = lines.find((line) => line.startsWith('event:'));
+    const eventName = eventLine?.slice('event:'.length).trim();
+    if (eventName && eventName === event.type) {
+      directives.push(`event: ${eventName}`);
+    }
+
+    return directives;
+  }
+
+  private safeLastEventId(value: unknown): string | undefined {
+    const candidate: unknown = Array.isArray(value) ? value[0] : value;
+    if (typeof candidate !== 'string') return undefined;
+    return this.isSafeSseDirectiveValue(candidate) ? candidate : undefined;
+  }
+
+  private isSafeSseDirectiveValue(value: string): boolean {
+    return value.length > 0 && value.length <= 256 && !/[\r\n]/.test(value);
   }
 }

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.types.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.types.ts
@@ -8,6 +8,7 @@ export type AgentSessionBindingKind =
 export type AgentSessionUnsupportedReason =
   | 'no_bot'
   | 'not_hive_managed'
+  | 'ambiguous_bot'
   | 'session_not_created';
 
 export interface AgentSessionStatus {

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-session.types.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-session.types.ts
@@ -1,0 +1,55 @@
+export type AgentSessionBindingKind =
+  | 'dm'
+  | 'routine-creation'
+  | 'topic-session'
+  | 'routine-execution'
+  | 'tracking';
+
+export type AgentSessionUnsupportedReason =
+  | 'no_bot'
+  | 'not_hive_managed'
+  | 'session_not_created';
+
+export interface AgentSessionStatus {
+  exists: boolean;
+  status?: 'active' | 'disposed';
+  ownedBy?: string | null;
+  queueLength?: number;
+  activityState?: 'active' | 'inactive';
+  unavailableReason?: 'not_found' | 'agent_pi_unavailable';
+}
+
+export interface AgentSessionBindingResponse {
+  channelId: string;
+  channelType: string;
+  kind: AgentSessionBindingKind | null;
+  supported: boolean;
+  unsupportedReason?: AgentSessionUnsupportedReason;
+  tenantId: string | null;
+  agentId: string | null;
+  botUserId: string | null;
+  sessionId: string | null;
+  routineId?: string;
+  executionId?: string;
+  taskcastTaskId?: string | null;
+  taskStatus?: string;
+  status?: AgentSessionStatus;
+}
+
+export interface SafeSessionComponentItem {
+  id: string;
+  typeKey: string;
+  priority?: number;
+  runtimeInjectedOnly: boolean;
+  schema?: unknown[];
+  latestData: {
+    data: Record<string, unknown>;
+    capturedAtCallId: string | null;
+    capturedAt: number;
+  } | null;
+}
+
+export interface SafeSessionComponentsResponse {
+  sessionId: string;
+  components: SafeSessionComponentItem[];
+}

--- a/apps/server/apps/gateway/src/im/agent-sessions/agent-sessions.module.ts
+++ b/apps/server/apps/gateway/src/im/agent-sessions/agent-sessions.module.ts
@@ -1,0 +1,14 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { ClawHiveModule } from '@team9/claw-hive';
+import { AuthModule } from '../../auth/auth.module.js';
+import { ChannelsModule } from '../channels/channels.module.js';
+import { AgentSessionController } from './agent-session.controller.js';
+import { AgentSessionBindingService } from './agent-session-binding.service.js';
+
+@Module({
+  imports: [AuthModule, forwardRef(() => ChannelsModule), ClawHiveModule],
+  controllers: [AgentSessionController],
+  providers: [AgentSessionBindingService],
+  exports: [AgentSessionBindingService],
+})
+export class AgentSessionsModule {}

--- a/apps/server/apps/gateway/src/im/im.module.ts
+++ b/apps/server/apps/gateway/src/im/im.module.ts
@@ -11,6 +11,7 @@ import { PropertiesModule } from './properties/properties.module.js';
 import { ViewsModule } from './views/views.module.js';
 import { BotMessagingModule } from './bot/bot-messaging.module.js';
 import { TopicSessionsModule } from './topic-sessions/topic-sessions.module.js';
+import { AgentSessionsModule } from './agent-sessions/agent-sessions.module.js';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { TopicSessionsModule } from './topic-sessions/topic-sessions.module.js';
     ViewsModule,
     BotMessagingModule,
     TopicSessionsModule,
+    AgentSessionsModule,
   ],
   exports: [
     AuthModule,
@@ -39,6 +41,7 @@ import { TopicSessionsModule } from './topic-sessions/topic-sessions.module.js';
     PropertiesModule,
     ViewsModule,
     TopicSessionsModule,
+    AgentSessionsModule,
   ],
 })
 export class ImModule {}

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts
@@ -82,6 +82,7 @@ const AGENT_ID = 'agent-alpha';
 function makeHiveBotRow(): any {
   return {
     userId: BOT_USER_ID,
+    tenantId: TENANT_ID,
     managedProvider: 'hive',
     managedMeta: { agentId: AGENT_ID },
     isActive: true,
@@ -303,6 +304,24 @@ describe('TopicSessionsService', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(clawHive.createSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the target bot belongs to a different tenant', async () => {
+      db.limit.mockResolvedValueOnce([
+        { ...makeHiveBotRow(), tenantId: 'other-tenant' },
+      ]);
+
+      await expect(
+        service.create({
+          creatorId: CREATOR_ID,
+          tenantId: TENANT_ID,
+          botUserId: BOT_USER_ID,
+          initialMessage: 'hi',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(clawHive.createSession).not.toHaveBeenCalled();
+      expect(channels.createTopicSessionChannel).not.toHaveBeenCalled();
     });
 
     it('compensates the agent-pi session when channel creation fails', async () => {

--- a/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/topic-sessions/topic-sessions.service.ts
@@ -23,7 +23,10 @@ import * as schema from '@team9/database/schemas';
 import { ClawHiveService } from '@team9/claw-hive';
 import { GatewayMQService } from '@team9/rabbitmq';
 import { type PostBroadcastTask } from '@team9/shared';
-import { ChannelsService } from '../channels/channels.service.js';
+import {
+  ChannelsService,
+  type ChannelResponse,
+} from '../channels/channels.service.js';
 import { WebsocketGateway } from '../websocket/websocket.gateway.js';
 import { WS_EVENTS } from '../websocket/events/events.constants.js';
 import { ImWorkerGrpcClientService } from '../services/im-worker-grpc-client.service.js';
@@ -114,6 +117,7 @@ export class TopicSessionsService {
     const [botRow] = await this.db
       .select({
         userId: schema.bots.userId,
+        tenantId: schema.installedApplications.tenantId,
         managedProvider: schema.bots.managedProvider,
         managedMeta: schema.bots.managedMeta,
         isActive: schema.bots.isActive,
@@ -121,14 +125,26 @@ export class TopicSessionsService {
       })
       .from(schema.bots)
       .innerJoin(schema.users, eq(schema.bots.userId, schema.users.id))
-      .where(eq(schema.bots.userId, botUserId))
+      .leftJoin(
+        schema.installedApplications,
+        eq(schema.bots.installedApplicationId, schema.installedApplications.id),
+      )
+      .where(
+        and(
+          eq(schema.bots.userId, botUserId),
+          tenantId
+            ? eq(schema.installedApplications.tenantId, tenantId)
+            : undefined,
+        ),
+      )
       .limit(1);
 
     if (
       !botRow ||
       botRow.userType !== 'bot' ||
       !botRow.isActive ||
-      botRow.managedProvider !== 'hive'
+      botRow.managedProvider !== 'hive' ||
+      (tenantId && botRow.tenantId !== tenantId)
     ) {
       throw new BadRequestException(
         'Target user is not an active hive-managed agent',
@@ -180,7 +196,7 @@ export class TopicSessionsService {
     }
 
     // --- Step 5: create channel + members in team9 DB ---
-    let channel;
+    let channel: ChannelResponse;
     try {
       channel = await this.channels.createTopicSessionChannel({
         creatorId,

--- a/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
@@ -337,6 +337,69 @@ describe('ClawHiveService', () => {
     });
   });
 
+  describe('session component and status helpers', () => {
+    it('GETs session components with tenant header', async () => {
+      const body = {
+        sessionId: 'team9/tenant/agent/dm/channel',
+        components: [
+          {
+            id: 'persona',
+            typeKey: 'persona',
+            runtimeInjectedOnly: false,
+            effectiveConfig: {},
+            latestData: {
+              data: { mood: 'focused' },
+              capturedAtCallId: 'call-1',
+              capturedAt: 1700000000000,
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await service.getSessionComponents(
+        'team9/tenant/agent/dm/channel',
+        'tenant-123',
+      );
+
+      expect(result).toEqual(body);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-hive:9999/api/sessions/team9%2Ftenant%2Fagent%2Fdm%2Fchannel/components',
+        {
+          method: 'GET',
+          headers: expect.objectContaining({
+            'X-Hive-Auth': 'test-token',
+            'X-Hive-Tenant': 'tenant-123',
+          }),
+        },
+      );
+    });
+
+    it('returns null when session components are missing', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'missing' }, 404));
+
+      await expect(service.getSessionComponents('missing')).resolves.toBeNull();
+    });
+
+    it('GETs session status', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          sessionId: 's1',
+          isStreaming: false,
+          queueLength: 2,
+          ownedBy: 'worker-1',
+        }),
+      );
+
+      await expect(service.getSessionStatus('s1')).resolves.toEqual({
+        sessionId: 's1',
+        isStreaming: false,
+        queueLength: 2,
+        ownedBy: 'worker-1',
+      });
+    });
+  });
+
   // ── sendInput ────────────────────────────────────────────────────────────
 
   describe('sendInput', () => {

--- a/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.spec.ts
@@ -391,12 +391,18 @@ describe('ClawHiveService', () => {
         }),
       );
 
-      await expect(service.getSessionStatus('s1')).resolves.toEqual({
+      await expect(
+        service.getSessionStatus('team9/tenant/s1'),
+      ).resolves.toEqual({
         sessionId: 's1',
         isStreaming: false,
         queueLength: 2,
         ownedBy: 'worker-1',
       });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-hive:9999/api/sessions/team9%2Ftenant%2Fs1/status',
+        expect.objectContaining({ method: 'GET' }),
+      );
     });
   });
 

--- a/apps/server/libs/claw-hive/src/claw-hive.service.ts
+++ b/apps/server/libs/claw-hive/src/claw-hive.service.ts
@@ -38,6 +38,33 @@ export interface HiveSessionDetail {
   [key: string]: unknown;
 }
 
+export interface HiveSessionComponentItem {
+  id: string;
+  typeKey: string;
+  priority?: number;
+  declaredConfig?: Record<string, unknown>;
+  effectiveConfig: Record<string, unknown>;
+  schema?: unknown[];
+  runtimeInjectedOnly: boolean;
+  latestData: {
+    data: Record<string, unknown>;
+    capturedAtCallId: string | null;
+    capturedAt: number;
+  } | null;
+}
+
+export interface HiveSessionComponentsResponse {
+  sessionId: string;
+  components: HiveSessionComponentItem[];
+}
+
+export interface HiveSessionStatusResponse {
+  sessionId: string;
+  isStreaming: boolean;
+  queueLength: number;
+  ownedBy: string | null;
+}
+
 @Injectable()
 export class ClawHiveService {
   private readonly logger = new Logger(ClawHiveService.name);
@@ -186,6 +213,40 @@ export class ClawHiveService {
       throw new Error(`Failed to get session: ${res.status} ${text}`);
     }
     return res.json() as Promise<HiveSessionDetail>;
+  }
+
+  async getSessionComponents(
+    sessionId: string,
+    tenantId?: string,
+  ): Promise<HiveSessionComponentsResponse | null> {
+    const res = await fetch(
+      `${this.baseUrl}/api/sessions/${encodeURIComponent(sessionId)}/components`,
+      { method: 'GET', headers: this.headers(tenantId) },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Failed to get session components: ${res.status} ${text}`,
+      );
+    }
+    return res.json() as Promise<HiveSessionComponentsResponse>;
+  }
+
+  async getSessionStatus(
+    sessionId: string,
+    tenantId?: string,
+  ): Promise<HiveSessionStatusResponse | null> {
+    const res = await fetch(
+      `${this.baseUrl}/api/sessions/${encodeURIComponent(sessionId)}/status`,
+      { method: 'GET', headers: this.headers(tenantId) },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Failed to get session status: ${res.status} ${text}`);
+    }
+    return res.json() as Promise<HiveSessionStatusResponse>;
   }
 
   /**

--- a/apps/server/libs/claw-hive/src/index.ts
+++ b/apps/server/libs/claw-hive/src/index.ts
@@ -3,5 +3,8 @@ export {
   type HiveModelRef,
   type HiveAgentSnapshot,
   type HiveSessionDetail,
+  type HiveSessionComponentItem,
+  type HiveSessionComponentsResponse,
+  type HiveSessionStatusResponse,
 } from './claw-hive.service.js';
 export { ClawHiveModule } from './claw-hive.module.js';

--- a/docs/superpowers/plans/2026-05-11-agent-session-bound-channel-panel.md
+++ b/docs/superpowers/plans/2026-05-11-agent-session-bound-channel-panel.md
@@ -128,7 +128,7 @@ describe("session component and status helpers", () => {
 Run:
 
 ```bash
-pnpm --filter @team9/gateway test -- claw-hive.service.spec.ts
+NODE_OPTIONS='--experimental-vm-modules' pnpm --dir apps/server exec jest --config libs/claw-hive/jest.config.cjs claw-hive.service.spec.ts
 ```
 
 Expected: FAIL with TypeScript errors that `getSessionComponents` and `getSessionStatus` do not exist.
@@ -207,7 +207,7 @@ async getSessionStatus(
 Run:
 
 ```bash
-pnpm --filter @team9/gateway test -- claw-hive.service.spec.ts
+NODE_OPTIONS='--experimental-vm-modules' pnpm --dir apps/server exec jest --config libs/claw-hive/jest.config.cjs claw-hive.service.spec.ts
 ```
 
 Expected: PASS for `claw-hive.service.spec.ts`.


### PR DESCRIPTION
## Summary

- Add backend channel-to-agent-session binding for DM, topic-session, routine-session, routine execution, and tracking channels.
- Add Claw Hive / agent-pi session component and status APIs, plus gateway endpoints for binding, component snapshots, and SSE event streaming.
- Add a right-side Agent Session panel in ChannelView that shows status, task/tracking context, and live component data.
- Harden the SSE boundary with allowlisted event projection, sensitive-field redaction, tenant-scoped bot resolution, ambiguous-bot rejection, token refresh handling, and stale-session refetching.

## Review fixes included

- Strictly project `component_data_snapshot` events and component data before forwarding to the client.
- Stop forwarding unknown upstream SSE records/directives verbatim.
- Scope bot eligibility to the channel tenant and reject multiple active Hive bots.
- Hide ordinary `no_bot` unsupported panels and avoid snapping the main chat away when only the agent panel is open.

## Validation

- `pnpm --filter @team9/gateway test -- agent-session.controller.spec.ts agent-session-binding.service.spec.ts agent-session-redaction.spec.ts topic-sessions.service.spec.ts`
- `pnpm --filter @team9/client test -- agent-session.test.ts useAgentSessionComponents.test.tsx AgentSessionPanel.test.tsx ChannelView.agentSessionPanel.test.tsx`
- `pnpm --filter @team9/gateway build`
- `pnpm --filter @team9/client typecheck`
- `pnpm --filter @team9/client lint:ci`
- `pnpm --filter @team9/server exec eslint apps/gateway/src/im/agent-sessions apps/gateway/src/im/topic-sessions/topic-sessions.service.ts apps/gateway/src/im/topic-sessions/topic-sessions.service.spec.ts`
- `pnpm --filter @team9/client build`

## Notes

This has not been end-to-end tested against a real agent-pi / Claw Hive instance.