### PR TITLE
feat(models): add Gemini 3.5 Flash and set as default Gemini model

### DIFF
--- a/apps/client/src/components/channel/editor/__tests__/RichTextEditor.upload.test.tsx
+++ b/apps/client/src/components/channel/editor/__tests__/RichTextEditor.upload.test.tsx
@@ -119,6 +119,7 @@ describe("RichTextEditor — upload vs disabled", () => {
     );
 
     expect(await screen.findAllByText("Gemini 3.1 Pro")).toHaveLength(2);
+    expect(screen.getByText("Gemini 3.5 Flash")).toBeInTheDocument();
     expect(screen.getByText("Gemini 3 Flash")).toBeInTheDocument();
     expect(screen.queryByText(/preview/i)).not.toBeInTheDocument();
     expect(screen.getByRole("menu")).toHaveClass("w-max");
@@ -127,7 +128,7 @@ describe("RichTextEditor — upload vs disabled", () => {
     const menu = within(screen.getByRole("menu"));
     expect(menu.getAllByRole("img", { name: "Claude logo" })).toHaveLength(2);
     expect(menu.getAllByRole("img", { name: "ChatGPT logo" })).toHaveLength(3);
-    expect(menu.getAllByRole("img", { name: "Gemini logo" })).toHaveLength(2);
+    expect(menu.getAllByRole("img", { name: "Gemini logo" })).toHaveLength(3);
     expect(
       menu.getByRole("img", { name: "DeepSeek logo" }),
     ).toBeInTheDocument();

--- a/apps/client/src/components/layout/contents/HomeMainContent.tsx
+++ b/apps/client/src/components/layout/contents/HomeMainContent.tsx
@@ -99,7 +99,7 @@ function pickDefaultAgent(agents: DashboardAgent[]): DashboardAgent | null {
 const FIXED_BASE_MODEL_LABELS = {
   claude: "Claude Sonnet 4.6",
   chatgpt: "GPT-5.4 Mini",
-  gemini: "Gemini 3 Flash Preview",
+  gemini: "Gemini 3.5 Flash",
 } as const;
 
 function getAgentModelLabel(

--- a/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
+++ b/apps/client/src/components/layout/contents/__tests__/HomeMainContent.test.tsx
@@ -707,6 +707,7 @@ describe("HomeMainContent", () => {
     fireEvent.pointerDown(screen.getByRole("button", { name: /gpt-4.1/i }));
 
     expect(await screen.findByText("Gemini 3.1 Pro")).toBeInTheDocument();
+    expect(screen.getByText("Gemini 3.5 Flash")).toBeInTheDocument();
     expect(screen.getByText("Gemini 3 Flash")).toBeInTheDocument();
     expect(screen.queryByText(/preview/i)).not.toBeInTheDocument();
     expect(screen.queryByText("OpenAI")).not.toBeInTheDocument();
@@ -718,7 +719,7 @@ describe("HomeMainContent", () => {
     const menu = within(screen.getByRole("menu"));
     expect(menu.getAllByRole("img", { name: "Claude logo" })).toHaveLength(2);
     expect(menu.getAllByRole("img", { name: "ChatGPT logo" })).toHaveLength(3);
-    expect(menu.getAllByRole("img", { name: "Gemini logo" })).toHaveLength(2);
+    expect(menu.getAllByRole("img", { name: "Gemini logo" })).toHaveLength(3);
     expect(
       menu.getByRole("img", { name: "DeepSeek logo" }),
     ).toBeInTheDocument();

--- a/apps/client/src/lib/common-staff-models.test.ts
+++ b/apps/client/src/lib/common-staff-models.test.ts
@@ -66,6 +66,12 @@ describe("COMMON_STAFF_MODELS", () => {
         }),
         expect.objectContaining({
           provider: "openrouter",
+          id: "google/gemini-3.5-flash",
+          label: "Gemini 3.5 Flash",
+          family: "google",
+        }),
+        expect.objectContaining({
+          provider: "openrouter",
           id: "google/gemini-3-flash-preview",
           label: "Gemini 3 Flash (Preview)",
           family: "google",
@@ -74,6 +80,9 @@ describe("COMMON_STAFF_MODELS", () => {
     );
     expect(formatStaffModelDisplayLabel("Gemini 3 Flash (Preview)")).toBe(
       "Gemini 3 Flash",
+    );
+    expect(formatStaffModelDisplayLabel("Gemini 3.5 Flash")).toBe(
+      "Gemini 3.5 Flash",
     );
   });
 

--- a/apps/client/src/lib/common-staff-models.ts
+++ b/apps/client/src/lib/common-staff-models.ts
@@ -42,6 +42,12 @@ export const COMMON_STAFF_MODELS: StaffModel[] = [
   },
   {
     provider: "openrouter",
+    id: "google/gemini-3.5-flash",
+    label: "Gemini 3.5 Flash",
+    family: "google",
+  },
+  {
+    provider: "openrouter",
     id: "google/gemini-3.1-pro-preview",
     label: "Gemini 3.1 Pro (Preview)",
     family: "google",

--- a/apps/server/apps/gateway/src/applications/handlers/base-model-staff.presets.ts
+++ b/apps/server/apps/gateway/src/applications/handlers/base-model-staff.presets.ts
@@ -28,7 +28,7 @@ export const BASE_MODEL_PRESETS: BaseModelPreset[] = [
     key: 'gemini',
     name: 'Gemini',
     provider: 'openrouter',
-    modelId: 'google/gemini-3-flash-preview',
+    modelId: 'google/gemini-3.5-flash',
     emoji: '🔵',
     avatar: '/assets/avatars/gemini.png',
   },

--- a/apps/server/apps/gateway/src/im/deep-research-sessions/deep-research-sessions.service.ts
+++ b/apps/server/apps/gateway/src/im/deep-research-sessions/deep-research-sessions.service.ts
@@ -34,7 +34,7 @@ import { WS_EVENTS } from '../websocket/events/events.constants.js';
 import { deepResearchText } from './deep-research-i18n.js';
 
 const DEEP_RESEARCH_CAPABILITY_NAME = 'deep_research_run';
-const DEFAULT_DEEP_RESEARCH_FOLLOW_UP_MODEL = 'gemini-3-flash-preview';
+const DEFAULT_DEEP_RESEARCH_FOLLOW_UP_MODEL = 'gemini-3.5-flash';
 const CAPABILITY_DISCOVERY_LIMIT = 100;
 const CAPABILITY_INVOKE_TIMEOUT_MS = 15_000;
 const TASK_POLL_INTERVAL_MS = 5_000;

--- a/apps/server/libs/ai-client/src/interfaces/ai-provider.interface.ts
+++ b/apps/server/libs/ai-client/src/interfaces/ai-provider.interface.ts
@@ -39,6 +39,7 @@ export type OpenAIModel = (typeof OPENAI_MODELS)[number];
 
 // Google Gemini Models
 export const GEMINI_MODELS = [
+  'gemini-3.5-flash',
   'gemini-3-pro-preview',
   'gemini-2.0-flash',
 ] as const;
@@ -50,6 +51,7 @@ export const OPENROUTER_MODELS = [
   'openai/gpt-4-turbo',
   'anthropic/claude-3.5-sonnet',
   'anthropic/claude-3-opus',
+  'google/gemini-3.5-flash',
   'google/gemini-pro-1.5',
   'meta-llama/llama-3.1-405b-instruct',
   'meta-llama/llama-3.1-70b-instruct',


### PR DESCRIPTION
## Summary
- Register `google/gemini-3.5-flash` ("Gemini 3.5 Flash") in the client staff-model list and server base-model presets
- Add the model to the AI provider model enums (`GEMINI_MODELS`, `OPENROUTER_MODELS`)
- Switch the default Gemini base-model and the deep-research follow-up model away from `gemini-3-flash-preview` to `gemini-3.5-flash`

## Changes
- Client: `common-staff-models.ts`, `HomeMainContent.tsx` (fixed base-model label)
- Server: `base-model-staff.presets.ts`, `deep-research-sessions.service.ts`, `ai-provider.interface.ts`

## Test plan
- Updated client tests (`common-staff-models.test.ts`, `HomeMainContent.test.tsx`, `RichTextEditor.upload.test.tsx`) to assert the new model renders alongside existing Gemini models

🤖 Generated with [Claude Code](https://claude.com/claude-code)