### PR TITLE
[codex] Fix agent session panel toggle

### DIFF
--- a/apps/client/src/components/channel/ChannelHeader.tsx
+++ b/apps/client/src/components/channel/ChannelHeader.tsx
@@ -10,6 +10,7 @@ import {
   Users,
   UserPlus,
   Pencil,
+  PanelRight,
   SquarePen,
   X,
 } from "lucide-react";
@@ -36,17 +37,24 @@ import type { Channel, ChannelWithUnread, MemberRole } from "@/types/im";
 interface ChannelHeaderProps {
   channel: Channel | ChannelWithUnread;
   currentUserRole?: MemberRole;
+  showAgentSessionToggle?: boolean;
+  isAgentSessionPanelOpen?: boolean;
+  onToggleAgentSessionPanel?: () => void;
 }
 
 export function ChannelHeader({
   channel,
   currentUserRole,
+  showAgentSessionToggle,
+  isAgentSessionPanelOpen,
+  onToggleAgentSessionPanel,
 }: ChannelHeaderProps) {
   const { t } = useTranslation(["channel", "navigation"]);
   const navigate = useNavigate();
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
   const [copiedUsername, setCopiedUsername] = useState(false);
+  const [copiedAgentIdentifier, setCopiedAgentIdentifier] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState(channel.name ?? "");
   const [defaultTab, setDefaultTab] = useState<
@@ -120,6 +128,16 @@ export function ChannelHeader({
     }
   };
 
+  const handleCopyAgentIdentifier = async (identifier: string) => {
+    try {
+      await navigator.clipboard.writeText(identifier);
+      setCopiedAgentIdentifier(true);
+      setTimeout(() => setCopiedAgentIdentifier(false), 1500);
+    } catch (err) {
+      console.error("Failed to copy agent id:", err);
+    }
+  };
+
   const startEditingTitle = () => {
     setTitleInput(channel.name ?? "");
     setIsEditingTitle(true);
@@ -147,7 +165,7 @@ export function ChannelHeader({
   return (
     <>
       <div className="min-h-14 py-2 px-4 flex items-center justify-between select-none">
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
           {isDirect && otherUser ? (
             <div className="relative">
               <UserAvatar
@@ -302,9 +320,43 @@ export function ChannelHeader({
                 )}
                 <AgentTypeBadge agentType={associatedAgent?.agentType} />
                 {agentIdentifier && (
-                  <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
-                    {agentIdentifier}
-                  </span>
+                  <TooltipProvider delayDuration={150}>
+                    <Tooltip
+                      key={
+                        copiedAgentIdentifier
+                          ? "copied-agent-identifier"
+                          : "agent-identifier"
+                      }
+                      open={copiedAgentIdentifier ? true : undefined}
+                    >
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`Copy agent id ${agentIdentifier}`}
+                          onClick={() =>
+                            void handleCopyAgentIdentifier(agentIdentifier)
+                          }
+                          className="group flex min-w-0 max-w-[24rem] items-center gap-1 rounded-sm font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                          <span className="truncate">{agentIdentifier}</span>
+                          {copiedAgentIdentifier ? (
+                            <Check
+                              size={12}
+                              className="shrink-0 text-success"
+                            />
+                          ) : (
+                            <Copy
+                              size={12}
+                              className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                            />
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        {copiedAgentIdentifier ? t("copied") : t("clickToCopy")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
               </div>
             ) : otherUser?.agentType === "base_model" ? (
@@ -330,7 +382,7 @@ export function ChannelHeader({
           </div>
         </div>
 
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1">
           {isOneOnOneAgentChat && associatedAgent && (
             <Button
               type="button"
@@ -342,6 +394,34 @@ export function ChannelHeader({
               <SquarePen size={16} />
               {t("newTopic", { ns: "navigation" as const })}
             </Button>
+          )}
+          {showAgentSessionToggle && (
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={isAgentSessionPanelOpen ? "secondary" : "ghost"}
+                    size="icon"
+                    aria-label={
+                      isAgentSessionPanelOpen
+                        ? "Hide agent session panel"
+                        : "Show agent session panel"
+                    }
+                    aria-pressed={isAgentSessionPanelOpen}
+                    onClick={onToggleAgentSessionPanel}
+                    className="size-8"
+                  >
+                    <PanelRight size={16} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {isAgentSessionPanelOpen
+                    ? "Hide agent session"
+                    : "Show agent session"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           {showChannelManagementActions && (
             <Button

--- a/apps/client/src/components/channel/ChannelView.tsx
+++ b/apps/client/src/components/channel/ChannelView.tsx
@@ -384,12 +384,21 @@ export function ChannelView({
   const [isSnapped, setIsSnapped] = useState(false);
   const [threadPanelWidth, setThreadPanelWidth] = useState(600);
   const [agentPanelWidth, setAgentPanelWidth] = useState(360);
+  const [isAgentSessionPanelOpen, setIsAgentSessionPanelOpen] = useState(false);
   const threadPanelWidthRef = useRef(threadPanelWidth);
   threadPanelWidthRef.current = threadPanelWidth;
 
+  useEffect(() => {
+    setIsAgentSessionPanelOpen(false);
+  }, [channelId]);
+
   const isAgentSessionCandidate =
     !isPreviewMode &&
-    (isBotDm || channel?.type === "tracking" || channel?.type === "task");
+    (isBotDm ||
+      channel?.type === "topic-session" ||
+      channel?.type === "routine-session" ||
+      channel?.type === "tracking" ||
+      channel?.type === "task");
   const agentSession = useChannelAgentSession(
     channelId,
     isAgentSessionCandidate,
@@ -399,16 +408,24 @@ export function ChannelView({
     (agentSession.data.supported ||
       (!!agentSession.data.unsupportedReason &&
         agentSession.data.unsupportedReason !== "no_bot"));
+  const isAgentSessionPanelVisible =
+    shouldShowAgentSessionPanel && isAgentSessionPanelOpen;
   const agentComponents = useAgentSessionComponents(
     channelId,
-    shouldShowAgentSessionPanel && agentSession.data?.supported === true,
+    isAgentSessionPanelVisible && agentSession.data?.supported === true,
     agentSession.data?.sessionId,
   );
-  const agentPanelCount = shouldShowAgentSessionPanel ? 1 : 0;
+  const agentPanelCount = isAgentSessionPanelVisible ? 1 : 0;
   const openThreadPanelCount =
     (primaryThread.isOpen && primaryThread.rootMessageId ? 1 : 0) +
     (secondaryThread.isOpen && secondaryThread.rootMessageId ? 1 : 0);
   const sidePanelCount = agentPanelCount + openThreadPanelCount;
+
+  useEffect(() => {
+    if (!shouldShowAgentSessionPanel) {
+      setIsAgentSessionPanelOpen(false);
+    }
+  }, [shouldShowAgentSessionPanel]);
 
   // Bot response indicator state (local)
   const [thinkingStatuses, setThinkingStatuses] = useState<BotThinkingStatus[]>(
@@ -655,7 +672,15 @@ export function ChannelView({
         className={`flex-1 flex flex-col min-w-0 select-text ${isSnapped ? "hidden" : ""}`}
       >
         {!hideHeader && (
-          <ChannelHeader channel={channel} currentUserRole={currentUserRole} />
+          <ChannelHeader
+            channel={channel}
+            currentUserRole={currentUserRole}
+            showAgentSessionToggle={shouldShowAgentSessionPanel}
+            isAgentSessionPanelOpen={isAgentSessionPanelVisible}
+            onToggleAgentSessionPanel={() =>
+              setIsAgentSessionPanelOpen((open) => !open)
+            }
+          />
         )}
 
         {/* Channel tabs - only show for non-direct, non-preview channels.
@@ -774,7 +799,7 @@ export function ChannelView({
         )}
       </div>
 
-      {agentSession.data && shouldShowAgentSessionPanel && (
+      {agentSession.data && isAgentSessionPanelVisible && (
         <AgentSessionPanel
           binding={agentSession.data}
           components={agentComponents.data}

--- a/apps/client/src/components/channel/__tests__/ChannelHeader.badge.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelHeader.badge.test.tsx
@@ -209,6 +209,59 @@ describe("ChannelHeader · Model badge placement", () => {
     expect(screen.getByText("agent-lxy-001")).toBeInTheDocument();
   });
 
+  it("truncates the agent identifier affordance while copying the full id", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const longAgentId = "personal-staff-019d7315-a4bb-7039-bdbe-b810e026061d";
+
+    render(
+      <ChannelHeader
+        channel={
+          {
+            id: "topic-1",
+            tenantId: "tenant-1",
+            name: "当前workspace技能",
+            type: "topic-session",
+            createdBy: "user-1",
+            order: 0,
+            isArchived: false,
+            isActivated: true,
+            unreadCount: 0,
+            createdAt: "2026-04-07T00:00:00Z",
+            updatedAt: "2026-04-07T00:00:00Z",
+            otherUser: {
+              id: "bot-lxy",
+              username: "lin_xiaoyu",
+              displayName: "林晓宇",
+              status: "online",
+              userType: "bot",
+              agentType: "openclaw",
+              roleTitle: "平台工程师",
+              agentId: longAgentId,
+            },
+          } as ChannelWithUnread
+        }
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", {
+      name: `Copy agent id ${longAgentId}`,
+    });
+    const idText = screen.getByText(longAgentId);
+
+    expect(copyButton).toHaveClass("min-w-0");
+    expect(idText).toHaveClass("truncate");
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(longAgentId);
+    });
+  });
+
   it("does not render member-management actions for topic-session channels", () => {
     mockUseChannelMembers.mockReturnValue({
       data: [

--- a/apps/client/src/components/channel/__tests__/ChannelHeader.newTopic.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelHeader.newTopic.test.tsx
@@ -67,6 +67,31 @@ describe("ChannelHeader — new topic button", () => {
     });
   });
 
+  it("places the agent-session toggle after the new-topic button", () => {
+    const onToggle = vi.fn();
+    render(
+      <ChannelHeader
+        channel={makeChannel({})}
+        showAgentSessionToggle
+        isAgentSessionPanelOpen={false}
+        onToggleAgentSessionPanel={onToggle}
+      />,
+    );
+
+    const newTopic = screen.getByRole("button", { name: "新建话题" });
+    const toggle = screen.getByRole("button", {
+      name: "Show agent session panel",
+    });
+
+    expect(
+      newTopic.compareDocumentPosition(toggle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
   it("shows the new-topic button for a direct DM with a bot", () => {
     render(<ChannelHeader channel={makeChannel({ type: "direct" })} />);
     expect(newTopicButton()).toBeInTheDocument();

--- a/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
+++ b/apps/client/src/components/channel/__tests__/ChannelView.agentSessionPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelView } from "../ChannelView";
 
@@ -142,7 +142,8 @@ vi.mock("@/hooks/useBotStartupCountdown", () => ({
 }));
 
 vi.mock("@/hooks/useChannelAgentSession", () => ({
-  useChannelAgentSession: () => viewState.agentSession,
+  useChannelAgentSession: (_channelId: string, enabled: boolean) =>
+    enabled ? viewState.agentSession : { data: undefined },
 }));
 
 vi.mock("@/hooks/useAgentSessionComponents", () => ({
@@ -157,7 +158,33 @@ vi.mock("../agent-session/AgentSessionPanel", () => ({
   AgentSessionPanel: () => <aside>Agent Session Panel</aside>,
 }));
 
-vi.mock("../ChannelHeader", () => ({ ChannelHeader: () => <div /> }));
+vi.mock("../ChannelHeader", () => ({
+  ChannelHeader: ({
+    showAgentSessionToggle,
+    isAgentSessionPanelOpen,
+    onToggleAgentSessionPanel,
+  }: {
+    showAgentSessionToggle?: boolean;
+    isAgentSessionPanelOpen?: boolean;
+    onToggleAgentSessionPanel?: () => void;
+  }) => (
+    <div>
+      {showAgentSessionToggle && (
+        <button
+          type="button"
+          aria-label={
+            isAgentSessionPanelOpen
+              ? "Hide agent session panel"
+              : "Show agent session panel"
+          }
+          onClick={onToggleAgentSessionPanel}
+        >
+          Agent Session Toggle
+        </button>
+      )}
+    </div>
+  ),
+}));
 vi.mock("../ChannelTabs", () => ({ ChannelTabs: () => <div /> }));
 vi.mock("../ChannelContent", () => ({
   ChannelContent: () => <div data-testid="channel-content" />,
@@ -199,8 +226,51 @@ describe("ChannelView agent session panel", () => {
     };
   });
 
-  it("renders the session panel for a supported binding", () => {
+  it("keeps the session panel collapsed until the header toggle is clicked", () => {
     render(<ChannelView channelId="channel-1" />);
+
+    expect(screen.queryByText("Agent Session Panel")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show agent session panel" }),
+    );
+
+    expect(screen.getByText("Agent Session Panel")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hide agent session panel" }),
+    );
+
+    expect(screen.queryByText("Agent Session Panel")).not.toBeInTheDocument();
+  });
+
+  it("requests the session binding for topic-session channels even before otherUser is hydrated", () => {
+    viewState.channel = {
+      id: "topic-1",
+      tenantId: "tenant-1",
+      type: "topic-session",
+      name: "Topic",
+      isArchived: false,
+      otherUser: undefined,
+    };
+    viewState.agentSession = {
+      data: {
+        channelId: "topic-1",
+        channelType: "topic-session",
+        kind: "topic-session",
+        supported: true,
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        botUserId: "bot-user-1",
+        sessionId: "team9/tenant-1/agent-1/dm/topic-1",
+      },
+    };
+
+    render(<ChannelView channelId="topic-1" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show agent session panel" }),
+    );
 
     expect(screen.getByText("Agent Session Panel")).toBeInTheDocument();
   });
@@ -235,6 +305,9 @@ describe("ChannelView agent session panel", () => {
 
   it("keeps chat visible when only the agent session panel is open", async () => {
     render(<ChannelView channelId="channel-1" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show agent session panel" }),
+    );
 
     await waitFor(() =>
       expect(screen.getByText("Agent Session Panel")).toBeInTheDocument(),


### PR DESCRIPTION
## Summary

- Keep the Agent Session side panel collapsed by default and add a header toggle next to the New Topic action.
- Allow topic/routine session channels to request session bindings before otherUser is hydrated, so the toggle appears for AI Agent topic rows.
- Truncate long agent ids in the channel header while preserving click-to-copy of the full id.

## Validation

- pnpm --filter @team9/client test -- agent-session.test.ts useAgentSessionComponents.test.tsx AgentSessionPanel.test.tsx ChannelView.agentSessionPanel.test.tsx ChannelHeader.newTopic.test.tsx ChannelHeader.badge.test.tsx
- pnpm --filter @team9/client typecheck
- pnpm --filter @team9/client lint:ci
- pnpm --filter @team9/client build