### PR TITLE
fix(im): copy full content for truncated long_text messages

### DIFF
--- a/apps/client/src/components/channel/MessageContextMenu.tsx
+++ b/apps/client/src/components/channel/MessageContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -8,6 +9,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { MessageSquare, Link, Copy, Pin, Trash2, Pencil } from "lucide-react";
+import imApi from "@/services/api/im";
 import type { Message } from "@/types/im";
 
 interface MessageContextMenuProps {
@@ -36,12 +38,10 @@ export function MessageContextMenu({
   onDelete,
 }: MessageContextMenuProps) {
   const { t } = useTranslation("message");
+  const queryClient = useQueryClient();
 
   const handleCopyMessage = () => {
-    if (message.content) {
-      navigator.clipboard.writeText(message.content);
-      onCopyMessage?.();
-    }
+    void copyMessageContent(message, queryClient, onCopyMessage);
   };
 
   const handleCopyLink = () => {
@@ -118,4 +118,54 @@ export function MessageContextMenu({
       </ContextMenuContent>
     </ContextMenu>
   );
+}
+
+function shouldFetchFullContentForCopy(message: Message): boolean {
+  return (
+    message.type === "long_text" &&
+    (message.isTruncated === true ||
+      (typeof message.fullContentLength === "number" &&
+        message.fullContentLength > message.content.length))
+  );
+}
+
+async function resolveMessageCopyContent(
+  message: Message,
+  queryClient: QueryClient,
+): Promise<string> {
+  if (!shouldFetchFullContentForCopy(message)) return message.content;
+
+  try {
+    const fullContent = await queryClient.ensureQueryData({
+      queryKey: ["message-full-content", message.id],
+      queryFn: () => imApi.messages.getFullContent(message.id),
+      staleTime: Infinity,
+    });
+    return fullContent.content || message.content;
+  } catch (error) {
+    console.warn("Failed to load full message content for copy", error);
+    return message.content;
+  }
+}
+
+async function copyMessageContent(
+  message: Message,
+  queryClient: QueryClient,
+  onCopyMessage?: () => void,
+) {
+  if (!message.content) return;
+
+  const clipboard = navigator.clipboard;
+  if (!clipboard?.writeText) {
+    console.warn("Clipboard API unavailable");
+    return;
+  }
+
+  try {
+    const content = await resolveMessageCopyContent(message, queryClient);
+    await clipboard.writeText(content);
+    onCopyMessage?.();
+  } catch (error) {
+    console.warn("Failed to copy message content", error);
+  }
 }

--- a/apps/client/src/components/channel/__tests__/MessageContextMenu.test.tsx
+++ b/apps/client/src/components/channel/__tests__/MessageContextMenu.test.tsx
@@ -1,0 +1,151 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { MouseEventHandler, ReactNode } from "react";
+import type { Message } from "@/types/im";
+
+const getFullContentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/api/im", () => ({
+  default: {
+    messages: {
+      getFullContent: getFullContentMock,
+    },
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuShortcut: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+import { MessageContextMenu } from "../MessageContextMenu";
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    channelId: "ch-1",
+    senderId: "user-1",
+    content: "preview content",
+    type: "text",
+    isPinned: false,
+    isEdited: false,
+    isDeleted: false,
+    createdAt: "2026-05-21T12:00:00Z",
+    updatedAt: "2026-05-21T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderMenu(message: Message, queryClient = createQueryClient()) {
+  const onCopyMessage = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MessageContextMenu
+        message={message}
+        isOwnMessage={false}
+        onCopyMessage={onCopyMessage}
+      >
+        <div>message row</div>
+      </MessageContextMenu>
+    </QueryClientProvider>,
+  );
+  return { onCopyMessage };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe("MessageContextMenu copy message", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    getFullContentMock.mockReset();
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("copies normal message content without fetching full content", async () => {
+    const { onCopyMessage } = renderMenu(makeMessage());
+
+    fireEvent.click(screen.getByRole("button", { name: /copyMessage/ }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("preview content");
+    });
+    expect(getFullContentMock).not.toHaveBeenCalled();
+    expect(onCopyMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches and copies full content for truncated long_text messages", async () => {
+    getFullContentMock.mockResolvedValue({ content: "full content" });
+    const { onCopyMessage } = renderMenu(
+      makeMessage({
+        type: "long_text",
+        isTruncated: true,
+        fullContentLength: 5000,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copyMessage/ }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("full content");
+    });
+    expect(getFullContentMock).toHaveBeenCalledWith("msg-1");
+    expect(onCopyMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses cached full content when available", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["message-full-content", "msg-1"], {
+      content: "cached full content",
+    });
+    renderMenu(
+      makeMessage({
+        type: "long_text",
+        isTruncated: true,
+        fullContentLength: 5000,
+      }),
+      queryClient,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copyMessage/ }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("cached full content");
+    });
+    expect(getFullContentMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

When copying a truncated `long_text` message via the message context menu, the clipboard now receives the **full** content (fetched lazily and cached through React Query) instead of the truncated preview. Falls back to the preview text if the fetch fails or the clipboard API is unavailable.

## Changes

- `MessageContextMenu.tsx`: extract copy logic into helpers; fetch full content for truncated `long_text` messages before writing to clipboard.
- `__tests__/MessageContextMenu.test.tsx`: new tests covering normal copy, full-content fetch for truncated messages, and cached-content reuse.

## Testing

- `npx vitest run src/components/channel/__tests__/MessageContextMenu.test.tsx` → 3/3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)